### PR TITLE
fix: initialise i18n properly

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -97,6 +97,9 @@ jobs:
               with:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            
+            - name: Build
+              run: yarn build
 
             - name: Test
               run: yarn test --coverage && yarn cucumber --tags 'not @draft'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-unresolved
+import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'
 export * from './period-calculation'


### PR DESCRIPTION
we added i18n and transifex in a previous PR, but this doesn't work without initialising i18n by calling `locales/index.js` in the entry point of the library