### PR TITLE
fix: changes for data entry app [LIBS-684]

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -97,7 +97,7 @@ jobs:
               with:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            
+
             - name: Build
               run: yarn build
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ts
@@ -1,5 +1,6 @@
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
+import getValidLocale from '../../utils/getValidLocale'
 import { fromAnyDate, getCustomCalendarIfExists } from '../../utils/index'
 import { buildDailyFixedPeriod } from '../daily-periods/index'
 import { generateFixedPeriods } from '../generate-fixed-periods/index'
@@ -30,6 +31,8 @@ const createFixedPeriodFromPeriodId: ParseFixedPeriodId = ({
         dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
     ) as SupportedCalendar
 
+    const validLocale = getValidLocale(locale) ?? 'en'
+
     if (isAnyYearlyPeriodId(periodId)) {
         const year = parseInt(periodId.substring(0, 4), 10)
         const periodType = getYearlyFixedPeriodTypeForPeriodId(periodId)
@@ -44,7 +47,7 @@ const createFixedPeriodFromPeriodId: ParseFixedPeriodId = ({
             periodType,
             year,
             calendar,
-            locale,
+            locale: validLocale,
         })
 
         const foundThisYear = monthlyPeriodsForYear.find(
@@ -61,7 +64,7 @@ const createFixedPeriodFromPeriodId: ParseFixedPeriodId = ({
             year: year + 1,
             periodType,
             calendar,
-            locale,
+            locale: validLocale,
         }).slice(-1)
 
         const foundNextYear = monthlyPeriodsForNextYear.find(

--- a/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
+++ b/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
@@ -1,13 +1,20 @@
 import { Temporal } from '@js-temporal/polyfill'
+import { SupportedCalendar } from '../../types'
+import { fromAnyDate } from '../../utils'
 
 type DoesPeriodEndBefore = (args: {
     period: { startDate: string; endDate: string }
     date: Temporal.PlainDate
+    calendar: SupportedCalendar
 }) => boolean
 
-const doesPeriodEndBefore: DoesPeriodEndBefore = ({ period, date }) => {
-    const periodStartDay = Temporal.PlainDate.from(period.startDate)
-    const periodEndDay = Temporal.PlainDate.from(period.endDate)
+const doesPeriodEndBefore: DoesPeriodEndBefore = ({
+    period,
+    date,
+    calendar,
+}) => {
+    const periodStartDay = fromAnyDate({ calendar, date: period.startDate })
+    const periodEndDay = fromAnyDate({ calendar, date: period.endDate })
 
     const periodStartsOnOrAfterDate =
         Temporal.PlainDate.compare(date, periodStartDay) < 1

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
@@ -62,7 +62,7 @@ const generateFixedPeriodsMonthly: GenerateFixedPeriodsMonthly = ({
 
             if (
                 endsBefore &&
-                doesPeriodEndBefore({ period, date: endsBefore })
+                doesPeriodEndBefore({ period, date: endsBefore, calendar })
             ) {
                 break
             }

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
@@ -52,10 +52,11 @@ const generateFixedPeriodsWeekly: GenerateFixedPeriodsWeekly = ({
             endsBefore &&
             doesPeriodEndBefore({
                 period: {
-                    startDate: date.toString(),
-                    endDate: endofWeek.toString(),
+                    startDate: formatYyyyMmDD(date),
+                    endDate: formatYyyyMmDD(endofWeek),
                 },
                 date: endsBefore,
+                calendar,
             })
         ) {
             break

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
@@ -65,7 +65,10 @@ const generateFixedPeriodsYearly: GenerateFixedPeriodsYearly = ({
             calendar,
         })
 
-        if (endsBefore && doesPeriodEndBefore({ period, date: endsBefore })) {
+        if (
+            endsBefore &&
+            doesPeriodEndBefore({ period, date: endsBefore, calendar })
+        ) {
             continue
         }
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
@@ -293,4 +293,101 @@ describe('Ethiopic Calendar fixed period calculation', () => {
             // expect(periods[periods.length - 1]).toEqual("2015-11-01/2015-13-06");
         })
     })
+
+    describe('periods calculated with endsBefore', () => {
+        it('should omit every period on/after the exclude date (daily)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'DAILY',
+                year: 2016,
+                calendar: 'ethiopic',
+                locale: 'en',
+                endsBefore: '2016-03-03',
+            })
+
+            expect(results.length).toBe(62)
+            expect(results[0]).toMatchObject({
+                displayName: 'Meskerem 1, 2016 ERA0',
+                endDate: '2016-01-01',
+                id: '20160101',
+                iso: '20160101',
+                name: '2016-01-01',
+                periodType: 'DAILY',
+                startDate: '2016-01-01',
+            })
+            expect(results[results.length - 1]).toMatchObject({
+                displayName: 'Hedar 2, 2016 ERA0',
+                endDate: '2016-03-02',
+                id: '20160302',
+                iso: '20160302',
+                name: '2016-03-02',
+                periodType: 'DAILY',
+                startDate: '2016-03-02',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (monthly)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'MONTHLY',
+                year: 2014,
+                calendar: 'ethiopic',
+                locale: 'en',
+                endsBefore: '2014-07-12',
+            })
+
+            expect(results.length).toBe(6)
+            expect(results[0]).toMatchObject({
+                periodType: 'MONTHLY',
+                id: '201401',
+                iso: '201401',
+                name: 'Meskerem 2014',
+                displayName: 'Meskerem 2014',
+                startDate: '2014-01-01',
+                endDate: '2014-01-30',
+            })
+            expect(results[results.length - 1]).toMatchObject({
+                periodType: 'MONTHLY',
+                id: '201406',
+                iso: '201406',
+                name: 'Yekatit 2014',
+                displayName: 'Yekatit 2014',
+                startDate: '2014-06-01',
+                endDate: '2014-06-30',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (weekly)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'WEEKLY',
+                year: 2014,
+                calendar: 'ethiopic',
+                locale: 'en',
+                endsBefore: '2014-07-12',
+                startingDay: 1,
+            })
+
+            expect(results[results.length - 1]).toMatchObject({
+                id: '2014W26',
+                iso: '2014W26',
+                name: 'Week 26 - 2014-06-29 - 2014-07-05',
+                displayName: 'Week 26 - 2014-06-29 - 2014-07-05',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (yearly)', () => {
+            const result = generateFixedPeriods({
+                periodType: 'YEARLY',
+                year: 2015,
+                endsBefore: '2015-03-01',
+                calendar: 'ethiopic',
+                locale: 'en',
+                yearsCount: null,
+            })
+            expect(result[0]).toMatchObject({
+                id: '2014',
+                iso: '2014',
+                name: '2014',
+                displayName: '2014',
+            })
+        })
+    })
 })

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
@@ -210,4 +210,101 @@ describe('Nepali Calendar fixed period calculation', () => {
             expect(periods[periods.length - 1]).toEqual('2079-11-01/2079-12-30')
         })
     })
+
+    describe('periods calculated with endsBefore', () => {
+        it('should omit every period on/after the exclude date (daily)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'DAILY',
+                year: 2076,
+                calendar: 'nepali',
+                locale: 'en',
+                endsBefore: '2076-03-03',
+            })
+
+            expect(results.length).toBe(65)
+            expect(results[0]).toMatchObject({
+                displayName: '2076-01-01',
+                endDate: '2076-01-01',
+                id: '20760101',
+                iso: '20760101',
+                name: '2076-01-01',
+                periodType: 'DAILY',
+                startDate: '2076-01-01',
+            })
+            expect(results[results.length - 1]).toMatchObject({
+                displayName: '2076-03-02',
+                endDate: '2076-03-02',
+                id: '20760302',
+                iso: '20760302',
+                name: '2076-03-02',
+                periodType: 'DAILY',
+                startDate: '2076-03-02',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (monthly)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'MONTHLY',
+                year: 2074,
+                calendar: 'nepali',
+                locale: 'en',
+                endsBefore: '2074-07-12',
+            })
+
+            expect(results.length).toBe(6)
+            expect(results[0]).toMatchObject({
+                periodType: 'MONTHLY',
+                id: '207401',
+                iso: '207401',
+                name: 'Baisakh 2074',
+                displayName: 'Baisakh 2074',
+                startDate: '2074-01-01',
+                endDate: '2074-01-31',
+            })
+            expect(results[results.length - 1]).toMatchObject({
+                periodType: 'MONTHLY',
+                id: '207406',
+                iso: '207406',
+                name: 'Ashwin 2074',
+                displayName: 'Ashwin 2074',
+                startDate: '2074-06-01',
+                endDate: '2074-06-31',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (weekly)', () => {
+            const results = generateFixedPeriods({
+                periodType: 'WEEKLY',
+                year: 2014,
+                calendar: 'nepali',
+                locale: 'en',
+                endsBefore: '2014-07-12',
+                startingDay: 1,
+            })
+
+            expect(results[results.length - 1]).toMatchObject({
+                id: '2014W28',
+                iso: '2014W28',
+                name: 'Week 28 - 2014-07-05 - 2014-07-11',
+                displayName: 'Week 28 - 2014-07-05 - 2014-07-11',
+            })
+        })
+
+        it('should omit every period on/after the exclude date (yearly)', () => {
+            const result = generateFixedPeriods({
+                periodType: 'YEARLY',
+                year: 2075,
+                endsBefore: '2075-03-01',
+                calendar: 'nepali',
+                locale: 'en',
+                yearsCount: null,
+            })
+            expect(result[0]).toMatchObject({
+                id: '2074',
+                iso: '2074',
+                name: '2074',
+                displayName: '2074',
+            })
+        })
+    })
 })

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ts
@@ -1,5 +1,6 @@
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
+import getValidLocale from '../../utils/getValidLocale'
 import { fromAnyDate, getCustomCalendarIfExists } from '../../utils/index'
 import {
     monthlyFixedPeriodTypes,
@@ -53,6 +54,8 @@ const generateFixedPeriods: GenerateFixedPeriods = ({
         dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
     ) as SupportedCalendar
 
+    const validLocale = getValidLocale(locale) ?? 'en'
+
     const endsBefore = _endsBefore
         ? fromAnyDate({ calendar, date: _endsBefore })
         : undefined
@@ -71,7 +74,7 @@ const generateFixedPeriods: GenerateFixedPeriods = ({
         return generateFixedPeriodsYearly({
             year,
             periodType,
-            locale,
+            locale: validLocale,
             calendar,
             endsBefore,
             yearsCount,
@@ -82,7 +85,7 @@ const generateFixedPeriods: GenerateFixedPeriods = ({
         return generateFixedPeriodsMonthly({
             year,
             periodType,
-            locale,
+            locale: validLocale,
             calendar,
             endsBefore,
         })
@@ -91,7 +94,7 @@ const generateFixedPeriods: GenerateFixedPeriods = ({
     if (periodType === 'DAILY') {
         return generateFixedPeriodsDaily({
             year,
-            locale,
+            locale: validLocale,
             calendar,
             endsBefore,
         })

--- a/src/utils/getValidLocale.spec.ts
+++ b/src/utils/getValidLocale.spec.ts
@@ -1,0 +1,33 @@
+import getValidLocale from './getValidLocale'
+
+describe('getValidLocale', () => {
+    it('returns language only for a valid language', () => {
+        const requestedLocale = 'pt'
+        const outputLocale = 'pt'
+        expect(getValidLocale(requestedLocale)).toEqual(outputLocale)
+    })
+
+    it('returns language-region from java format', () => {
+        const requestedLocale = 'pt_BR'
+        const outputLocale = 'pt-BR'
+        expect(getValidLocale(requestedLocale)).toEqual(outputLocale)
+    })
+
+    it('returns language-region from valid ISO format', () => {
+        const requestedLocale = 'pt-BR'
+        const outputLocale = 'pt-BR'
+        expect(getValidLocale(requestedLocale)).toEqual(outputLocale)
+    })
+
+    it('returns language-script-region from DHIS2 format', () => {
+        const requestedLocale = 'uz_UZ_Cyrl'
+        const outputLocale = 'uz-Cyrl-UZ'
+        expect(getValidLocale(requestedLocale)).toEqual(outputLocale)
+    })
+
+    it('returns undefined for an invalid locale', () => {
+        const requestedLocale = 'pb'
+        const outputLocale = undefined
+        expect(getValidLocale(requestedLocale)).toEqual(outputLocale)
+    })
+})

--- a/src/utils/getValidLocale.ts
+++ b/src/utils/getValidLocale.ts
@@ -12,7 +12,18 @@
 const getValidLocale = (requestedLocale = '') => {
     // this "replace" is to cater for DHIS2 locales using underscore as Java allows both hyphens and underscores
     // while JavaScript expects a hyphen (which is the correct way according to RFC-5646 that both rely on)
-    const locale = requestedLocale.replace('_', '-')
+    const [lng, region, script] = requestedLocale
+        .replaceAll('_', '-')
+        .split('-')
+
+    let locale = lng
+    if (script) {
+        locale = `${locale}-${script}`
+    }
+    if (region) {
+        locale = `${locale}-${region}`
+    }
+
     try {
         const result = Intl.DateTimeFormat.supportedLocalesOf(locale)
         if (result && result.length === 1) {

--- a/src/utils/getValidLocale.ts
+++ b/src/utils/getValidLocale.ts
@@ -12,9 +12,7 @@
 const getValidLocale = (requestedLocale = '') => {
     // this "replace" is to cater for DHIS2 locales using underscore as Java allows both hyphens and underscores
     // while JavaScript expects a hyphen (which is the correct way according to RFC-5646 that both rely on)
-    const [lng, region, script] = requestedLocale
-        .replaceAll('_', '-')
-        .split('-')
+    const [lng, region, script] = requestedLocale.replace(/_/g, '-').split('-')
 
     let locale = lng
     if (script) {


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/LIBS/issues/LIBS-684

This PR makes some changes to support use of multi-calendar-dates library in the aggregate data entry app.

- does-period-end-before.ts: had some inconsistent date calculation logic. The endsBefore date was computed by using the calendar, but the period dates were not, so the logic did not work consistently with non-Gregorian calendars.
- generate-fixed-periods-weekly.ts: use a toString method which did not work with certain calendars (I think Nepali?)
- I've added some locale handling using getValidLocale for functions that aggregate data entry app uses, to prevent errors with the java-formatted locales returned from the ui ([DHIS2-18031](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18031))
- I've modified getValidLocale slightly to handle the invalid formats like `uz_UZ_Cyrl` (i.e. in addition to `_`, we have the script in the wrong position).

[DHIS2-18031]: https://dhis2.atlassian.net/browse/DHIS2-18031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ