### PR TITLE
fix(useDatePicker): fix onDateSelect type, export types

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,2 @@
 export { useResolvedDirection } from './useResolvedDirection'
-export { useDatePicker } from './useDatePicker'
+export { useDatePicker, DatePickerOptions, OnDateSelectPayload } from './useDatePicker'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,6 @@
 export { useResolvedDirection } from './useResolvedDirection'
-export { useDatePicker, DatePickerOptions, OnDateSelectPayload } from './useDatePicker'
+export {
+    useDatePicker,
+    DatePickerOptions,
+    OnDateSelectPayload,
+} from './useDatePicker'

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -17,14 +17,15 @@ import {
 import { useResolvedLocaleOptions } from './internal/useResolvedLocaleOptions'
 import { useWeekDayLabels } from './internal/useWeekDayLabels'
 
-type DatePickerOptions = {
+export type OnDateSelectPayload = {
+    calendarDate: Temporal.ZonedDateTime
+    calendarDateString: string
+} | null
+
+export type DatePickerOptions = {
     date: string
     options: PickerOptions
-    onDateSelect: ({
-        calendarDateString,
-    }: {
-        calendarDateString: string
-    }) => void
+    onDateSelect: (payload: OnDateSelectPayload) => void
     minDate?: string
     maxDate?: string
     format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -18,7 +18,6 @@ import { useResolvedLocaleOptions } from './internal/useResolvedLocaleOptions'
 import { useWeekDayLabels } from './internal/useWeekDayLabels'
 
 export type OnDateSelectPayload = {
-    calendarDate: Temporal.ZonedDateTime
     calendarDateString: string
 } | null
 


### PR DESCRIPTION
Trying to  destructure the object in `onDateSelect` causes a runtime error, because it can be null (and is `null` when using `clear`-button in UI, that consumes this hook. I've updated the parameter type of `onDateSelect` to include null. However I also noticed that the hooks actually just calls it with 

```typescript
   onDateSelect({
                calendarDateString: formatDate(zdt, undefined, date.format),
            })
```
, excluding the `calendarDate`. Should we update the type for the calendar to be optional, or the runtime code here? 


I've also exported the types, as it's convenient for consumers to be able to import types callback and options. Previously you would need to do something like `type UseDatePickerOptions = Parameters<typeof useDatePicker>[0]`

Note that the UI needs to update to the new version to get this propagated to UI-types, but it shouldn't require code changes in UI. 