### PR TITLE
fix: update validation logic to expose error code and mirror RFF format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './period-calculation'
 export {
     getNowInCalendar,
     validateDateString,
+    DateValidationResult,
     convertFromIso8601,
     convertToIso8601,
 } from './utils'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -80,7 +80,7 @@ export const extractAndValidateDateString = (
     }
 
     const validation = validateDateString(date, options)
-    if (validation.isValid) {
+    if (!validation.error) {
         return getValidDateResult(date, options)
     } else {
         return getInvalidDateResult(options)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,9 @@ export { default as fromAnyDate } from './from-any-date'
 export { default as getNowInCalendar } from './getNowInCalendar'
 export * from './helpers'
 export { default as localisationHelpers } from './localisationHelpers'
-export { validateDateString } from './validate-date-string'
+export {
+    validateDateString,
+    DateValidationResult,
+} from './validate-date-string'
 
 export { convertFromIso8601, convertToIso8601 } from './convert-date'

--- a/src/utils/validate-date-string.spec.ts
+++ b/src/utils/validate-date-string.spec.ts
@@ -4,40 +4,40 @@ describe('validateDateString', () => {
     it('should return an error for an empty date string', () => {
         const date = ''
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe('Date is not given')
-        expect(validation.isValid).toBe(false)
+        expect(validation.validationText).toBe('Date is not given')
+        expect(validation.error).toBe(true)
     })
 
     it('should return an error for incorrect date format with missing parts', () => {
         const date = '2015-'
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date string is invalid, received "2015-"'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should return an error for incorrect date format', () => {
         const date = '2015-11-2015'
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date string is invalid, received "2015-11-2015"'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate dd-mm-yyyy is a correct date format', () => {
         const date = '07-07-2020'
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
     })
 
     it('should validate yyyy-mm-dd is a correct date format', () => {
         const date = '2020-07-07'
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
     })
 
     it('should validate min date for yyyy-mm-dd format', () => {
@@ -46,10 +46,10 @@ describe('validateDateString', () => {
         const options = { minDateString: minDate }
 
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 2015-06-27 is less than the minimum allowed date 2015-06-28.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate max date for yyyy-mm-dd format', () => {
@@ -57,10 +57,10 @@ describe('validateDateString', () => {
         const maxDate = '2018-06-28'
         const options = { maxDateString: maxDate }
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 2018-06-29 is greater than the maximum allowed date 2018-06-28.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate min date for dd-mm-yyyy format', () => {
@@ -69,10 +69,10 @@ describe('validateDateString', () => {
         const options = { minDateString: minDate }
 
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 27-06-2015 is less than the minimum allowed date 28-06-2015.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate max date for dd-mm-yyyy format', () => {
@@ -80,10 +80,10 @@ describe('validateDateString', () => {
         const maxDate = '28-06-2018'
         const options = { maxDateString: maxDate }
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 29-06-2018 is greater than the maximum allowed date 28-06-2018.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate min date for mixed formats', () => {
@@ -92,10 +92,10 @@ describe('validateDateString', () => {
 
         const options = { minDateString: minDate }
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 28-06-2018 is less than the minimum allowed date 2018-06-29.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('should validate max date for mixed formats', () => {
@@ -104,10 +104,10 @@ describe('validateDateString', () => {
 
         const options = { maxDateString: maxDate }
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 29-06-2018 is greater than the maximum allowed date 2018-06-28.'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 
     it('Should give a warning when date is less than the min date and strictValidation is set to false', () => {
@@ -116,11 +116,10 @@ describe('validateDateString', () => {
         const options = { minDateString: minDate, strictValidation: false }
 
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe('')
-        expect(validation.warningMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 27-06-2015 is less than the minimum allowed date 28-06-2015.'
         )
-        expect(validation.isValid).toBe(true)
+        expect(validation.warning).toBe(true)
     })
 
     it('Should give a warning when date is greater than the max date and strictValidation is set to false"', () => {
@@ -129,70 +128,72 @@ describe('validateDateString', () => {
         const options = { maxDateString: maxDate, strictValidation: false }
 
         const validation = validateDateString(date, options)
-        expect(validation.errorMessage).toBe('')
-        expect(validation.warningMessage).toBe(
+        expect(validation.validationText).toBe(
             'Date 27-06-2015 is greater than the maximum allowed date 26-06-2015.'
         )
-        expect(validation.isValid).toBe(true)
+        expect(validation.warning).toBe(true)
     })
 })
 
 describe('validateDateString (gregory)', () => {
     it('should return valid for a date with dashes as delimiter', () => {
         const validation = validateDateString('2024-02-02')
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return valid for a date with dashes as slashes', () => {
         const validation = validateDateString('2024/02/02')
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return valid for a date with dashes as dots', () => {
         const validation = validateDateString('2024.02.02')
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return an error message for a date with mixed delimiters', () => {
-        expect(validateDateString('2024/02.02').errorMessage).toBe(
+        expect(validateDateString('2024/02.02').validationText).toBe(
             'Date string is invalid, received "2024&#x2F;02.02"'
         )
     })
 
     it('should return an error message for a date missing year digits', () => {
-        expect(validateDateString('200.02.02').errorMessage).toBe(
+        expect(validateDateString('200.02.02').validationText).toBe(
             'Date string is invalid, received "200.02.02"'
         )
     })
 
     it('should return an error message for a date missing month digits', () => {
-        expect(validateDateString('2000.2.02').errorMessage).toBe(
+        expect(validateDateString('2000.2.02').validationText).toBe(
             'Date string is invalid, received "2000.2.02"'
         )
     })
 
     it('should return an error message for a date missing day digits', () => {
-        expect(validateDateString('2000.02.2').errorMessage).toBe(
+        expect(validateDateString('2000.02.2').validationText).toBe(
             'Date string is invalid, received "2000.02.2"'
         )
     })
 
     it('should return an error message when the value is out of range', () => {
-        expect(validateDateString('2025-12-32').errorMessage).toBe(
-            'value out of range: 1 <= 32 <= 31'
+        expect(validateDateString('2025-12-32').validationText).toBe(
+            'Invalid date in specified calendar'
         )
     })
 
     it('should return an error for non-leap year February 29', () => {
         const date = '2019-02-29'
         const validation = validateDateString(date)
-        expect(validation.errorMessage).toBe(
-            'value out of range: 1 <= 29 <= 28'
+        expect(validation.validationText).toBe(
+            'Invalid date in specified calendar'
         )
-        expect(validation.isValid).toBe(false)
+        expect(validation.error).toBe(true)
     })
 })
 
@@ -201,124 +202,130 @@ describe('validateDateString (ethiopic)', () => {
         const validation = validateDateString('2015-13-06', {
             calendar: 'ethiopic',
         })
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return valid for a date with dashes as slashes', () => {
         const validation = validateDateString('2015-13-06', {
             calendar: 'ethiopic',
         })
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return valid for a date with dashes as dots', () => {
         const validation = validateDateString('2015-13-06', {
             calendar: 'ethiopic',
         })
-        expect(validation.errorMessage).toBe('')
-        expect(validation.isValid).toBe(true)
+        expect(validation.validationText).toBeUndefined()
+        expect(validation.error).toBe(false)
+        expect(validation.warning).toBe(false)
     })
 
     it('should return an error message for a date with mixed delimiters', () => {
         expect(
             validateDateString('2015.13/06', { calendar: 'ethiopic' })
-                .errorMessage
+                .validationText
         ).toBe('Date string is invalid, received "2015.13&#x2F;06"')
     })
 
     it('should return an error message for a date missing year digits', () => {
         expect(
             validateDateString('201.13/06', { calendar: 'ethiopic' })
-                .errorMessage
+                .validationText
         ).toBe('Date string is invalid, received "201.13&#x2F;06"')
     })
 
     it('should return an error message for a date missing month digits', () => {
         expect(
             validateDateString('201.1/06', { calendar: 'ethiopic' })
-                .errorMessage
+                .validationText
         ).toBe('Date string is invalid, received "201.1&#x2F;06"')
     })
 
     it('should return an error message for a date missing day digits', () => {
         expect(
             validateDateString('2015.13/6', { calendar: 'ethiopic' })
-                .errorMessage
+                .validationText
         ).toBe('Date string is invalid, received "2015.13&#x2F;6"')
     })
 
     it('should return an error message when the value is out of range', () => {
         expect(
             validateDateString('2015-14-01', { calendar: 'ethiopic' })
-                .errorMessage
-        ).toBe('value out of range: 1 <= 14 <= 13')
+                .validationText
+        ).toBe('Invalid date in specified calendar')
     })
 })
 
 describe('validateDateString (nepali)', () => {
     it('should return valid for a date with dashes as delimiter', () => {
         expect(
-            validateDateString('2080-10-29', { calendar: 'nepali' }).isValid
-        ).toBe(true)
+            validateDateString('2080-10-29', { calendar: 'nepali' }).error
+        ).toBe(false)
     })
 
     it('should return valid for a date with dashes as slashes', () => {
         expect(
-            validateDateString('2080/10/29', { calendar: 'nepali' }).isValid
-        ).toBe(true)
+            validateDateString('2080/10/29', { calendar: 'nepali' }).error
+        ).toBe(false)
     })
 
     it('should return valid for a date with dashes as dots', () => {
         expect(
-            validateDateString('2080.10.29', { calendar: 'nepali' }).isValid
-        ).toBe(true)
+            validateDateString('2080.10.29', { calendar: 'nepali' }).error
+        ).toBe(false)
     })
 
     it('should return an error message for a date with mixed delimiters', () => {
         expect(
             validateDateString('2080.10/29', { calendar: 'nepali' })
-                .errorMessage
+                .validationText
         ).toBe('Date string is invalid, received "2080.10&#x2F;29"')
     })
 
     it('should return an error message for a date missing year digits', () => {
         expect(
-            validateDateString('280.10.29', { calendar: 'nepali' }).errorMessage
+            validateDateString('280.10.29', { calendar: 'nepali' })
+                .validationText
         ).toBe('Date string is invalid, received "280.10.29"')
     })
 
     it('should return an error message for a date missing month digits', () => {
         expect(
-            validateDateString('2080.1.29', { calendar: 'nepali' }).errorMessage
+            validateDateString('2080.1.29', { calendar: 'nepali' })
+                .validationText
         ).toBe('Date string is invalid, received "2080.1.29"')
     })
 
     it('should return an error message for a date missing day digits', () => {
         expect(
-            validateDateString('2080.10.9', { calendar: 'nepali' }).errorMessage
+            validateDateString('2080.10.9', { calendar: 'nepali' })
+                .validationText
         ).toBe('Date string is invalid, received "2080.10.9"')
     })
 
     it('should return an error message when day is out of range', () => {
         expect(
             validateDateString('2080.04.33', { calendar: 'nepali' })
-                .errorMessage
+                .validationText
         ).toBe('Day 33 is out of range | 1 <= 33 <= 32.')
     })
 
     it('should return an error message when month is out of range', () => {
         expect(
             validateDateString('2080.13.33', { calendar: 'nepali' })
-                .errorMessage
+                .validationText
         ).toBe('Month 13 is out of range | 1 <= 13 <= 12.')
     })
 
     it('should return an error message when year is out of supported range', () => {
         expect(
             validateDateString('2101.04.33', { calendar: 'nepali' })
-                .errorMessage
+                .validationText
         ).toBe('Year 2101 is out of range.')
     })
 })

--- a/src/utils/validate-date-string.ts
+++ b/src/utils/validate-date-string.ts
@@ -6,19 +6,27 @@ import type { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
 import { getCustomCalendarIfExists } from './helpers'
 
-function validateNepaliDate(year: number, month: number, day: number) {
+type ValidateNepaliDateFn = (
+    year: number,
+    month: number,
+    day: number
+) => ValidationResult
+
+const validateNepaliDate: ValidateNepaliDateFn = (year, month, day) => {
     const nepaliYearData = NEPALI_CALENDAR_DATA[year]
     if (!nepaliYearData) {
         return {
-            isValid: false,
-            errorMessage: i18n.t(`Year {{year}} is out of range.`, { year }),
+            error: true,
+            validationCode: DateValidationResult.INVALID_DATE_IN_CALENDAR,
+            validationText: i18n.t(`Year {{year}} is out of range.`, { year }),
         }
     }
 
     if (month < 1 || month > 12) {
         return {
-            isValid: false,
-            errorMessage: i18n.t(
+            error: true,
+            validationCode: DateValidationResult.INVALID_DATE_IN_CALENDAR,
+            validationText: i18n.t(
                 `Month {{month}} is out of range | 1 <= {{month}} <= 12.`,
                 { month }
             ),
@@ -29,8 +37,9 @@ function validateNepaliDate(year: number, month: number, day: number) {
 
     if (day < 1 || day > daysInMonth) {
         return {
-            isValid: false,
-            errorMessage: i18n.t(
+            error: true,
+            validationCode: DateValidationResult.INVALID_DATE_IN_CALENDAR,
+            validationText: i18n.t(
                 `Day {{day}} is out of range | 1 <= {{day}} <= {{daysInMonth}}.`,
                 { day, daysInMonth }
             ),
@@ -38,122 +47,163 @@ function validateNepaliDate(year: number, month: number, day: number) {
     }
 
     return {
-        isValid: true,
-        errorMessage: '',
+        error: false,
+        warning: false,
     }
 }
 
-export function validateDateString(
+type ValidationOptions = {
+    calendar?: SupportedCalendar
+    minDateString?: string
+    maxDateString?: string
+    strictValidation?: boolean
+    format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'
+}
+
+export enum DateValidationResult {
+    INVALID_DATE_IN_CALENDAR = 'INVALID_DATE_IN_CALENDAR',
+    WRONG_FORMAT = 'WRONG_FORMAT',
+    LESS_THAN_MIN = 'LESS_THAN_MIN',
+    MORE_THAN_MAX = 'INVALID_DATE_MORE_THAN_MAX',
+}
+
+type ValidationResult =
+    | {
+          error: boolean
+          warning?: never
+          validationText: string
+          validationCode: DateValidationResult
+      }
+    | {
+          warning: boolean
+          error?: never
+          validationText: string
+          validationCode: DateValidationResult
+      }
+    | {
+          error: false
+          warning: false
+          validationText: undefined
+          validationCode: undefined
+      }
+
+type ValidateDateStringFn = (
     dateString: string,
-    {
+    options?: ValidationOptions
+) => ValidationResult
+
+export const validateDateString: ValidateDateStringFn = (
+    dateString,
+    options = {}
+) => {
+    const {
         calendar = 'gregory',
         minDateString,
         maxDateString,
         strictValidation = true,
         format,
-    }: {
-        calendar?: SupportedCalendar
-        minDateString?: string
-        maxDateString?: string
-        strictValidation?: boolean
-        format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'
-    } = {}
-): {
-    isValid: boolean
-    errorMessage?: string
-    warningMessage?: string
-    year?: number
-    month?: number
-    day?: number
-} {
+    } = options
     const resolvedCalendar = getCustomCalendarIfExists(
         dhis2CalendarsMap[calendar] ?? calendar
     )
 
+    const validationType = strictValidation
+        ? { error: true }
+        : { warning: true }
+
+    // Will throw if the format of the date is incorrect
+    if (!dateString) {
+        return {
+            error: true,
+            validationCode: DateValidationResult.WRONG_FORMAT,
+            validationText: i18n.t(`Date is not given`),
+        }
+    }
+
+    let dateParts: {
+        year: number
+        month: number
+        day: number
+        format: string
+    }
+
     try {
-        // Will throw if the format of the date is incorrect
-        if (!dateString) {
-            throw new Error(i18n.t(`Date is not given`))
+        dateParts = extractDatePartsFromDateString(dateString, format)
+    } catch (e: any) {
+        return {
+            error: true,
+            validationCode: DateValidationResult.WRONG_FORMAT,
+            validationText: e?.message,
         }
-        const dateParts = extractDatePartsFromDateString(dateString, format)
+    }
+    if (resolvedCalendar.toString() === 'nepali') {
+        // ToDo: double check why nepali can't just be handle with Temporal.PlainDate.from
+        return validateNepaliDate(
+            dateParts.year,
+            dateParts.month,
+            dateParts.day
+        )
+    }
 
-        if (resolvedCalendar.toString() === 'nepali') {
-            const { isValid, errorMessage } = validateNepaliDate(
-                dateParts.year,
-                dateParts.month,
-                dateParts.day
-            )
+    let date: Temporal.PlainDate
 
-            if (!isValid) {
-                throw new Error(errorMessage)
-            }
-        }
-
-        // Will throw if the year, month or day is out of range
-        const date = Temporal.PlainDate.from(
+    // Will throw if the year, month or day is out of range
+    try {
+        date = Temporal.PlainDate.from(
             { ...dateParts, calendar: resolvedCalendar },
             { overflow: 'reject' }
         )
-
-        let warningMessage = ''
-
-        if (minDateString) {
-            const minDateParts = extractDatePartsFromDateString(minDateString)
-            const minDate = Temporal.PlainDate.from({
-                ...minDateParts,
-                calendar: resolvedCalendar,
-            })
-
-            if (Temporal.PlainDate.compare(date, minDate) < 0) {
-                if (strictValidation) {
-                    throw new Error(
-                        i18n.t(
-                            `Date {{dateString}} is less than the minimum allowed date {{minDateString}}.`,
-                            { dateString, minDateString }
-                        )
-                    )
-                } else {
-                    warningMessage = i18n.t(
-                        `Date {{dateString}} is less than the minimum allowed date {{minDateString}}.`,
-                        { dateString, minDateString }
-                    )
-                }
-            }
-        }
-
-        if (maxDateString) {
-            const maxDateParts = extractDatePartsFromDateString(maxDateString)
-            const maxDate = Temporal.PlainDate.from({
-                ...maxDateParts,
-                calendar: resolvedCalendar,
-            })
-
-            if (Temporal.PlainDate.compare(date, maxDate) > 0) {
-                if (strictValidation) {
-                    throw new Error(
-                        i18n.t(
-                            `Date {{dateString}} is greater than the maximum allowed date {{maxDateString}}.`,
-                            { dateString, maxDateString }
-                        )
-                    )
-                } else {
-                    warningMessage = i18n.t(
-                        `Date {{dateString}} is greater than the maximum allowed date {{maxDateString}}.`,
-                        { dateString, maxDateString }
-                    )
-                }
-            }
-        }
+    } catch (err) {
         return {
-            isValid: true,
-            errorMessage: '',
-            warningMessage,
+            error: true,
+            validationCode: DateValidationResult.INVALID_DATE_IN_CALENDAR,
+            validationText: i18n.t('Invalid date in specified calendar'),
         }
-    } catch (e) {
-        return {
-            isValid: false,
-            errorMessage: (e as Error).message,
-            warningMessage: '',
+    }
+
+    if (minDateString) {
+        const minDateParts = extractDatePartsFromDateString(minDateString)
+        const minDate = Temporal.PlainDate.from({
+            ...minDateParts,
+            calendar: resolvedCalendar,
+        })
+
+        if (Temporal.PlainDate.compare(date, minDate) < 0) {
+            const result: ValidationResult = {
+                ...validationType,
+                validationCode: DateValidationResult.LESS_THAN_MIN,
+                validationText: i18n.t(
+                    `Date {{dateString}} is less than the minimum allowed date {{minDateString}}.`,
+                    { dateString, minDateString }
+                ),
+            }
+
+            return result
         }
+    }
+
+    if (maxDateString) {
+        const maxDateParts = extractDatePartsFromDateString(maxDateString)
+        const maxDate = Temporal.PlainDate.from({
+            ...maxDateParts,
+            calendar: resolvedCalendar,
+        })
+
+        if (Temporal.PlainDate.compare(date, maxDate) > 0) {
+            const result: ValidationResult = {
+                ...validationType,
+                validationCode: DateValidationResult.MORE_THAN_MAX,
+                validationText: i18n.t(
+                    `Date {{dateString}} is greater than the maximum allowed date {{maxDateString}}.`,
+                    { dateString, maxDateString }
+                ),
+            }
+
+            return result
+        }
+    }
+    return {
+        error: false,
+        warning: false,
     }
 }


### PR DESCRIPTION
I started this PR to add the error codes to the validation message, but ended up also doing some refactoring mainly to make the object format similar to what React Final Form expects, so that it can be used directly by consumer to set the properties and avoid mapping logic like [this](https://github.com/dhis2/ui/pull/1616/files#diff-120e399d5d9961536cb3140222cf6169242c148f66e446003944462695d797a3R173-R177).

I also exposed an enum of ValidationResults that consumers can use to check the expected error codes, and show a custom message for example.