### PR TITLE
fix: export-type

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,3 @@
 export { useResolvedDirection } from './useResolvedDirection'
-export {
-    useDatePicker,
-    DatePickerOptions,
-    OnDateSelectPayload,
-} from './useDatePicker'
+export { useDatePicker } from './useDatePicker'
+export type { DatePickerOptions, OnDateSelectPayload } from './useDatePicker'


### PR DESCRIPTION
I thought the compiler was smart enough to omit the exports that were 'types', but this broke the lib, because the types doesn't exist at runtime. So we use `export type` to fix this. 