### PR TITLE
refactor: remove unnecessary export before merging to main branch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,4 @@ import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'
 export * from './period-calculation'
-export {
-    getNowInCalendar,
-    validateDateString,
-    convertFromIso8601,
-    convertToIso8601,
-} from './utils'
+export { getNowInCalendar, convertFromIso8601, convertToIso8601 } from './utils'


### PR DESCRIPTION
this is not used directly by the UI component anymore, so no need to export it (otherwise removing it after would be a major version change in main branch)