### PR TITLE
fix: parse date correctly when a dhis2 calendar type is passed

### DIFF
--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -550,7 +550,7 @@ describe('changing the calendar on the fly', () => {
 describe('default options for hook', () => {
     const originalDateTimeFormat = Intl.DateTimeFormat
     afterEach(() => {
-        // eslint-disable-next-line @typescript-eslint/no-extra-semi
+        // eslint-disable-next-line @typescript-eslint/no-extra-semi, @typescript-eslint/no-explicit-any
         ;(Intl.DateTimeFormat as any) = originalDateTimeFormat
     })
 
@@ -597,4 +597,26 @@ describe('default options for hook', () => {
         const result = renderedHook?.result?.current as UseDatePickerReturn
         expect(result.weekDayLabels).toContain('lunes')
     })
+})
+
+it('should generate the correct calendar weeks when passed "Ethiopian" rather than "ethiopic" (bug)', () => {
+    const onDateSelect = jest.fn()
+    const date = '2015-06-29'
+    const options = {
+        calendar: 'ethiopian' as SupportedCalendar,
+    }
+    const renderedHook = renderHook(() =>
+        useDatePicker({ onDateSelect, date, options })
+    )
+    const result = renderedHook.result?.current as UseDatePickerReturn
+
+    expect(
+        result.calendarWeekDays.map((week) => week.map((d) => d.label))
+    ).toEqual([
+        ['29', '30', '1', '2', '3', '4', '5'],
+        ['6', '7', '8', '9', '10', '11', '12'],
+        ['13', '14', '15', '16', '17', '18', '19'],
+        ['20', '21', '22', '23', '24', '25', '26'],
+        ['27', '28', '29', '30', '1', '2', '3'],
+    ])
 })

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -78,7 +78,14 @@ export const useDatePicker: UseDatePickerHookType = ({
     date: dateParts,
     options,
 }) => {
-    const resolvedOptions = useResolvedLocaleOptions(options)
+    const calendar = getCustomCalendarIfExists(
+        dhis2CalendarsMap[options.calendar!] ?? options.calendar
+    ) as SupportedCalendar
+
+    const resolvedOptions = useResolvedLocaleOptions({
+        ...options,
+        calendar,
+    })
     const prevDateStringRef = useRef(dateParts)
 
     const todayZdt = useMemo(
@@ -98,16 +105,12 @@ export const useDatePicker: UseDatePickerHookType = ({
               Temporal.MonthOrMonthCode & { day: number })
         : todayZdt
 
-    const calendar: Temporal.CalendarLike = getCustomCalendarIfExists(
-        dhis2CalendarsMap[resolvedOptions.calendar] ?? resolvedOptions.calendar
-    )
-
     const temporalCalendar = useMemo(
-        () => Temporal.Calendar.from(calendar),
-        [calendar]
+        () => Temporal.Calendar.from(resolvedOptions.calendar),
+        [resolvedOptions.calendar]
     )
     const temporalTimeZone = useMemo(
-        () => Temporal.TimeZone.from(resolvedOptions.timeZone!),
+        () => Temporal.TimeZone.from(resolvedOptions.timeZone),
         [resolvedOptions]
     )
 


### PR DESCRIPTION
DHIS2 uses non-standard calendar names (i.e. `Ethiopian` rather than `ethiopic`) for some calendar types. We have [a map](https://github.com/dhis2/multi-calendar-dates/blob/main/src/constants/dhis2CalendarsMap.ts#L7) to convert these to the standard JS types expected by `Intl.DateTimeFormat`.

There was a regression that caused this step not to happen when passed a date string, which results in returning the wrong calendar dates to be displayed in the UI. This PR fixes the issue by ensuring that the mapping happens first thing in the hook, and the correct calendar is used afterwards.

fixes [DHIS2-14900](https://dhis2.atlassian.net/browse/DHIS2-14900)

[DHIS2-14900]: https://dhis2.atlassian.net/browse/DHIS2-14900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ