### PR TITLE
feat: expose function to convert dates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './hooks'
 export * as constants from './constants'
 export * from './period-calculation'
-export { getNowInCalendar, validateDateString } from './utils'
+export { getNowInCalendar, validateDateString, convertDate } from './utils'

--- a/src/utils/convert-date.ts
+++ b/src/utils/convert-date.ts
@@ -1,0 +1,15 @@
+import { Temporal } from '@js-temporal/polyfill'
+import { NepaliCalendar } from '../custom-calendars/nepaliCalendar'
+import { SupportedCalendar } from '../types'
+
+type ConvertDateFn = (
+    date: string | Temporal.PlainDate,
+    calendar: SupportedCalendar
+) => Temporal.PlainDate
+
+export const convertDate: ConvertDateFn = (date, calendar) => {
+    if (calendar === 'nepali') {
+        return Temporal.PlainDate.from(date).withCalendar(new NepaliCalendar())
+    }
+    return Temporal.PlainDate.from(date).withCalendar(calendar)
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,5 @@ export { default as getNowInCalendar } from './getNowInCalendar'
 export * from './helpers'
 export { default as localisationHelpers } from './localisationHelpers'
 export { validateDateString } from './validate-date-string'
+
+export { convertDate } from './convert-date'


### PR DESCRIPTION
exposes a method to convert dates from one calendar to another.


## Usage: 

First install the version of the library from alpha (once PR is merged) `yarn add "@dhis2/multi-calendar-dates@alpha"`

```js
import { convertDate } from '@dhis2/multi-calendar-dates'


let date = convertDate('2022-10-18', 'nepali')
console.log(date.year, date.month, date.day)

date = convertDate('2022-10-18', 'ethiopic')
console.log(date.eraYear, date.month, date.day) 

```

The method returns a PlainDate object than can be deconstructed into its parts (year/eraYear, month, day), a helper like the one below can be implemented to return an iso-like string

```js

const toString  = (date) => {
    return date.year + '-'
     + String(date.month).padStart(2, '0')
     + '-'
     + String(date.day).padStart(2, '0')
}


let date = convertDate('2022-10-18', 'nepali')
console.log(toString(date)) // logs  2079-07-01
```
![image](https://github.com/dhis2/multi-calendar-dates/assets/1014725/0e645308-9313-4c6d-9e20-39ee232afe7b)
