### PR TITLE
feat: clean up use date picker

### DIFF
--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -1,8 +1,9 @@
-import { Intl } from '@js-temporal/polyfill'
+import { Intl, Temporal } from '@js-temporal/polyfill'
 import { render } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { SupportedCalendar } from '../types'
+import { formatDate } from '../utils'
 import localisationHelpers from '../utils/localisationHelpers'
 import { useDatePicker, UseDatePickerReturn } from './useDatePicker'
 
@@ -271,13 +272,21 @@ describe('useDatePicker hook', () => {
     })
     describe('highlighting today', () => {
         const getDayByDate: (
-            calendarWeekDays: { calendarDate: string; isToday: boolean }[][],
+            calendarWeekDays: {
+                isToday: boolean
+                zdt: Temporal.ZonedDateTime
+            }[][],
             dayToFind: string
         ) => { calendarDate: string; isToday: boolean }[] = (
             calendarWeekDays,
             dayToFind
         ) => {
-            const days = calendarWeekDays.flatMap((week) => week)
+            const days = calendarWeekDays
+                .flatMap((week) => week)
+                .map((day) => ({
+                    ...day,
+                    calendarDate: formatDate(day.zdt, undefined, 'YYYY-MM-DD'),
+                }))
 
             return days.filter((day) => day.calendarDate === dayToFind)
         }
@@ -485,7 +494,12 @@ describe('clicking a day', () => {
 
         // find and click the day passed to the calendar
         for (let i = 0; i < days.length; i++) {
-            if (days[i].calendarDate === date) {
+            const formattedDate = formatDate(
+                days[i].zdt,
+                undefined,
+                'YYYY-MM-DD'
+            )
+            if (formattedDate === date) {
                 days[i].onClick()
                 break
             }

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -44,18 +44,12 @@ export type UseDatePickerReturn = UseNavigationReturnType & {
         isToday: boolean
         isInCurrentMonth: boolean
     }[][]
-    isValid: boolean
-    warningMessage: string
-    errorMessage: string
 }
 
 type UseDatePickerHookType = (options: DatePickerOptions) => UseDatePickerReturn
 type ValidatedDate = Temporal.YearOrEraAndEraYear &
     Temporal.MonthOrMonthCode & {
         day: number
-        isValid: boolean
-        warningMessage: string
-        errorMessage: string
         format?: string
     }
 
@@ -219,8 +213,5 @@ export const useDatePicker: UseDatePickerHookType = ({
         ),
         ...navigation,
         weekDayLabels,
-        isValid: date.isValid,
-        warningMessage: date.warningMessage,
-        errorMessage: date.errorMessage,
     }
 }

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -38,14 +38,12 @@ export type UseDatePickerReturn = UseNavigationReturnType & {
     calendarWeekDays: {
         zdt: Temporal.ZonedDateTime
         label: string | number
-        calendarDate: string
         onClick: () => void
         isSelected: boolean | undefined
         isToday: boolean
         isInCurrentMonth: boolean
     }[][]
 }
-
 type UseDatePickerHookType = (options: DatePickerOptions) => UseDatePickerReturn
 type ValidatedDate = Temporal.YearOrEraAndEraYear &
     Temporal.MonthOrMonthCode & {
@@ -194,7 +192,6 @@ export const useDatePicker: UseDatePickerHookType = ({
         calendarWeekDays: calendarWeekDaysZdts.map((week) =>
             week.map((weekDayZdt) => ({
                 zdt: weekDayZdt,
-                calendarDate: formatDate(weekDayZdt, undefined, date.format),
                 label: localisationHelpers.localiseWeekLabel(
                     weekDayZdt.withCalendar(localeOptions.calendar),
                     localeOptions

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,9 +14,6 @@ export const padWithZeroes = (number: number, count = 2) =>
 type DayType = 'endOfMonth' | 'startOfMonth'
 
 type customDate = Temporal.PlainDateLike & {
-    isValid: boolean
-    warningMessage?: string
-    errorMessage?: string
     format?: string
 }
 
@@ -77,20 +74,16 @@ export const extractAndValidateDateString = (
         strictValidation?: boolean
         format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'
     }
-): Temporal.PlainDateLike & {
-    isValid: boolean
-    warningMessage?: string
-    errorMessage?: string
-} => {
+): Temporal.PlainDateLike => {
     if (!date) {
         return getCurrentDateResult(options)
     }
 
     const validation = validateDateString(date, options)
     if (validation.isValid) {
-        return getValidDateResult(date, validation, options)
+        return getValidDateResult(date, options)
     } else {
-        return getInvalidDateResult(options, validation.errorMessage)
+        return getInvalidDateResult(options)
     }
 }
 
@@ -102,24 +95,13 @@ const getCurrentDateResult = (options: PickerOptions) => {
     return { year, month, day, isValid: true }
 }
 
-const getValidDateResult = (
-    date: string,
-    validation: {
-        isValid: boolean
-        warningMessage?: string
-        errorMessage?: string
-    },
-    options: PickerOptions
-) => {
+const getValidDateResult = (date: string, options: PickerOptions) => {
     const { year, month, day, format } = extractDatePartsFromDateString(date)
     let result: customDate = {
         year,
         month,
         day,
         format,
-        isValid: validation.isValid,
-        warningMessage: validation.warningMessage,
-        errorMessage: validation.errorMessage,
     }
 
     if (options.calendar === 'ethiopic') {
@@ -129,15 +111,12 @@ const getValidDateResult = (
     return result
 }
 
-const getInvalidDateResult = (
-    options: PickerOptions,
-    errorMessage?: string
-) => {
+const getInvalidDateResult = (options: PickerOptions) => {
     const { year, month, day } = getNowInCalendar(
         options.calendar,
         options.timeZone
     )
-    return { year, month, day, isValid: false, errorMessage }
+    return { year, month, day }
 }
 
 const adjustForEthiopicCalendar = (result: customDate) => {


### PR DESCRIPTION
Refactoring useDatePicker:

- Remove isValid, errorMessage, and warningMessage as we are using validateDateString directly.
- Remove calendarDate as well, since we don't want to expose it anymore

