### PR TITLE
fix: address merge issues [LIBS-684]

### DIFF
--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
@@ -52,8 +52,8 @@ const generateFixedPeriodsWeekly: GenerateFixedPeriodsWeekly = ({
             endsBefore &&
             doesPeriodEndBefore({
                 period: {
-                    startDate: formatYyyyMmDD(date),
-                    endDate: formatYyyyMmDD(endofWeek),
+                    startDate: formatDate(date),
+                    endDate: formatDate(endofWeek),
                 },
                 date: endsBefore,
                 calendar,


### PR DESCRIPTION
updates function used (`formatYyyyMmDD` is no longer exported as it has been replaced by `formatDate` which defaults to `YYYY-MM-DD` format.

Fixes problem here: https://github.com/dhis2/multi-calendar-dates/actions/runs/11053474757/job/30708034708