### PR TITLE
fix: update localisation logic for fixed period generation to make it more resilient

### DIFF
--- a/src/period-calculation/fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/fixed-periods.gregorian.spec.ts
@@ -209,4 +209,130 @@ describe('Gregorian Calendar fixed period calculation', () => {
             expect(periods[periods.length - 1]).toEqual('2015-11-01/2015-12-31')
         })
     })
+
+    describe('localising the periods', () => {
+        const date = {
+            year: 2015,
+            calendar: 'gregory' as const,
+            startingDay: 1,
+            periodType: 'MONTHLY' as const,
+        }
+        it('should accept a locale without a region specifier', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                locale: 'fr',
+            })
+            expect(periods[0].name).toEqual('Janvier 2015')
+        })
+
+        it('should accept a locale with a region specifier', () => {
+            const colombianSpanishperiods = generateFixedPeriods({
+                ...date,
+                locale: 'es-CO',
+            })
+            const genericSpanishPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'es',
+            })
+            expect(colombianSpanishperiods[0].name).toEqual('Enero de 2015')
+            expect(genericSpanishPeriods[0].name).toEqual('Enero de 2015')
+        })
+        it('should accept a locale if it uses underscore instead of dash as DHIS does', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                locale: 'ar_TN', // DHIS sends underscore instead of hyphen
+            })
+
+            expect(periods[0].name).toEqual('جانفي 2015')
+        })
+        it('should fallback to english if a wrong locale is passed', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                locale: 'xx_YY',
+            })
+
+            expect(periods[0].name).toEqual('January 2015')
+        })
+        it('should fallback to english if a no locale is passed', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                locale: undefined,
+            })
+
+            expect(periods[0].name).toEqual('January 2015')
+        })
+    })
+
+    describe('capitalising first letter (when the language allows it)', () => {
+        const date = {
+            year: 2015,
+            calendar: 'gregory' as const,
+            startingDay: 1,
+            periodType: 'MONTHLY' as const,
+        }
+        it('should capitalise the first letter of a month', () => {
+            const frenchPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'fr',
+            })
+            const englishPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'en',
+            })
+            const arabicPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'ar-SD', // no capitals in Arabic
+            })
+            expect(englishPeriods[0].name).toEqual('January 2015')
+            expect(frenchPeriods[0].name).toEqual('Janvier 2015')
+            expect(arabicPeriods[0].name).toEqual('يناير ٢٠١٥')
+        })
+
+        it('should capitalise the first letter of a SIXMONTHLY periods', () => {
+            const date = {
+                year: 2015,
+                calendar: 'gregory' as const,
+                startingDay: 1,
+                periodType: 'SIXMONTHLY' as const,
+            }
+            const frenchPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'fr',
+            })
+            const englishPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'en',
+            })
+            const arabicPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'ar-SD', // no capitals in Arabic
+            })
+            expect(englishPeriods[0].name).toEqual('January - June 2015')
+            expect(frenchPeriods[0].name).toEqual('Janvier - Juin 2015')
+            expect(arabicPeriods[0].name).toEqual('يناير - يونيو ٢٠١٥')
+        })
+        it('should capitalise the first letter of a QUARTERLY periods', () => {
+            const date = {
+                year: 2015,
+                calendar: 'gregory' as const,
+                startingDay: 1,
+                periodType: 'QUARTERLY' as const,
+            }
+            const frenchPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'fr',
+            })
+            const englishPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'en',
+            })
+            const arabicPeriods = generateFixedPeriods({
+                ...date,
+                locale: 'ar-SD', // no capitals in Arabic
+            })
+            expect(englishPeriods[0].name).toEqual('January - March 2015')
+            expect(frenchPeriods[0].name).toEqual('Janvier - Mars 2015')
+            expect(arabicPeriods[0].name).toEqual('يناير - مارس ٢٠١٥')
+        })
+    })
 })

--- a/src/period-calculation/fixed-periods.ts
+++ b/src/period-calculation/fixed-periods.ts
@@ -1,5 +1,6 @@
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../types'
+import getValidLocale from '../utils/getValidLocale'
 import { getCustomCalendarIfExists } from '../utils/helpers'
 import { getDailyPeriods } from './getDailyPeriods'
 import { getMonthlyPeriods } from './getMonthlyPeriods'
@@ -52,7 +53,7 @@ const generateFixedPeriods: GeneratedPeriodsFunc = ({
     year: yearString,
     periodType,
     calendar: requestedCalendar,
-    locale = 'en',
+    locale: requestedLocale = 'en',
     startingDay = 1,
 }) => {
     let year: number
@@ -68,6 +69,8 @@ const generateFixedPeriods: GeneratedPeriodsFunc = ({
     const calendar = getCustomCalendarIfExists(
         dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
     ) as SupportedCalendar
+
+    const locale = getValidLocale(requestedLocale)
 
     if (periodType?.match('WEEKLY')) {
         return getWeeklyPeriods({

--- a/src/period-calculation/getMonthlyPeriods.ts
+++ b/src/period-calculation/getMonthlyPeriods.ts
@@ -1,6 +1,7 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { SupportedCalendar } from '../types'
 import {
+    capitalize,
     formatYyyyMmDD,
     isCustomCalendar,
     padWithZeroes,
@@ -134,12 +135,18 @@ const buildLabel: BuildLabelFunc = (options) => {
     ) {
         const format =
             month.year === nextMonth.year ? monthOnlyFormat : withYearFormat
-        result = `${month.toLocaleString(
-            locale,
-            format
-        )} - ${nextMonth.toLocaleString(locale, withYearFormat)}`
+        result = `${capitalize(
+            month.toLocaleString(locale, format),
+            locale
+        )} - ${capitalize(
+            nextMonth.toLocaleString(locale, withYearFormat),
+            locale
+        )}`
     } else {
-        result = `${month.toLocaleString(locale, withYearFormat)}`
+        result = `${capitalize(
+            month.toLocaleString(locale, withYearFormat),
+            locale
+        )}`
     }
 
     // needed for ethiopic calendar - the default formatter adds the era, which is not what we want in DHIS2

--- a/src/utils/getValidLocale.ts
+++ b/src/utils/getValidLocale.ts
@@ -9,7 +9,10 @@
  * @param locale locale to validate and return
  * @returns the locale if it's valid, otherwise undefined
  */
-const getValidLocale = (locale = '') => {
+const getValidLocale = (requestedLocale = '') => {
+    // this "replace" is to cater for DHIS2 locales using underscore as Java allows both hyphens and underscores
+    // while JavaScript expects a hyphen (which is the correct way according to RFC-5646 that both rely on)
+    const locale = requestedLocale.replace('_', '-')
     try {
         const result = Intl.DateTimeFormat.supportedLocalesOf(locale)
         if (result && result.length === 1) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -28,8 +28,12 @@ export const formatYyyyMmDD = (
     return `${year}-${month}-${dayString}`
 }
 
-export const capitalize = (string: string) =>
-    string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
+// capitalize method taking into account locales that have different way of lower/upper case
+// based on https://stackoverflow.com/a/53930826
+export const capitalize = (
+    [firstLetter = '', ...rest]: string,
+    locale = 'en'
+) => [firstLetter.toLocaleUpperCase(locale), ...rest].join('')
 
 export const getCustomCalendarIfExists = (
     calendar: Temporal.CalendarLike


### PR DESCRIPTION
part of [DHIS2-14678](https://dhis2.atlassian.net/browse/DHIS2-14678)

While working on supporting localisation for the library integration with analytics - (https://github.com/dhis2/analytics/pull/1432), I noticed a couple of issues that needs addressing in the context of localisation in DHIS2:

- DHIS2 defines locales using underscore rather than hyphens (i.e. `en_GB` rather `en-GB`). Java allows both hyphens and underscores, but JavaScript's `.toLocaleString` and other locale-aware methods expect hyphens which is the correct representation according to [RFC-5646](https://www.rfc-editor.org/rfc/rfc5646) that both JS and Java follow, but Java allows a more [lenient variant](https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html).

- I am also now passing the locale passed to fixed period generation through the locale validation method (similar to the date picker) to make sure the locale is valid, or otherwise fallback to English.
   - I am not falling back to the user's locale in this case, as we're anyhow aiming to follow the locale passed by DHIS2 not the user.

- Finally, there seems to be a quirk with date formatting `.toLocaleString` where localisation to English capitalises the first letter, while it's not the case for other locales like French or Spanish. The current behaviour of analytics is that it expects the month names to be capitalised, so I have updated this to match what's expected (and what makes sense actually) while making sure it doesn't affect languages without an "upper case" concept.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/1014725/220133023-531e13e9-865a-4411-a241-d52815223f20.png">


[DHIS2-14678]: https://dhis2.atlassian.net/browse/DHIS2-14678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ