### PR TITLE
fix: check first week of next year, get period by date [LIBS-688]

### DIFF
--- a/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.ethiopic.spec.ts
+++ b/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.ethiopic.spec.ts
@@ -37,6 +37,17 @@ describe('Ethiopic Calendar period by date calculation', () => {
             expect(actual?.id).toBe('2014W1')
         })
 
+        it('should return "2018W1" for period type "WEEKLY" on "2017-13-04"', () => {
+            const actual = getFixedPeriodByDate({
+                periodType: 'WEEKLY',
+                date: '2017-13-04',
+                calendar: 'ethiopic',
+                locale: 'en',
+            })
+
+            expect(actual?.id).toBe('2018W1')
+        })
+
         it('should return "2010WedW52" for period type "WEEKLYWED" on "2011-01-01"', () => {
             const actual = getFixedPeriodByDate({
                 periodType: 'WEEKLYWED',
@@ -136,7 +147,7 @@ describe('Ethiopic Calendar period by date calculation', () => {
             expect(actual?.id).toBe('2014BiW26')
         })
 
-        it('should return "2012SunW1" for period type "BIWEEKLY" on "2012-01-01"', () => {
+        it('should return "2012BiW1" for period type "BIWEEKLY" on "2012-01-01"', () => {
             const actual = getFixedPeriodByDate({
                 periodType: 'BIWEEKLY',
                 date: '2012-01-01',
@@ -145,6 +156,17 @@ describe('Ethiopic Calendar period by date calculation', () => {
             })
 
             expect(actual?.id).toBe('2012BiW1')
+        })
+
+        it('should return "2018BiW1" for period type "BIWEEKLY" on "2017-13-04"', () => {
+            const actual = getFixedPeriodByDate({
+                periodType: 'BIWEEKLY',
+                date: '2017-13-04',
+                calendar: 'ethiopic',
+                locale: 'en',
+            })
+
+            expect(actual?.id).toBe('2018BiW1')
         })
     })
 

--- a/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.gregorian.spec.ts
+++ b/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.gregorian.spec.ts
@@ -30,6 +30,14 @@ describe('Gregorian Calendar period by date calculation', () => {
             expect(actual?.id).toBe('2022W1')
         })
 
+        it('should return "2025W1" for period type "WEEKLY" on "2024-12-31"', () => {
+            const periodType = 'WEEKLY'
+            const date = '2024-12-31'
+            const actual = getFixedPeriodByDate({ periodType, date, calendar })
+
+            expect(actual?.id).toBe('2025W1')
+        })
+
         it('should return "2018WedW52" for period type "WEEKLYWED" on "2019-01-01"', () => {
             const periodType = 'WEEKLYWED'
             const date = '2019-01-01'
@@ -94,6 +102,14 @@ describe('Gregorian Calendar period by date calculation', () => {
             expect(actual?.id).toBe('2023SunW1')
         })
 
+        it('should return "2025SunW1" for period type "WEEKLYSUN" on "2024-12-31"', () => {
+            const periodType = 'WEEKLYSUN'
+            const date = '2024-12-31'
+            const actual = getFixedPeriodByDate({ periodType, date, calendar })
+
+            expect(actual?.id).toBe('2025SunW1')
+        })
+
         it('should return "2020BiW26" for period type "BIWEEKLY" on "2021-01-01"', () => {
             const periodType = 'BIWEEKLY'
             const date = '2021-01-01'
@@ -102,12 +118,20 @@ describe('Gregorian Calendar period by date calculation', () => {
             expect(actual?.id).toBe('2020BiW26')
         })
 
-        it('should return "2020SunW1" for period type "BIWEEKLY" on "2020-01-01"', () => {
+        it('should return "2020BiW1" for period type "BIWEEKLY" on "2020-01-01"', () => {
             const periodType = 'BIWEEKLY'
             const date = '2020-01-01'
             const actual = getFixedPeriodByDate({ periodType, date, calendar })
 
             expect(actual?.id).toBe('2020BiW1')
+        })
+
+        it('should return "2025BiW1" for period type "BIWEEKLY" on "2024-12-31"', () => {
+            const periodType = 'BIWEEKLY'
+            const date = '2024-12-31'
+            const actual = getFixedPeriodByDate({ periodType, date, calendar })
+
+            expect(actual?.id).toBe('2025BiW1')
         })
     })
 

--- a/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.nepali.spec.ts
+++ b/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.nepali.spec.ts
@@ -37,6 +37,17 @@ describe('Nepali Calendar period by date calculation', () => {
             expect(actual.id).toBe('2078W1')
         })
 
+        it('should return "2083W1" for period type "WEEKLY" on "2082-12-30"', () => {
+            const actual = getFixedPeriodByDate({
+                periodType: 'WEEKLY',
+                date: '2082-12-30',
+                calendar: 'nepali',
+                locale: 'en',
+            })
+
+            expect(actual.id).toBe('2083W1')
+        })
+
         it('should return "2075WedW53" for period type "WEEKLYWED" on "2076-01-01"', () => {
             const actual = getFixedPeriodByDate({
                 periodType: 'WEEKLYWED',
@@ -79,6 +90,17 @@ describe('Nepali Calendar period by date calculation', () => {
             })
 
             expect(actual.id).toBe('2076ThuW1')
+        })
+
+        it('should return "2069ThuW1" for period type "WEEKLYTHU" on "2068-12-30"', () => {
+            const actual = getFixedPeriodByDate({
+                periodType: 'WEEKLYTHU',
+                date: '2068-12-30',
+                calendar: 'nepali',
+                locale: 'en',
+            })
+
+            expect(actual.id).toBe('2069ThuW1')
         })
 
         it('should return "2077SatW53" for period type "WEEKLYSAT" on "2078-01-01"', () => {

--- a/src/period-calculation/get-fixed-period-by-date/get-weekly-fixed-period-by-date.ts
+++ b/src/period-calculation/get-fixed-period-by-date/get-weekly-fixed-period-by-date.ts
@@ -21,8 +21,8 @@ const getWeeklyFixedPeriodByDate: GetWeeklyFixedPeriodByDate = ({
         startingDay: 1,
     })
 
-    // if start date of first period of year is after current date get last
-    // period of last year
+    // if current date is before start date of first period of year
+    // get last period of previous year
     if (date < weeklyPeriods[0].startDate) {
         return generateFixedPeriodsWeekly({
             year: year - 1,
@@ -30,6 +30,17 @@ const getWeeklyFixedPeriodByDate: GetWeeklyFixedPeriodByDate = ({
             periodType,
             startingDay: 1,
         }).slice(-1)[0]
+    }
+
+    // if current date is after end date of last period of year
+    // get first period of following year
+    if (date > weeklyPeriods.slice(-1)[0].endDate) {
+        return generateFixedPeriodsWeekly({
+            year: year + 1,
+            calendar,
+            periodType,
+            startingDay: 1,
+        })[0]
     }
 
     const fixedPeriod = weeklyPeriods.find((currentPeriod) => {


### PR DESCRIPTION
See: https://dhis2.atlassian.net/jira/software/c/projects/LIBS/issues/LIBS-688

I've amended the logic of GetWeeklyFixedPeriodByDate to return the first period of the subsequent year if the requested date is after the end date of the the periods for the year. This logic mirrors the existing logic for returning the previous year's last week if requested date is before the start date of the first period of the year.

I guess a slightly safer implementation would also perform the check on the previous year/subsequent year's period to make sure the requested date is in range, but I assume it should not be necessary.