### PR TITLE
fix: remove Temporal references from hook public API and clean up use date picker

### DIFF
--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -1,9 +1,9 @@
-import { Intl, Temporal } from '@js-temporal/polyfill'
+import { Intl } from '@js-temporal/polyfill'
 import { render } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { SupportedCalendar } from '../types'
-import { convertToIso8601, formatDate } from '../utils'
+import { convertToIso8601 } from '../utils'
 import localisationHelpers from '../utils/localisationHelpers'
 import { useDatePicker, UseDatePickerReturn } from './useDatePicker'
 

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -1,8 +1,9 @@
-import { Intl } from '@js-temporal/polyfill'
+import { Intl, Temporal } from '@js-temporal/polyfill'
 import { render } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { SupportedCalendar } from '../types'
+import { formatDate } from '../utils'
 import localisationHelpers from '../utils/localisationHelpers'
 import { useDatePicker, UseDatePickerReturn } from './useDatePicker'
 
@@ -271,13 +272,21 @@ describe('useDatePicker hook', () => {
     })
     describe('highlighting today', () => {
         const getDayByDate: (
-            calendarWeekDays: { calendarDate: string; isToday: boolean }[][],
+            calendarWeekDays: {
+                isToday: boolean
+                zdt: Temporal.ZonedDateTime
+            }[][],
             dayToFind: string
         ) => { calendarDate: string; isToday: boolean }[] = (
             calendarWeekDays,
             dayToFind
         ) => {
-            const days = calendarWeekDays.flatMap((week) => week)
+            const days = calendarWeekDays
+                .flatMap((week) => week)
+                .map((day) => ({
+                    ...day,
+                    calendarDate: formatDate(day.zdt, undefined, 'YYYY-MM-DD'),
+                }))
 
             return days.filter((day) => day.calendarDate === dayToFind)
         }
@@ -485,7 +494,12 @@ describe('clicking a day', () => {
 
         // find and click the day passed to the calendar
         for (let i = 0; i < days.length; i++) {
-            if (days[i].calendarDate === date) {
+            const formattedDate = formatDate(
+                days[i].zdt,
+                undefined,
+                'YYYY-MM-DD'
+            )
+            if (formattedDate === date) {
                 days[i].onClick()
                 break
             }

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -271,24 +271,16 @@ describe('useDatePicker hook', () => {
         })
     })
     describe('highlighting today', () => {
-        const getDayByDate: (
+        const getDayByDate = (
             calendarWeekDays: {
                 isToday: boolean
-                zdt: Temporal.ZonedDateTime
+                dateValue: string
             }[][],
             dayToFind: string
-        ) => { calendarDate: string; isToday: boolean }[] = (
-            calendarWeekDays,
-            dayToFind
         ) => {
-            const days = calendarWeekDays
-                .flatMap((week) => week)
-                .map((day) => ({
-                    ...day,
-                    calendarDate: formatDate(day.zdt, undefined, 'YYYY-MM-DD'),
-                }))
+            const days = calendarWeekDays.flatMap((week) => week)
 
-            return days.filter((day) => day.calendarDate === dayToFind)
+            return days.filter((day) => day.dateValue === dayToFind)
         }
 
         it('should highlight today date in a an ethiopic calendar', () => {
@@ -494,11 +486,7 @@ describe('clicking a day', () => {
 
         // find and click the day passed to the calendar
         for (let i = 0; i < days.length; i++) {
-            const formattedDate = formatDate(
-                days[i].zdt,
-                undefined,
-                'YYYY-MM-DD'
-            )
+            const formattedDate = days[i].dateValue
             if (formattedDate === date) {
                 days[i].onClick()
                 break
@@ -528,7 +516,7 @@ describe('clicking a day', () => {
     })
     it('should call the callback with correct info for a custom (Nepali) calendar', () => {
         const date = '2077-12-30'
-        const { calendarDate, calendarDateString } = renderForClick({
+        const { calendarDateString } = renderForClick({
             calendar: 'nepali',
             date,
         })

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { SupportedCalendar } from '../types'
-import { formatDate } from '../utils'
+import { convertToIso8601, formatDate } from '../utils'
 import localisationHelpers from '../utils/localisationHelpers'
 import { useDatePicker, UseDatePickerReturn } from './useDatePicker'
 
@@ -510,34 +510,21 @@ describe('clicking a day', () => {
     }
     it('should call the callback with correct info for Gregorian calendar', () => {
         const date = '2018-01-22'
-        const { calendarDate, calendarDateString } = renderForClick({
+        const { calendarDateString } = renderForClick({
             calendar: 'gregory',
             date,
         })
-        expect(calendarDate.toString()).toEqual(
-            '2018-01-22T00:00:00+02:00[Africa/Khartoum][u-ca=gregory]'
-        )
         expect(calendarDateString).toEqual('2018-01-22')
     })
     it('should call the callback with correct info for Ethiopic calendar', () => {
         const date = '2015-13-02'
-        const { calendarDate, calendarDateString } = renderForClick({
+        const { calendarDateString } = renderForClick({
             calendar: 'ethiopic',
             date,
         })
         expect(calendarDateString).toEqual('2015-13-02')
-        expect(
-            calendarDate.withCalendar('iso8601').toLocaleString('en-GB')
-        ).toMatch('07/09/2023')
-
-        expect(
-            calendarDate.toLocaleString('en-GB', {
-                month: 'long',
-                year: 'numeric',
-                day: 'numeric',
-                calendar: 'ethiopic',
-            })
-        ).toEqual('2 Pagumen 2015 ERA1')
+        const calendarDate = convertToIso8601(calendarDateString, 'ethiopic')
+        expect(calendarDate).toEqual({ day: 7, month: 9, year: 2023 })
     })
     it('should call the callback with correct info for a custom (Nepali) calendar', () => {
         const date = '2077-12-30'
@@ -548,7 +535,11 @@ describe('clicking a day', () => {
         expect(calendarDateString).toEqual('2077-12-30')
         expect(
             localisationHelpers.localiseMonth(
-                calendarDate,
+                {
+                    year: 20777,
+                    month: 12,
+                    day: 30,
+                },
                 {
                     locale: 'en-NP',
                     calendar: 'nepali',

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -44,18 +44,12 @@ export type UseDatePickerReturn = UseNavigationReturnType & {
         isToday: boolean
         isInCurrentMonth: boolean
     }[][]
-    isValid: boolean
-    warningMessage: string
-    errorMessage: string
 }
 
 type UseDatePickerHookType = (options: DatePickerOptions) => UseDatePickerReturn
 type ValidatedDate = Temporal.YearOrEraAndEraYear &
     Temporal.MonthOrMonthCode & {
         day: number
-        isValid: boolean
-        warningMessage: string
-        errorMessage: string
         format?: string
     }
 
@@ -219,8 +213,5 @@ export const useDatePicker: UseDatePickerHookType = ({
         ),
         ...navigation,
         weekDayLabels,
-        isValid: date.isValid,
-        warningMessage: date.warningMessage,
-        errorMessage: date.errorMessage,
     }
 }

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -34,7 +34,7 @@ type DatePickerOptions = {
 export type UseDatePickerReturn = UseNavigationReturnType & {
     weekDayLabels: string[]
     calendarWeekDays: {
-        zdt: Temporal.ZonedDateTime
+        dateValue: string
         label: string | number
         onClick: () => void
         isSelected: boolean | undefined
@@ -185,10 +185,10 @@ export const useDatePicker: UseDatePickerHookType = ({
         temporalCalendar,
         temporalTimeZone,
     ])
-    return {
+    const result: UseDatePickerReturn = {
         calendarWeekDays: calendarWeekDaysZdts.map((week) =>
             week.map((weekDayZdt) => ({
-                zdt: weekDayZdt,
+                dateValue: formatDate(weekDayZdt, undefined, format),
                 label: localisationHelpers.localiseWeekLabel(
                     weekDayZdt.withCalendar(localeOptions.calendar),
                     localeOptions
@@ -208,4 +208,6 @@ export const useDatePicker: UseDatePickerHookType = ({
         ...navigation,
         weekDayLabels,
     }
+
+    return result
 }

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -38,14 +38,12 @@ export type UseDatePickerReturn = UseNavigationReturnType & {
     calendarWeekDays: {
         zdt: Temporal.ZonedDateTime
         label: string | number
-        calendarDate: string
         onClick: () => void
         isSelected: boolean | undefined
         isToday: boolean
         isInCurrentMonth: boolean
     }[][]
 }
-
 type UseDatePickerHookType = (options: DatePickerOptions) => UseDatePickerReturn
 type ValidatedDate = Temporal.YearOrEraAndEraYear &
     Temporal.MonthOrMonthCode & {
@@ -194,7 +192,6 @@ export const useDatePicker: UseDatePickerHookType = ({
         calendarWeekDays: calendarWeekDaysZdts.map((week) =>
             week.map((weekDayZdt) => ({
                 zdt: weekDayZdt,
-                calendarDate: formatDate(weekDayZdt, undefined, date.format),
                 label: localisationHelpers.localiseWeekLabel(
                     weekDayZdt.withCalendar(localeOptions.calendar),
                     localeOptions

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -21,10 +21,8 @@ type DatePickerOptions = {
     date: string
     options: PickerOptions
     onDateSelect: ({
-        calendarDate,
         calendarDateString,
     }: {
-        calendarDate: Temporal.ZonedDateTime
         calendarDateString: string
     }) => void
     minDate?: string
@@ -150,7 +148,6 @@ export const useDatePicker: UseDatePickerHookType = ({
     const selectDate = useCallback(
         (zdt: Temporal.ZonedDateTime) => {
             onDateSelect({
-                calendarDate: zdt,
                 calendarDateString: formatDate(zdt, undefined, date.format),
             })
         },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,9 +14,6 @@ export const padWithZeroes = (number: number, count = 2) =>
 type DayType = 'endOfMonth' | 'startOfMonth'
 
 type customDate = Temporal.PlainDateLike & {
-    isValid: boolean
-    warningMessage?: string
-    errorMessage?: string
     format?: string
 }
 
@@ -77,20 +74,16 @@ export const extractAndValidateDateString = (
         strictValidation?: boolean
         format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'
     }
-): Temporal.PlainDateLike & {
-    isValid: boolean
-    warningMessage?: string
-    errorMessage?: string
-} => {
+): Temporal.PlainDateLike => {
     if (!date) {
         return getCurrentDateResult(options)
     }
 
     const validation = validateDateString(date, options)
     if (validation.isValid) {
-        return getValidDateResult(date, validation, options)
+        return getValidDateResult(date, options)
     } else {
-        return getInvalidDateResult(options, validation.errorMessage)
+        return getInvalidDateResult(options)
     }
 }
 
@@ -102,24 +95,13 @@ const getCurrentDateResult = (options: PickerOptions) => {
     return { year, month, day, isValid: true }
 }
 
-const getValidDateResult = (
-    date: string,
-    validation: {
-        isValid: boolean
-        warningMessage?: string
-        errorMessage?: string
-    },
-    options: PickerOptions
-) => {
+const getValidDateResult = (date: string, options: PickerOptions) => {
     const { year, month, day, format } = extractDatePartsFromDateString(date)
     let result: customDate = {
         year,
         month,
         day,
         format,
-        isValid: validation.isValid,
-        warningMessage: validation.warningMessage,
-        errorMessage: validation.errorMessage,
     }
 
     if (options.calendar === 'ethiopic') {
@@ -129,15 +111,12 @@ const getValidDateResult = (
     return result
 }
 
-const getInvalidDateResult = (
-    options: PickerOptions,
-    errorMessage?: string
-) => {
+const getInvalidDateResult = (options: PickerOptions) => {
     const { year, month, day } = getNowInCalendar(
         options.calendar,
         options.timeZone
     )
-    return { year, month, day, isValid: false, errorMessage }
+    return { year, month, day }
 }
 
 const adjustForEthiopicCalendar = (result: customDate) => {

--- a/src/utils/localisationHelpers.ts
+++ b/src/utils/localisationHelpers.ts
@@ -113,7 +113,11 @@ const localiseWeekLabel = (
 }
 
 const localiseMonth = (
-    zdt: Temporal.ZonedDateTime | Temporal.PlainYearMonth | Temporal.PlainDate,
+    zdt:
+        | Temporal.ZonedDateTime
+        | Temporal.PlainYearMonth
+        | Temporal.PlainDate
+        | Temporal.PlainDateLike,
     localeOptions: PickerOptions,
     format: Intl.DateTimeFormatOptions
 ) => {

--- a/src/utils/localisationHelpers.ts
+++ b/src/utils/localisationHelpers.ts
@@ -131,7 +131,7 @@ const localiseMonth = (
     )
 
     return isCustom
-        ? customLocale?.monthNames[zdt.month - 1]
+        ? customLocale?.monthNames[zdt.month! - 1]
         : zdt.toLocaleString(localeOptions.locale, format)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Remove Temporal references from hook public API

Addresses  [DHIS2-18131](https://dhis2.atlassian.net/browse/DHIS2-18131) and [LIBS-651](https://dhis2.atlassian.net/browse/LIBS-651)

Refactoring useDatePicker: 
- Remove isValid, errorMessage, and warningMessage as we are using validateDateString directly.
- Remove calendarDate as well, since we don't want to expose it anymore

[DHIS2-18131]: https://dhis2.atlassian.net/browse/DHIS2-18131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIBS-651]: https://dhis2.atlassian.net/browse/LIBS-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ