### PR TITLE
fix: use custom locale when it exists

### DIFF
--- a/src/hooks/internal/useResolvedLocaleOptions.ts
+++ b/src/hooks/internal/useResolvedLocaleOptions.ts
@@ -6,6 +6,7 @@ import {
     WeekDayFormat,
 } from '../../types'
 import getValidLocale from '../../utils/getValidLocale'
+import { isCustomCalendar } from '../../utils/helpers'
 
 type UseResolvedLocaleOptionsHook = (
     options: PickerOptions
@@ -59,9 +60,20 @@ export const useResolvedLocaleOptions: UseResolvedLocaleOptionsHook = (
                 weekday: userOptions.weekDayFormat,
             }).resolvedOptions()
 
+        let localeToUse = resolvedLocale || defaultUserOptions.locale
+        // This step is necessary for custom locales where we have our own localisation values (like ne-NP)
+        // otherwise they can be overridden by  Intl.DateTimeFormat().resolvedOptions()
+        if (
+            userOptions.calendar &&
+            userOptions.locale &&
+            isCustomCalendar(userOptions.calendar)
+        ) {
+            localeToUse = userOptions.locale
+        }
+
         return {
             calendar: userOptions.calendar || defaultUserOptions.calendar,
-            locale: resolvedLocale || defaultUserOptions.locale,
+            locale: localeToUse,
             timeZone: resolvedOptions.timeZone || defaultUserOptions.timeZone,
             numberingSystem:
                 resolvedOptions.numberingSystem ||


### PR DESCRIPTION
This fixes an issue where `ne-NP` (nepali) calendar tests in dhis/ui broke after integrating the updated version of this library.

The issue is caused by resolvedOptions overriding the custom locale based on the browser. There is a test for the scenario in this repo, but it passed because `ne-NP` is a supported locale in node environments, but it's not on chromium-based browsers so it just defaulted to the user locale in that case. This change makes sure that, when we are providing our locale resources, then we always use them.

related PR: https://github.com/dhis2/ui/pull/1248

<img width="308" alt="image" src="https://user-images.githubusercontent.com/1014725/224018132-5ed160d6-e00e-4618-871c-c7df9ed1480e.png">

<img width="392" alt="image" src="https://user-images.githubusercontent.com/1014725/224018176-99bbc17e-ca55-4eb5-82b6-f742b45675ba.png">
