### PR TITLE
fix: [DHIS2-21475] avoid Chrome 148 iso8601 month label bug

### DIFF
--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
@@ -121,6 +121,74 @@ describe('Gregorian Calendar fixed period calculation', () => {
     })
 
     describe('all monthly periods', () => {
+        describe.each([
+            ['gregory' as SupportedCalendar],
+            ['iso8601' as SupportedCalendar],
+        ])('calendar: %s', (calendar) => {
+            it.each(['en', 'en-US'])(
+                'should generate 2026 month labels for locale %s',
+                (locale) => {
+                    const monthly = generateFixedPeriods({
+                        periodType: 'MONTHLY',
+                        year: 2026,
+                        calendar,
+                        locale,
+                    }).map((period) => period.name)
+                    const bimonthly = generateFixedPeriods({
+                        periodType: 'BIMONTHLY',
+                        year: 2026,
+                        calendar,
+                        locale,
+                    }).map((period) => period.name)
+                    const quarterly = generateFixedPeriods({
+                        periodType: 'QUARTERLY',
+                        year: 2026,
+                        calendar,
+                        locale,
+                    }).map((period) => period.name)
+                    const sixmonthly = generateFixedPeriods({
+                        periodType: 'SIXMONTHLY',
+                        year: 2026,
+                        calendar,
+                        locale,
+                    }).map((period) => period.name)
+
+                    expect(monthly).toEqual([
+                        'January 2026',
+                        'February 2026',
+                        'March 2026',
+                        'April 2026',
+                        'May 2026',
+                        'June 2026',
+                        'July 2026',
+                        'August 2026',
+                        'September 2026',
+                        'October 2026',
+                        'November 2026',
+                        'December 2026',
+                    ])
+                    expect(bimonthly).toEqual([
+                        'January - February 2026',
+                        'March - April 2026',
+                        'May - June 2026',
+                        'July - August 2026',
+                        'September - October 2026',
+                        'November - December 2026',
+                    ])
+                    expect(quarterly).toEqual([
+                        'January - March 2026',
+                        'April - June 2026',
+                        'July - September 2026',
+                        'October - December 2026',
+                    ])
+                    expect(sixmonthly).toEqual([
+                        'January - June 2026',
+                        'July - December 2026',
+                    ])
+                }
+            )
+        })
+
         describe('periodType: MONTHLY', () => {
             it('should omit every period on/after the exclude date', () => {
                 const results = generateFixedPeriods({

--- a/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
+++ b/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
@@ -147,6 +147,10 @@ const buildLabel: BuildLabelFunc = (options) => {
         return buildLabelForCustomCalendar(options)
     }
 
+    if (calendar === 'gregory' || calendar === 'iso8601') {
+        return buildLabelForGregorianCalendar(options)
+    }
+
     const withYearFormat = {
         month: 'long' as const,
         year: 'numeric' as const,
@@ -173,6 +177,49 @@ const buildLabel: BuildLabelFunc = (options) => {
     // needed for ethiopic calendar - the default formatter adds the era, which is not what we want in DHIS2
     result = result.replace(/ERA\d+\s*/g, '').trim()
     return result
+}
+
+const buildLabelForGregorianCalendar: BuildLabelFunc = ({
+    periodType,
+    month,
+    nextMonth,
+    locale,
+}) => {
+    if (multiMonthFixedPeriodTypes.includes(periodType)) {
+        const format = month.year === nextMonth.year ? 'month' : 'monthYear'
+        return `${localiseGregorianMonth(
+            month,
+            locale,
+            format
+        )} - ${localiseGregorianMonth(nextMonth, locale, 'monthYear')}`
+    }
+
+    return localiseGregorianMonth(month, locale, 'monthYear')
+}
+
+const localiseGregorianMonth = (
+    month: Temporal.PlainDate,
+    locale: string,
+    format: 'month' | 'monthYear'
+) => {
+    const gregorianCalendar = 'gregory' as SupportedCalendar
+    const gregorianMonth = Temporal.PlainDate.from({
+        year: month.year,
+        month: month.month,
+        day: 1,
+        calendar: gregorianCalendar,
+    })
+    const monthName = localisationHelpers.localiseMonth(
+        gregorianMonth,
+        { locale, calendar: gregorianCalendar },
+        { month: 'long' }
+    )
+
+    if (!monthName) {
+        throw new Error(`could not localise month ${month.month}`)
+    }
+
+    return format === 'month' ? monthName : `${monthName} ${month.year}`
 }
 
 const buildLabelForCustomCalendar: BuildLabelFunc = ({


### PR DESCRIPTION
## Summary
Fixes Chrome 148-specific month-label rendering in `generateFixedPeriods` for Gregorian monthly period labels by bypassing Temporal/polyfill month-year formatting for `gregory` and `iso8601` calendars.

Observed in Chrome 148.0.7778.97 against `play.im.dhis2.org/stable-2-43-0`: the Aggregate Data Entry period selector received FixedPeriod `name`/`displayName` values such as `2026` instead of `January 2026`, before React rendered the dropdown. The live instance system info reports `calendar: "iso8601"`.

The broken platform permutation is native Chrome 148:

```js
new Intl.DateTimeFormat(locale, {
    calendar: 'iso8601',
    month: 'long',
    year: 'numeric',
}).format(new Date(...))
```

For `en`/`en-US`, that returns `"2026 "`; month-only formatting with `calendar: 'iso8601'` returns `""`. The same options with `calendar: 'gregory'` or no calendar return the expected month names.

Fix strategy: keep custom-calendar handling unchanged, preserve the existing Ethiopic/non-Gregorian branch including ERA suffix stripping, and add a Gregorian-only (`gregory`/production `iso8601`) label builder that localizes month names through an explicit Gregorian date/month formatter and appends the year from the period date.

Regression coverage added in `src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts` for 2026 MONTHLY, BIMONTHLY, QUARTERLY, and SIXMONTHLY labels for locales `en` and `en-US`, including the production `iso8601` calendar path.

Verified fix-preview deployment in Chrome 148.0.7778.97:

https://play.im.dhis2.org/stable-2-43-0/api/apps/aggregate-data-entry-fix-preview/

<img width="1600" height="1000" alt="fix-preview-period-dropdown-chrome148" src="https://github.com/user-attachments/assets/54a7a1a6-f4ea-45e8-88dc-3cbe20a1f273" />


## Review & Testing Checklist for Human
- [ ] Review the Gregorian/iso8601 label-builder path and confirm it should apply only to `gregory` and `iso8601`, leaving Ethiopic and other native calendars on the existing formatter branch.
- [ ] Confirm the added regression expectations match DHIS2 period-label conventions for MONTHLY/BIMONTHLY/QUARTERLY/SIXMONTHLY.
- [ ] If possible, deploy the built package into Aggregate Data Entry and verify the period dropdown on Chrome 148 still shows `January 2026` through `December 2026`.

### Notes
Local verification run:

```sh
CI=true yarn test src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts --runInBand --watchAll=false
yarn lint
yarn build:types
yarn build
```

`yarn lint` passes with existing warnings in unrelated files.