### PR TITLE
chore: pin @js-temporal/polyfill to version 0.4.3 to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         ]
     },
     "dependencies": {
-        "@js-temporal/polyfill": "^0.4.2",
+        "@js-temporal/polyfill": "0.4.3",
         "classnames": "^2.3.2"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,7 +3001,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@js-temporal/polyfill@^0.4.2":
+"@js-temporal/polyfill@0.4.3", "@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
   integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==


### PR DESCRIPTION
The library [introduced breaking changes](https://github.com/js-temporal/temporal-polyfill/blob/main/CHANGELOG.md#044) in version 0.4.4 which break our library.
This PR pins the version to 0.4.3 to prevent this library from breaking (which it would, e.g. [here](https://github.com/dhis2/multi-calendar-dates/blob/85e96b19fe28062b0ce43a691af040a522825ee6/src/hooks/internal/useCalendarWeekDays.ts#L32))