### PR TITLE
fix(LIBS-629): default 'ne' locale to Nepali script

### DIFF
--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -407,6 +407,29 @@ describe('custom calendars', () => {
 
             expect(result.currMonth.label).toEqual('Ashadh')
         })
+        it('should default to Nepali if NE is passed as it is the case for DHIS2', () => {
+            const onDateSelect = jest.fn()
+            const date = '2079-03-32'
+            const options = {
+                locale: 'ne', // non-supported locale
+                calendar: 'nepali' as const,
+                timeZone: 'Africa/Khartoum',
+            }
+            const renderedHook = renderHook(() =>
+                useDatePicker({ onDateSelect, date, options })
+            )
+            const result = renderedHook?.result.current as UseDatePickerReturn
+
+            expect(result.weekDayLabels).toEqual([
+                'सोम',
+                'मंगल',
+                'बुध',
+                'बिही',
+                'शुक्र',
+                'शनि',
+                'आइत',
+            ])
+        })
     })
     describe('rendering Nepali (custom) day names', () => {
         it('should render Nepali with ne-NP passed', () => {

--- a/src/utils/localisationHelpers.ts
+++ b/src/utils/localisationHelpers.ts
@@ -8,6 +8,21 @@ import {
 import { PickerOptions, SupportedCalendar } from '../types'
 import { formatYyyyMmDD, isCustomCalendar } from './helpers'
 
+const getPartialLocaleMatch: (
+    locales: Record<string, CalendarCustomLocale>,
+    locale: string | undefined
+) => CalendarCustomLocale | undefined = (availableLocales, locale) => {
+    // try to see if there is a language match (even if the region doesn't match)
+    const partialLocaleMatch = Object.keys(availableLocales).find(
+        (supportedLocale) =>
+            supportedLocale.split('-')?.[0]?.toLowerCase() === locale
+    )
+
+    if (partialLocaleMatch) {
+        return availableLocales[partialLocaleMatch]
+    }
+}
+
 const getCustomCalendarLocale = (
     calendar: Temporal.CalendarLike,
     locale: string | undefined
@@ -17,9 +32,11 @@ const getCustomCalendarLocale = (
     if (!customCalendar) {
         return undefined
     }
+
     const customLocalisations = customCalendar.locales || {}
     const result =
         (locale && customLocalisations?.[locale]) ??
+        getPartialLocaleMatch(customLocalisations, locale) ??
         customLocalisations?.[customCalendar.defaultLocale]
 
     if (!result) {


### PR DESCRIPTION
fixes https://dhis2.atlassian.net/browse/LIBS-629

For Nepali, DHIS2 passes `ne` as a locale rather than `ne-NP`.

Given that Nepali is not a locale supported by the browser's [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), we had custom logic for it and that logic was falling back to English.

In this PR, we update the logic to fallback to the language if there is a partial match, even if the region or script don't match.