### PR TITLE
refactor: use Kotlin Multi Platform to generate daily periods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 lib/
 
 .d2
+.yalc/

--- a/features/fixed-periods.ethiopic.feature
+++ b/features/fixed-periods.ethiopic.feature
@@ -45,6 +45,7 @@ Feature: Ethiopic Calendar fixed periods
             | 2015 | MONTHLY    | 11          | Hamle 2015    | 201511      |
             | 2015 | MONTHLY    | 12          | Nehasse 2015  | 201512      |
 
+    @kotlin
     Scenario: Generate daily Periods
         When the user requests "daily" periods for "2015"
         Then the dates for the period type should be generated

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     },
     "dependencies": {
         "@js-temporal/polyfill": "^0.4.2",
-        "classnames": "^2.3.2"
+        "classnames": "^2.3.2",
+        "dhis2-period-generator": "file:.yalc/dhis2-period-generator"
     },
     "peerDependencies": {
         "react": "16.8",

--- a/src/period-calculation/fixed-periods-from-kotlin.spec.js
+++ b/src/period-calculation/fixed-periods-from-kotlin.spec.js
@@ -1,0 +1,48 @@
+import generateFixedPeriods from './fixed-periods'
+
+it('should generate daily fixed periods', () => {
+    const result = generateFixedPeriods({
+        year: 2015,
+        calendar: 'gregory',
+        locale: 'en',
+        periodType: 'DAILY',
+    })
+
+    expect(result[0]).toEqual({
+        endDate: '2015-1-1[u-ca=gregorian]',
+        id: '20150101',
+        iso: '20150101',
+        name: '2015/1/1',
+        startDate: '2015-1-1[u-ca=gregorian]',
+    })
+    expect(result[result.length - 1]).toEqual({
+        endDate: '2015-12-31[u-ca=gregorian]',
+        id: '20151231',
+        iso: '20151231',
+        name: '2015/12/31',
+        startDate: '2015-12-31[u-ca=gregorian]',
+    })
+})
+it('should generate daily fixed periods for Ethiopian', () => {
+    const result = generateFixedPeriods({
+        year: 2015,
+        calendar: 'ethiopic',
+        locale: 'en',
+        periodType: 'DAILY',
+    })
+
+    expect(result[0]).toEqual({
+        endDate: '2022-9-11[u-ca=gregorian]',
+        id: '20150101',
+        iso: '20150101',
+        name: 'መስከረም, 1, 2015',
+        startDate: '2022-9-11[u-ca=gregorian]',
+    })
+    expect(result[result.length - 1]).toEqual({
+        endDate: '2023-9-10[u-ca=gregorian]',
+        id: '20151305',
+        iso: '20151305',
+        name: 'ጳጐሜን/ጳጉሜ, 5, 2015',
+        startDate: '2023-9-10[u-ca=gregorian]',
+    })
+})

--- a/src/period-calculation/getDailyPeriods.ts
+++ b/src/period-calculation/getDailyPeriods.ts
@@ -1,30 +1,33 @@
-import { Temporal } from '@js-temporal/polyfill'
-import { formatYyyyMmDD } from '../utils/helpers'
-import { FixedPeriod, GeneratedPeriodsFunc } from './fixed-periods'
+import {
+    CalendarType,
+    PeriodGenerator,
+    PeriodOptions,
+    PeriodType,
+} from 'dhis2-period-generator'
+import Calendar from '../utils/calendarUtils'
+import { GeneratedPeriodsFunc } from './fixed-periods'
 
-export const getDailyPeriods: GeneratedPeriodsFunc = ({ year, calendar }) => {
-    const day = Temporal.PlainDate.from({
-        year,
-        month: 1,
-        day: 1,
-        calendar,
-    })
+/**
+ *
+ * Notes about consuming Kotlin Multi-Platform from JS:
+ * - Generally, it is very straightforwrd
+ * - There is a directive generateTypeScriptDefinitions() in gradle that generate TypeScript types
+ * (a.k.a Make Birk Happy)
+ * - Generated types have some issues, but still good enough
+ * - Generated code is more Object Oriented than functional, which doesn't fit nicely with JS patterns but that can be further abstracted with a façade like multi-calendar-dates library
+ *
+ * Already some improvements in this implementation because of bringing FE and BE closer together:
+ * - Start and end dates are converted to Gregorian which is inline with what the BE expects
+ * - Start and end dates are encoded using the IS8601 / RFC 3339 for date serialisation which introduced a "calendar extension"
+ *
+ */
+export const getDailyPeriods: GeneratedPeriodsFunc = ({
+    year,
+    calendar: calendarToUse,
+}) => {
+    const calendar: CalendarType = Calendar.fromString(calendarToUse) // would be nice to be able to just pass a string
+    const options = new PeriodOptions(year, PeriodType.DAILY, calendar)
+    const result = new PeriodGenerator().generatePeriod(options)
 
-    const days: FixedPeriod[] = []
-    for (let i = 0; i < day.daysInYear; i++) {
-        const nextDay = day.add({ days: i })
-        const value = `${day.year}${String(nextDay.month).padStart(
-            2,
-            '0'
-        )}${String(nextDay.day).padStart(2, '0')}`
-
-        days.push({
-            id: value,
-            iso: value,
-            name: formatYyyyMmDD(nextDay),
-            startDate: formatYyyyMmDD(nextDay),
-            endDate: formatYyyyMmDD(nextDay),
-        })
-    }
-    return days
+    return result
 }

--- a/src/utils/calendarUtils.ts
+++ b/src/utils/calendarUtils.ts
@@ -1,0 +1,18 @@
+import { CalendarType } from 'dhis2-period-generator'
+import { SupportedCalendar } from '../types'
+
+const Calendar = {
+    fromString: (calendar: SupportedCalendar) => {
+        if (calendar === 'ethiopic') {
+            return new CalendarType.Ethiopian()
+        }
+
+        if (calendar === 'nepali') {
+            return new CalendarType.Nepali()
+        }
+
+        return new CalendarType.Gregorian()
+    },
+}
+
+export default Calendar

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,0 +1,10 @@
+{
+  "version": "v1",
+  "packages": {
+    "dhis2-period-generator": {
+      "version": "1.0.0-SNAPSHOT",
+      "signature": "2eb4256d4b725603aa17d68c5ac3a3d3",
+      "file": true
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,6 +3001,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@js-joda/core@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
+  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
 "@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
@@ -6310,6 +6315,12 @@ detective@^5.2.1:
     defined "^1.0.0"
     minimist "^1.2.6"
 
+"dhis2-period-generator@file:.yalc/dhis2-period-generator":
+  version "1.0.0-SNAPSHOT"
+  dependencies:
+    "@js-joda/core" "3.2.0"
+    format-util "^1.0.5"
+
 didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
@@ -7629,6 +7640,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+format-util@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
+  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
The Kotlin code: https://github.com/Balcan/dhis2-period-generator

Notes about consuming Kotlin Multi-Platform from JS:

 - Generally, it is very straightforwrd
 - There is a directive `generateTypeScriptDefinitions`  (a.k.a Make Birk Happy) in gradle that generates TypeScript types
   - Generated types have some issues, but still good enough. For example, optional properties in an object are respected in JS if using the object constructor, but not object literal.
 - The generated code is more Object Oriented than functional, which doesn't fit nicely with JS patterns but that can be further abstracted with a façade like multi-calendar-dates library

 Already some improvements in this implementation because of bringing FE and BE closer together:

 - Start and end dates are converted to Gregorian which is inline with what the BE expects
 - Start and end dates are encoded using the IS8601 / RFC 3339 for date serialisation which introduced a "calendar extension"
 
![image](https://github.com/dhis2/multi-calendar-dates/assets/1014725/3587365b-2d57-4014-9210-b9798849caf1)
