### PR TITLE
fix: upgrade to polyfill 0.5.1 (wip)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-08-27T05:56:11.774Z\n"
-"PO-Revision-Date: 2024-08-27T05:56:11.774Z\n"
+"POT-Creation-Date: 2026-05-12T16:04:16.214Z\n"
+"PO-Revision-Date: 2026-05-12T16:04:16.215Z\n"
 
 msgid "Couldn't find a monthly period for weekly period id \"{{periodId}}\""
 msgstr "Couldn't find a monthly period for weekly period id \"{{periodId}}\""
@@ -45,17 +45,11 @@ msgstr ""
 msgid "Unrecognized date, received \"{{date}}\""
 msgstr "Unrecognized date, received \"{{date}}\""
 
-msgid "Year {{year}} is out of range."
-msgstr "Year {{year}} is out of range."
-
-msgid "Month {{month}} is out of range | 1 <= {{month}} <= 12."
-msgstr "Month {{month}} is out of range | 1 <= {{month}} <= 12."
-
-msgid "Day {{day}} is out of range | 1 <= {{day}} <= {{daysInMonth}}."
-msgstr "Day {{day}} is out of range | 1 <= {{day}} <= {{daysInMonth}}."
-
 msgid "Date is not given"
 msgstr "Date is not given"
+
+msgid "Invalid date in specified calendar"
+msgstr "Invalid date in specified calendar"
 
 msgid "Date {{dateString}} is less than the minimum allowed date {{minDateString}}."
 msgstr "Date {{dateString}} is less than the minimum allowed date {{minDateString}}."

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     },
     "dependencies": {
         "@dhis2/d2-i18n": "^1.1.3",
-        "@js-temporal/polyfill": "0.4.3",
+        "@js-temporal/polyfill": "0.5.1",
         "classnames": "^2.3.2"
     },
     "peerDependencies": {

--- a/src/custom-calendars/calendar-routing.ts
+++ b/src/custom-calendars/calendar-routing.ts
@@ -1,0 +1,215 @@
+import { Temporal } from '@js-temporal/polyfill'
+import { NepaliPlainDate, NepaliZonedDateTime } from './nepaliCalendar'
+
+// Calendar-agnostic shapes the rest of the library can hold and read from.
+// `NepaliPlainDate` / `NepaliZonedDateTime` mirror the same API surface as
+// their Temporal counterparts for everything this library actually consumes
+// (year/month/day getters, `with`, `add`, `subtract`, `equals`, `toString`,
+// etc.) so most call sites can stay duck-typed.
+export type CalendarPlainDate = Temporal.PlainDate | NepaliPlainDate
+export type CalendarZonedDateTime = Temporal.ZonedDateTime | NepaliZonedDateTime
+
+export const isNepaliCalendar = (
+    calendar: string | undefined | null
+): boolean => calendar === 'nepali'
+
+export const isNepaliPlainDate = (value: unknown): value is NepaliPlainDate =>
+    value instanceof NepaliPlainDate
+
+export const isNepaliZonedDateTime = (
+    value: unknown
+): value is NepaliZonedDateTime => value instanceof NepaliZonedDateTime
+
+type PlainDateFields = {
+    year?: number
+    month?: number
+    monthCode?: string
+    day: number
+    era?: string
+    eraYear?: number
+}
+
+/**
+ * Build a `Temporal.PlainDate` (or `NepaliPlainDate` if `calendar` is
+ * `'nepali'`) from a fields object or ISO-style date string. Routes around
+ * the fact that 0.5.x's `Temporal.PlainDate.from` only accepts built-in
+ * calendar identifiers.
+ */
+export const plainDateFrom = (
+    input: PlainDateFields | string,
+    calendar?: string,
+    options?: Temporal.AssignmentOptions
+): CalendarPlainDate => {
+    if (isNepaliCalendar(calendar)) {
+        if (typeof input === 'string') {
+            return NepaliPlainDate.from(input, options)
+        }
+        const { year, month, monthCode, day } = input
+        const resolvedMonth =
+            month ??
+            (monthCode ? Number(monthCode.replace(/^M/, '')) : undefined)
+        if (year === undefined || resolvedMonth === undefined) {
+            throw new Error(
+                'NepaliPlainDate requires year + month (or monthCode) + day'
+            )
+        }
+        return NepaliPlainDate.fromNepaliFields(
+            { year, month: resolvedMonth, day },
+            options
+        )
+    }
+
+    if (typeof input === 'string') {
+        const date = Temporal.PlainDate.from(input, options)
+        if (calendar && calendar !== 'iso8601') {
+            return date.withCalendar(calendar)
+        }
+        return date
+    }
+    return Temporal.PlainDate.from(
+        {
+            ...input,
+            ...(calendar ? { calendar } : {}),
+        } as Temporal.PlainDateLike,
+        options
+    )
+}
+
+/**
+ * Returns a date in the requested calendar, given any source date.
+ */
+export const withCalendar = (
+    source: CalendarPlainDate | Temporal.PlainDateLike | string,
+    calendar: string
+): CalendarPlainDate => {
+    if (isNepaliCalendar(calendar)) {
+        if (isNepaliPlainDate(source)) {
+            return source
+        }
+        if (source instanceof Temporal.PlainDate) {
+            return NepaliPlainDate.fromIso(source)
+        }
+        if (typeof source === 'string') {
+            const iso = Temporal.PlainDate.from(source)
+            return NepaliPlainDate.fromIso(iso)
+        }
+        // Plain object source — assume iso8601 fields
+        const obj = source as Temporal.PlainDateLike
+        return NepaliPlainDate.fromIso(
+            Temporal.PlainDate.from({
+                year: obj.year as number,
+                month: obj.month as number,
+                day: obj.day as number,
+            })
+        )
+    }
+
+    if (isNepaliPlainDate(source)) {
+        return source.withCalendar(calendar) as Temporal.PlainDate
+    }
+    if (source instanceof Temporal.PlainDate) {
+        return source.withCalendar(calendar)
+    }
+    if (typeof source === 'string') {
+        return Temporal.PlainDate.from(source).withCalendar(calendar)
+    }
+    return Temporal.PlainDate.from(source).withCalendar(calendar)
+}
+
+type ZdtFields = {
+    year?: number
+    month?: number
+    monthCode?: string
+    day: number
+    hour?: number
+    minute?: number
+    second?: number
+    era?: string
+    eraYear?: number
+}
+
+export const zonedDateTimeFrom = (
+    input: ZdtFields | CalendarZonedDateTime,
+    calendar: string,
+    timeZone: string
+): CalendarZonedDateTime => {
+    if (isNepaliCalendar(calendar)) {
+        if (isNepaliZonedDateTime(input)) {
+            return input
+        }
+        const fields = input as ZdtFields
+        const month =
+            fields.month ??
+            (fields.monthCode
+                ? Number(fields.monthCode.replace(/^M/, ''))
+                : undefined)
+        if (fields.year === undefined || month === undefined) {
+            throw new Error(
+                'NepaliZonedDateTime requires year + month (or monthCode) + day'
+            )
+        }
+        return NepaliZonedDateTime.fromNepaliFields({
+            year: fields.year,
+            month,
+            day: fields.day,
+            hour: fields.hour,
+            minute: fields.minute,
+            second: fields.second,
+            timeZone,
+        })
+    }
+
+    if (isNepaliZonedDateTime(input)) {
+        // converting from Nepali → built-in calendar
+        return input.withCalendar(calendar) as Temporal.ZonedDateTime
+    }
+    if (input instanceof Temporal.ZonedDateTime) {
+        return input.withCalendar(calendar as Temporal.CalendarLike)
+    }
+    const fields = { ...(input as ZdtFields) } as Record<string, unknown>
+    // Drop keys whose value is `undefined` so the polyfill doesn't see them
+    // as set (e.g. `year: undefined` collides with `era`/`eraYear`).
+    Object.keys(fields).forEach((key) => {
+        if (fields[key] === undefined) {
+            delete fields[key]
+        }
+    })
+    return Temporal.ZonedDateTime.from({
+        ...fields,
+        calendar,
+        timeZone,
+    } as Temporal.ZonedDateTimeLike)
+}
+
+/**
+ * Convert a built-in-calendar ZonedDateTime → Nepali (or no-op if already
+ * Nepali / non-Nepali target).
+ */
+export const zonedDateTimeWithCalendar = (
+    source: CalendarZonedDateTime,
+    calendar: string
+): CalendarZonedDateTime => {
+    if (isNepaliCalendar(calendar)) {
+        if (isNepaliZonedDateTime(source)) {
+            return source
+        }
+        return NepaliZonedDateTime.fromIso(source)
+    }
+    if (isNepaliZonedDateTime(source)) {
+        return source.withCalendar(calendar) as Temporal.ZonedDateTime
+    }
+    return source.withCalendar(calendar as Temporal.CalendarLike)
+}
+
+export const comparePlainDates = (
+    a: CalendarPlainDate,
+    b: CalendarPlainDate
+): -1 | 0 | 1 => {
+    const aIso = isNepaliPlainDate(a) ? a.toIso() : a
+    const bIso = isNepaliPlainDate(b) ? b.toIso() : b
+    return Temporal.PlainDate.compare(aIso, bIso)
+}
+
+/** True when the value behaves like a `Temporal.PlainDate` (real or shadow). */
+export const isPlainDateLike = (value: unknown): value is CalendarPlainDate =>
+    value instanceof Temporal.PlainDate || isNepaliPlainDate(value)

--- a/src/custom-calendars/index.ts
+++ b/src/custom-calendars/index.ts
@@ -1,7 +1,5 @@
-import { Temporal } from '@js-temporal/polyfill'
 import { SupportedCalendar } from '../types'
 import calendarLocalisations from './calendarLocalisations'
-import { NepaliCalendar } from './nepaliCalendar'
 
 export type CustomCalendarTypes = 'nepali'
 
@@ -16,14 +14,34 @@ export type CalendarCustomLocale = {
 
 export const customCalendars: Partial<{
     [key in SupportedCalendar]: {
-        calendar: Temporal.CalendarProtocol
         locales: Record<string, CalendarCustomLocale>
         defaultLocale: string
     }
 }> = {
     nepali: {
-        calendar: new NepaliCalendar(),
         locales: calendarLocalisations.nepali,
         defaultLocale: 'en-NP',
     },
 }
+
+export {
+    NepaliPlainDate,
+    NepaliPlainYearMonth,
+    NepaliZonedDateTime,
+} from './nepaliCalendar'
+
+export {
+    isNepaliCalendar,
+    isNepaliPlainDate,
+    isNepaliZonedDateTime,
+    isPlainDateLike,
+    plainDateFrom,
+    withCalendar,
+    zonedDateTimeFrom,
+    zonedDateTimeWithCalendar,
+    comparePlainDates,
+} from './calendar-routing'
+export type {
+    CalendarPlainDate,
+    CalendarZonedDateTime,
+} from './calendar-routing'

--- a/src/custom-calendars/nepaliCalendar.spec.ts
+++ b/src/custom-calendars/nepaliCalendar.spec.ts
@@ -1,20 +1,15 @@
 import { Temporal } from '@js-temporal/polyfill'
-import { NepaliCalendar } from './nepaliCalendar'
-
-const calendar = new NepaliCalendar()
+import { NepaliPlainDate } from './nepaliCalendar'
 
 describe('from nepali to gregorian', () => {
     it('should convert from nepali calendar to gregorian', () => {
-        const nepaliDate = {
+        const result = NepaliPlainDate.fromNepaliFields({
             year: 2079,
             month: 7,
             day: 1,
-        } // 1st of Kartik 2079 is 18th of October 2022
-
-        const result =
-            Temporal.Calendar.from(calendar).dateFromFields(nepaliDate)
+        }) // 1st of Kartik 2079 is 18th of October 2022
         expect(result.toString()).toEqual('2022-10-18[u-ca=nepali]')
-        expect(result.calendar.id).toEqual('nepali')
+        expect(result.calendarId).toEqual('nepali')
     })
 
     it('should convert from nepali calendar to gregorian for the last n years', () => {
@@ -23,21 +18,18 @@ describe('from nepali to gregorian', () => {
         const nepaliStartYear = 2100
 
         for (let i = 0; i < 100; i++) {
-            const nepaliDate = {
+            const date = NepaliPlainDate.fromNepaliFields({
                 year: nepaliStartYear - i,
                 month: 7,
                 day: 1,
-            }
-
-            const date =
-                Temporal.Calendar.from(calendar).dateFromFields(nepaliDate)
+            })
             expect(date.toString()).toMatch(`${gregorianStartYear - i}-10-`)
         }
     })
 
     it('should throw an error if nepali year is out of range of supported dates', () => {
         expect(() =>
-            Temporal.Calendar.from(calendar).dateFromFields({
+            NepaliPlainDate.fromNepaliFields({
                 year: 1969,
                 month: 7,
                 day: 1,
@@ -46,7 +38,7 @@ describe('from nepali to gregorian', () => {
             'Conversions are only possible between 1970 and 2100 in Nepali calendar'
         )
         expect(() =>
-            Temporal.Calendar.from(calendar).dateFromFields({
+            NepaliPlainDate.fromNepaliFields({
                 year: 2101,
                 month: 7,
                 day: 1,
@@ -56,23 +48,22 @@ describe('from nepali to gregorian', () => {
         )
     })
 
-    it('should convert a year/month from nepali calendar to gregorian', () => {
-        const nepaliDate = {
+    it('should expose year and month for a year/month pair', () => {
+        const result = NepaliPlainDate.fromNepaliFields({
             year: 2079,
             month: 7,
-            calendar,
-        }
-
-        const result = Temporal.PlainYearMonth.from(nepaliDate)
+            day: 1,
+        }).toPlainYearMonth()
         expect(result.year).toEqual(2079)
         expect(result.month).toEqual(7)
     })
 })
 
-describe('from greogorian to nepali', () => {
+describe('from gregorian to nepali', () => {
     it('should convert from gregorian calendar to nepali', () => {
-        const nepaliDate =
-            Temporal.PlainDate.from('2022-10-18').withCalendar(calendar)
+        const nepaliDate = NepaliPlainDate.fromIso(
+            Temporal.PlainDate.from('2022-10-18')
+        )
 
         expect(nepaliDate.year).toEqual(2079)
         expect(nepaliDate.eraYear).toEqual(2079)
@@ -85,17 +76,16 @@ describe('from greogorian to nepali', () => {
         const nepaliStartYear = 2100
 
         for (let i = 0; i < 100; i++) {
-            const nepaliDate = Temporal.PlainDate.from(
-                `${gregorianStartYear - i}-10-18`
-            ).withCalendar(calendar)
-
+            const nepaliDate = NepaliPlainDate.fromIso(
+                Temporal.PlainDate.from(`${gregorianStartYear - i}-10-18`)
+            )
             expect(nepaliDate.year).toEqual(nepaliStartYear - i)
         }
     })
 
     it('should throw an error if nepali year is out of range of supported dates', () => {
         expect(() => {
-            Temporal.PlainDate.from('2044-10-18').withCalendar(calendar).year
+            NepaliPlainDate.fromIso(Temporal.PlainDate.from('2044-10-18'))
         }).toThrow(
             'Conversions are only possible between 1970 and 2100 in Nepali calendar'
         )
@@ -105,11 +95,10 @@ describe('from greogorian to nepali', () => {
 describe('nepali calendar arithmetic', () => {
     it('should get the next month correctly for all nepali years from 1971 to 2100', () => {
         for (let year = 1971; year < 2100; year++) {
-            const date = Temporal.PlainDate.from({
+            const date = NepaliPlainDate.fromNepaliFields({
                 year,
                 month: 1,
                 day: 14,
-                calendar,
             })
 
             const afterOneMonth = date.add({ months: 1 })
@@ -162,15 +151,16 @@ describe('some random conversions nepali <-> gregorian', () => {
             ad: gregorianDate,
         }: typeof RANDOM_CONVERSION_MAPS[number]) => {
             const isoResult =
-                Temporal.Calendar.from(calendar).dateFromFields(nepaliDate)
+                NepaliPlainDate.fromNepaliFields(nepaliDate).toIso()
+            expect({
+                year: isoResult.year,
+                month: isoResult.month,
+                day: isoResult.day,
+            }).toEqual(gregorianDate)
 
-            const { isoYear, isoMonth, isoDay } = isoResult.getISOFields()
-            expect({ year: isoYear, month: isoMonth, day: isoDay }).toEqual(
-                gregorianDate
+            const nepaliResult = NepaliPlainDate.fromIso(
+                Temporal.PlainDate.from(gregorianDate)
             )
-
-            const nepaliResult =
-                Temporal.PlainDate.from(gregorianDate).withCalendar(calendar)
 
             expect(nepaliResult.year).toEqual(nepaliDate.year)
             expect(nepaliResult.month).toEqual(nepaliDate.month)

--- a/src/custom-calendars/nepaliCalendar.ts
+++ b/src/custom-calendars/nepaliCalendar.ts
@@ -1,100 +1,21 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { NEPALI_CALENDAR_DATA } from './nepaliCalendarData'
-type CalendarYMD = { year: number; month: number; day: number }
 
-/**
- * https://tc39.es/proposal-temporal/docs/calendar.html
- *
- * This implementation is based on World-Calendars library by Keith Wood:
- * https://github.com/kbwood/world-calendars
- */
-class NepaliCalendar extends Temporal.Calendar {
-    constructor() {
-        super('iso8601')
-    }
+// `@js-temporal/polyfill` 0.5.x removed user-defined calendars entirely, so
+// Nepali (which is not in CLDR / the polyfill's built-in calendar list) can no
+// longer be expressed as a `Temporal.Calendar` subclass. Instead we provide
+// `NepaliPlainDate` / `NepaliZonedDateTime` shadow types that mirror the
+// subset of the `Temporal.PlainDate` / `Temporal.ZonedDateTime` API surface
+// that the rest of this library uses.
+//
+// Internally each shadow holds an iso8601-backed Temporal value and the cached
+// Nepali year/month/day, computed via the same hardcoded data table the
+// original `Temporal.Calendar` subclass used. Conversion logic
+// (`_isoToNepali` / `_nepaliToIso`) is unchanged from the 0.4.x implementation
+// and is still based on the World-Calendars library by Keith Wood.
+// https://github.com/kbwood/world-calendars
 
-    toString() {
-        return 'nepali'
-    }
-
-    /**
-     * The methods year, month, day return the Nepali date
-     *
-     * A custom implementation of these methods is used to convert the ISO calendar date to the calendar-space arguments.
-     */
-    year(date: Temporal.PlainDate | Temporal.PlainDateTime) {
-        const {
-            isoYear: year,
-            isoMonth: month,
-            isoDay: day,
-        } = date.getISOFields()
-        const nepaliYear = _isoToNepali({ year, month, day })?.year
-        return nepaliYear
-    }
-    eraYear(date: Temporal.PlainDate | Temporal.PlainDateTime) {
-        return this.year(date)
-    }
-    daysInMonth(date: Temporal.PlainDate | Temporal.PlainDateTime): number {
-        const { year, month } = date
-        return NEPALI_CALENDAR_DATA[year][month]
-    }
-    month(date: Temporal.PlainDate) {
-        const {
-            isoYear: year,
-            isoMonth: month,
-            isoDay: day,
-        } = date.getISOFields()
-        return _isoToNepali({ year, month, day })?.month
-    }
-    monthCode(date: Temporal.PlainDate) {
-        const { month } = date
-        return buildMonthCode(month)
-    }
-    day(date: Temporal.PlainDate) {
-        const {
-            isoYear: year,
-            isoMonth: month,
-            isoDay: day,
-        } = date.getISOFields()
-        const { day: nepaliDay } = _isoToNepali({ year, month, day })
-        return nepaliDay
-    }
-    /**
-     * The methods dateFromFields, yearMonthFromFields, monthDayFromFields convert from nepali to iso
-     *
-     * A custom implementation of these methods is used to convert the calendar-space arguments to the ISO calendar.
-     */
-    dateFromFields(
-        fields: CalendarYMD,
-        options: Temporal.AssignmentOptions
-    ): Temporal.PlainDate {
-        const { year, day, month } = _nepaliToIso(
-            {
-                year: fields.year,
-                month: fields.month,
-                day: fields.day,
-            },
-            options
-        )
-        return new Temporal.PlainDate(year, month, day, this)
-    }
-    yearMonthFromFields(fields: CalendarYMD): Temporal.PlainYearMonth {
-        const { year, day, month } = _nepaliToIso({
-            year: fields.year,
-            month: fields.month,
-            day: fields.day,
-        })
-        return new Temporal.PlainYearMonth(year, month, this, day)
-    }
-    monthDayFromFields(fields: CalendarYMD): Temporal.PlainMonthDay {
-        const { year, day, month } = _nepaliToIso({
-            year: fields.year,
-            month: fields.month,
-            day: fields.day,
-        })
-        return new Temporal.PlainMonthDay(day, month, this, year)
-    }
-}
+type NepaliFields = { year: number; month: number; day: number }
 
 const supportedNepaliYears = Object.keys(NEPALI_CALENDAR_DATA)
 const firstSupportedNepaliYear = Number(supportedNepaliYears[0])
@@ -102,10 +23,41 @@ const lastSupportedNepaliYear = Number(
     supportedNepaliYears[supportedNepaliYears.length - 1]
 )
 
+const padTwo = (n: number) => String(n).padStart(2, '0')
+const buildMonthCode = (month: number | string) =>
+    `M${month.toString().padStart(2, '0')}`
+
+const clampNepaliDay = (year: number, month: number, day: number) => {
+    const dim = NEPALI_CALENDAR_DATA[year][month]
+    if (day < 1) {
+        return 1
+    }
+    if (day > dim) {
+        return dim
+    }
+    return day
+}
+
+const computeDaysInNepaliYear = (year: number) => {
+    let total = 0
+    for (let m = 1; m <= 12; m++) {
+        total += NEPALI_CALENDAR_DATA[year][m]
+    }
+    return total
+}
+
+const computeDayOfYearInNepali = (year: number, month: number, day: number) => {
+    let total = day
+    for (let m = 1; m < month; m++) {
+        total += NEPALI_CALENDAR_DATA[year][m]
+    }
+    return total
+}
+
 const _nepaliToIso = (
-    fields: { day: number; year: number; month: number },
+    fields: NepaliFields,
     { overflow }: Temporal.AssignmentOptions = {}
-) => {
+): { year: number; month: number; day: number } => {
     let { year: nepaliYear } = fields
 
     if (
@@ -137,15 +89,11 @@ const _nepaliToIso = (
             ? 56
             : 57)
 
-    // First we add the amount of days in the actual Nepali month as the day of year in the
-    // Gregorian one because at least these days are gone since the 1st Jan.
     if (nepaliMonth !== 9) {
         gregorianDayOfYear = nepaliDay
         monthCounter--
     }
 
-    // Now we loop through all Nepali months and add the amount of days to gregorianDayOfYear
-    // we do this till we reach Paush (9th month). 1st January always falls in this month.
     while (monthCounter !== 9) {
         if (monthCounter <= 0) {
             monthCounter = 12
@@ -155,14 +103,8 @@ const _nepaliToIso = (
         monthCounter--
     }
 
-    // If the date that has to be converted is in Paush (month no. 9) we have to do some other calculation
     if (nepaliMonth === 9) {
-        // Add the days that are passed since the first day of Paush and substract the
-        // amount of days that lie between 1st Jan and 1st Paush
         gregorianDayOfYear += nepaliDay - NEPALI_CALENDAR_DATA[nepaliYear][0]
-        // For the first days of Paush we are now in negative values,
-        // because in the end of the Gregorian year we substract
-        // 365 / 366 days (P.S. remember math in school + - gives -)
         if (gregorianDayOfYear < 0) {
             gregorianDayOfYear += Temporal.PlainDate.from({
                 year: gregorianYear,
@@ -185,18 +127,15 @@ const _nepaliToIso = (
     return {
         year: result.year,
         month: result.month,
-        monthCode: buildMonthCode(result.month),
         day: result.day,
     }
 }
 
-const _isoToNepali = (
-    isoDate:
-        | Temporal.PlainDate
-        | Temporal.PlainDateTime
-        | Temporal.PlainDateLike
-) => {
-    // make sure this is iso8601
+const _isoToNepali = (isoDate: {
+    year: number
+    month: number
+    day: number
+}): NepaliFields => {
     const gregorianDate = Temporal.PlainDate.from({
         year: isoDate.year,
         month: isoDate.month,
@@ -204,9 +143,10 @@ const _isoToNepali = (
     })
 
     const gregorianYear = gregorianDate.year
-
     const gregorianDayOfYear = gregorianDate.dayOfYear
-    let nepaliYear = gregorianYear + 56 // this is not final, it could be also +57 but +56 is always true for 1st Jan.
+
+    // not final, could be +57 but +56 is always true for 1 Jan
+    let nepaliYear = gregorianYear + 56
 
     if (!NEPALI_CALENDAR_DATA[nepaliYear]) {
         throw new Error(
@@ -214,26 +154,12 @@ const _isoToNepali = (
         )
     }
 
-    let nepaliMonth = 9 // Jan 1 always fall in Nepali month Paush which is the 9th month of Nepali calendar.
-    // Get the Nepali day in Paush (month 9) of 1st January
-
+    // 1 Jan always falls in Paush (month 9)
+    let nepaliMonth = 9
     const dayOfFirstJanInPaush = NEPALI_CALENDAR_DATA[nepaliYear][0]
-    // Check how many days are left of Paush.
-    // Days calculated from 1st Jan till the end of the actual Nepali month,
-    // we use this value to check if the Gregorian date is in the actual Nepali month.
     let daysSinceJanFirstToEndOfNepaliMonth =
         NEPALI_CALENDAR_DATA[nepaliYear][nepaliMonth] - dayOfFirstJanInPaush + 1
 
-    // If the Gregorian day-of-year is smaller than or equal to the sum of days between the 1st January and
-    // the end of the actual Nepali month we have found the correct Nepali month.
-    // Example:
-    // The 4th February 2011 is the gregorianDayOfYear 35 (31 days of January + 4)
-    // 1st January 2011 is in the Nepali year 2067, where 1st January is the 17th day of Paush (9th month).
-    // In 2067 Paush has 30 days, which means (30-17+1=14) there are 14 days between 1st January and end of Paush
-    // (including 17th January).
-    // The gregorianDayOfYear (35) is bigger than 14, so we check the next month.
-    // The next Nepali month (Mangh) has 29 days
-    // 29+14=43, this is bigger than gregorianDayOfYear (35) so, we have found the correct Nepali month.
     while (gregorianDayOfYear > daysSinceJanFirstToEndOfNepaliMonth) {
         nepaliMonth++
         if (nepaliMonth > 12) {
@@ -248,12 +174,6 @@ const _isoToNepali = (
             `Conversions are only possible between ${firstSupportedNepaliYear} and ${lastSupportedNepaliYear} in Nepali calendar`
         )
     }
-    // The last step is to calculate the Nepali day-of-month.
-    // To continue our example from before:
-    // we calculated there are 43 days from 1st January (17 Paush) till end of Mangh (29 days).
-    // When we subtract from this 43 days the day-of-year of the the Gregorian date (35),
-    // we know how far the searched day is away from the end of the Nepali month.
-    // So we simply subtract this number from the amount of days in this month (30).
     const nepaliDayOfMonth =
         NEPALI_CALENDAR_DATA[nepaliYear][nepaliMonth] -
         (daysSinceJanFirstToEndOfNepaliMonth - gregorianDayOfYear)
@@ -265,8 +185,471 @@ const _isoToNepali = (
     }
 }
 
-function buildMonthCode(month: number | string) {
-    return `M${month.toString().padStart(2, '0')}`
+type WithFields = {
+    year?: number
+    month?: number
+    monthCode?: string
+    day?: number
 }
 
-export { NepaliCalendar }
+type Duration = {
+    years?: number
+    months?: number
+    weeks?: number
+    days?: number
+}
+
+const monthFromCode = (monthCode: string) => {
+    const m = monthCode.match(/^M(\d{2})$/)
+    if (!m) {
+        throw new Error(`Invalid Nepali monthCode "${monthCode}"`)
+    }
+    return Number(m[1])
+}
+
+/**
+ * A `Temporal.PlainDate`-compatible value living in the Nepali calendar.
+ *
+ * Year/month/day getters return Nepali values; date arithmetic respects
+ * Nepali month lengths. An iso8601-backed `Temporal.PlainDate` is cached
+ * for cheap conversion via `withCalendar('iso8601')`.
+ */
+class NepaliPlainDate {
+    readonly calendarId = 'nepali'
+    private readonly _nepali: NepaliFields
+    private readonly _iso: Temporal.PlainDate // iso8601 calendar
+
+    constructor(nepali: NepaliFields, iso: Temporal.PlainDate) {
+        this._nepali = nepali
+        this._iso = iso
+    }
+
+    static fromNepaliFields(
+        fields: NepaliFields,
+        options?: Temporal.AssignmentOptions
+    ): NepaliPlainDate {
+        if (
+            fields.year < firstSupportedNepaliYear ||
+            fields.year > lastSupportedNepaliYear
+        ) {
+            throw new Error(
+                `Conversions are only possible between ${firstSupportedNepaliYear} and ${lastSupportedNepaliYear} in Nepali calendar`
+            )
+        }
+        const overflow = options?.overflow ?? 'constrain'
+        const day =
+            overflow === 'reject'
+                ? fields.day
+                : clampNepaliDay(fields.year, fields.month, fields.day)
+        const iso = _nepaliToIso({ ...fields, day }, options)
+        const isoDate = Temporal.PlainDate.from({
+            year: iso.year,
+            month: iso.month,
+            day: iso.day,
+        })
+        return new NepaliPlainDate(
+            { year: fields.year, month: fields.month, day },
+            isoDate
+        )
+    }
+
+    static fromIso(isoDate: Temporal.PlainDate): NepaliPlainDate {
+        const iso = isoDate.withCalendar('iso8601')
+        const nepali = _isoToNepali({
+            year: iso.year,
+            month: iso.month,
+            day: iso.day,
+        })
+        return new NepaliPlainDate(nepali, iso)
+    }
+
+    static from(
+        input: NepaliPlainDate | NepaliFields | string,
+        options?: Temporal.AssignmentOptions
+    ): NepaliPlainDate {
+        if (input instanceof NepaliPlainDate) {
+            return input
+        }
+        if (typeof input === 'string') {
+            const m = input.match(/^(\d{4})-(\d{2})-(\d{2})/)
+            if (!m) {
+                throw new Error(`Invalid Nepali date string "${input}"`)
+            }
+            return NepaliPlainDate.fromNepaliFields(
+                { year: +m[1], month: +m[2], day: +m[3] },
+                options
+            )
+        }
+        return NepaliPlainDate.fromNepaliFields(input, options)
+    }
+
+    static compare(a: NepaliPlainDate, b: NepaliPlainDate): -1 | 0 | 1 {
+        return Temporal.PlainDate.compare(a._iso, b._iso)
+    }
+
+    // Iso-backed read-throughs
+    get dayOfWeek() {
+        return this._iso.dayOfWeek
+    }
+    get dayOfYear() {
+        return computeDayOfYearInNepali(
+            this._nepali.year,
+            this._nepali.month,
+            this._nepali.day
+        )
+    }
+    get daysInWeek() {
+        return 7
+    }
+    get daysInYear() {
+        return computeDaysInNepaliYear(this._nepali.year)
+    }
+    get monthsInYear() {
+        return 12
+    }
+    get inLeapYear() {
+        return false
+    }
+    get era(): string | undefined {
+        return undefined
+    }
+
+    // Nepali-space getters
+    get year() {
+        return this._nepali.year
+    }
+    get eraYear() {
+        return this._nepali.year
+    }
+    get month() {
+        return this._nepali.month
+    }
+    get monthCode() {
+        return buildMonthCode(this._nepali.month)
+    }
+    get day() {
+        return this._nepali.day
+    }
+    get daysInMonth() {
+        return NEPALI_CALENDAR_DATA[this._nepali.year][this._nepali.month]
+    }
+
+    /** Underlying iso8601 PlainDate */
+    toIso(): Temporal.PlainDate {
+        return this._iso
+    }
+
+    withCalendar(
+        calendar: string | NepaliPlainDate
+    ): Temporal.PlainDate | NepaliPlainDate {
+        if (calendar === 'nepali') {
+            return this
+        }
+        return this._iso.withCalendar(calendar as Temporal.CalendarLike)
+    }
+
+    with(
+        fields: WithFields,
+        options?: Temporal.AssignmentOptions
+    ): NepaliPlainDate {
+        const month =
+            fields.month ??
+            (fields.monthCode
+                ? monthFromCode(fields.monthCode)
+                : this._nepali.month)
+        const next = {
+            year: fields.year ?? this._nepali.year,
+            month,
+            day: fields.day ?? this._nepali.day,
+        }
+        return NepaliPlainDate.fromNepaliFields(next, options)
+    }
+
+    add(duration: Duration): NepaliPlainDate {
+        const { years = 0, months = 0, weeks = 0, days = 0 } = duration
+
+        // Year / month arithmetic in Nepali space (so month #s stay sensible).
+        let y = this._nepali.year
+        let m = this._nepali.month
+        const d = this._nepali.day
+
+        if (years || months) {
+            let total = m + months + years * 12
+            // normalize into 1..12
+            while (total > 12) {
+                total -= 12
+                y += 1
+            }
+            while (total < 1) {
+                total += 12
+                y -= 1
+            }
+            m = total
+        }
+
+        let result = NepaliPlainDate.fromNepaliFields({
+            year: y,
+            month: m,
+            day: clampNepaliDay(y, m, d),
+        })
+
+        const dayDelta = weeks * 7 + days
+        if (dayDelta !== 0) {
+            result = NepaliPlainDate.fromIso(
+                result._iso.add({ days: dayDelta })
+            )
+        }
+        return result
+    }
+
+    subtract(duration: Duration): NepaliPlainDate {
+        return this.add({
+            years: -(duration.years ?? 0),
+            months: -(duration.months ?? 0),
+            weeks: -(duration.weeks ?? 0),
+            days: -(duration.days ?? 0),
+        })
+    }
+
+    since(other: NepaliPlainDate | Temporal.PlainDate): Temporal.Duration {
+        const otherIso = other instanceof NepaliPlainDate ? other._iso : other
+        return this._iso.since(otherIso)
+    }
+
+    equals(other: NepaliPlainDate | Temporal.PlainDate): boolean {
+        const otherIso = other instanceof NepaliPlainDate ? other._iso : other
+        return this._iso.equals(otherIso)
+    }
+
+    toString(options?: Temporal.ShowCalendarOption): string {
+        const iso = `${this._iso.year}-${padTwo(this._iso.month)}-${padTwo(
+            this._iso.day
+        )}`
+        const display = options?.calendarName ?? 'auto'
+        if (display === 'never') {
+            return iso
+        }
+        return `${iso}[u-ca=nepali]`
+    }
+
+    toLocaleString() {
+        // Nepali is not in CLDR; we only render a stable numeric form here.
+        // Localised month/day labels are produced by `localisationHelpers`.
+        return `${this._nepali.year}-${padTwo(this._nepali.month)}-${padTwo(
+            this._nepali.day
+        )}`
+    }
+
+    toPlainYearMonth() {
+        return new NepaliPlainYearMonth(this._nepali.year, this._nepali.month)
+    }
+}
+
+class NepaliPlainYearMonth {
+    readonly calendarId = 'nepali'
+    constructor(readonly year: number, readonly month: number) {}
+    get monthCode() {
+        return buildMonthCode(this.month)
+    }
+    get daysInMonth() {
+        return NEPALI_CALENDAR_DATA[this.year][this.month]
+    }
+    get daysInYear() {
+        return computeDaysInNepaliYear(this.year)
+    }
+    get monthsInYear() {
+        return 12
+    }
+    toLocaleString() {
+        return `${this.year}-${padTwo(this.month)}`
+    }
+    toString() {
+        return `${this.year}-${padTwo(this.month)}-01[u-ca=nepali]`
+    }
+}
+
+/**
+ * A `Temporal.ZonedDateTime`-compatible value living in the Nepali calendar.
+ * Internally wraps an iso8601-backed `Temporal.ZonedDateTime`, plus the
+ * Nepali year/month/day for that instant.
+ */
+class NepaliZonedDateTime {
+    readonly calendarId = 'nepali'
+    private readonly _nepali: NepaliFields
+    private readonly _iso: Temporal.ZonedDateTime // iso8601 calendar
+
+    constructor(nepali: NepaliFields, iso: Temporal.ZonedDateTime) {
+        this._nepali = nepali
+        this._iso = iso
+    }
+
+    static fromIso(isoZdt: Temporal.ZonedDateTime): NepaliZonedDateTime {
+        const iso = isoZdt.withCalendar('iso8601')
+        const nepali = _isoToNepali({
+            year: iso.year,
+            month: iso.month,
+            day: iso.day,
+        })
+        return new NepaliZonedDateTime(nepali, iso)
+    }
+
+    static fromNepaliFields(
+        fields: NepaliFields & {
+            hour?: number
+            minute?: number
+            second?: number
+            timeZone: string
+        }
+    ): NepaliZonedDateTime {
+        const iso = _nepaliToIso(fields)
+        const isoZdt = Temporal.PlainDateTime.from({
+            year: iso.year,
+            month: iso.month,
+            day: iso.day,
+            hour: fields.hour ?? 0,
+            minute: fields.minute ?? 0,
+            second: fields.second ?? 0,
+        }).toZonedDateTime(fields.timeZone)
+        return new NepaliZonedDateTime(
+            { year: fields.year, month: fields.month, day: fields.day },
+            isoZdt
+        )
+    }
+
+    get timeZoneId() {
+        return this._iso.timeZoneId
+    }
+    get year() {
+        return this._nepali.year
+    }
+    get eraYear() {
+        return this._nepali.year
+    }
+    get month() {
+        return this._nepali.month
+    }
+    get monthCode() {
+        return buildMonthCode(this._nepali.month)
+    }
+    get day() {
+        return this._nepali.day
+    }
+    get dayOfWeek() {
+        return this._iso.dayOfWeek
+    }
+    get dayOfYear() {
+        return computeDayOfYearInNepali(
+            this._nepali.year,
+            this._nepali.month,
+            this._nepali.day
+        )
+    }
+    get daysInWeek() {
+        return 7
+    }
+    get daysInMonth() {
+        return NEPALI_CALENDAR_DATA[this._nepali.year][this._nepali.month]
+    }
+    get daysInYear() {
+        return computeDaysInNepaliYear(this._nepali.year)
+    }
+    get monthsInYear() {
+        return 12
+    }
+    get hour() {
+        return this._iso.hour
+    }
+    get minute() {
+        return this._iso.minute
+    }
+    get second() {
+        return this._iso.second
+    }
+
+    toPlainDate(): NepaliPlainDate {
+        return new NepaliPlainDate(
+            this._nepali,
+            this._iso.toPlainDate().withCalendar('iso8601')
+        )
+    }
+
+    toIsoZonedDateTime(): Temporal.ZonedDateTime {
+        return this._iso
+    }
+
+    startOfDay(): NepaliZonedDateTime {
+        return new NepaliZonedDateTime(this._nepali, this._iso.startOfDay())
+    }
+
+    withCalendar(
+        calendar: string
+    ): Temporal.ZonedDateTime | NepaliZonedDateTime {
+        if (calendar === 'nepali') {
+            return this
+        }
+        return this._iso.withCalendar(calendar as Temporal.CalendarLike)
+    }
+
+    with(fields: WithFields & { hour?: number }): NepaliZonedDateTime {
+        const month =
+            fields.month ??
+            (fields.monthCode
+                ? monthFromCode(fields.monthCode)
+                : this._nepali.month)
+        const next: NepaliFields & {
+            hour?: number
+            minute?: number
+            second?: number
+            timeZone: string
+        } = {
+            year: fields.year ?? this._nepali.year,
+            month,
+            day: clampNepaliDay(
+                fields.year ?? this._nepali.year,
+                month,
+                fields.day ?? this._nepali.day
+            ),
+            hour: this._iso.hour,
+            minute: this._iso.minute,
+            second: this._iso.second,
+            timeZone: this._iso.timeZoneId,
+        }
+        return NepaliZonedDateTime.fromNepaliFields(next)
+    }
+
+    add(duration: Duration): NepaliZonedDateTime {
+        const plain = this.toPlainDate().add(duration)
+        const isoBacking = plain.toIso()
+        const isoZdt = isoBacking
+            .toPlainDateTime({
+                hour: this._iso.hour,
+                minute: this._iso.minute,
+                second: this._iso.second,
+                millisecond: this._iso.millisecond,
+                microsecond: this._iso.microsecond,
+                nanosecond: this._iso.nanosecond,
+            })
+            .toZonedDateTime(this._iso.timeZoneId)
+        return new NepaliZonedDateTime(
+            { year: plain.year, month: plain.month, day: plain.day },
+            isoZdt
+        )
+    }
+
+    subtract(duration: Duration): NepaliZonedDateTime {
+        return this.add({
+            years: -(duration.years ?? 0),
+            months: -(duration.months ?? 0),
+            weeks: -(duration.weeks ?? 0),
+            days: -(duration.days ?? 0),
+        })
+    }
+
+    equals(other: NepaliZonedDateTime | Temporal.ZonedDateTime): boolean {
+        const otherIso =
+            other instanceof NepaliZonedDateTime ? other._iso : other
+        return this._iso.equals(otherIso)
+    }
+}
+
+export { NepaliPlainDate, NepaliPlainYearMonth, NepaliZonedDateTime }

--- a/src/hooks/internal/useCalendarWeekDays.ts
+++ b/src/hooks/internal/useCalendarWeekDays.ts
@@ -1,9 +1,14 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { useMemo } from 'react'
+import {
+    CalendarZonedDateTime,
+    isNepaliZonedDateTime,
+    NepaliZonedDateTime,
+} from '../../custom-calendars'
 
 const groupByWeek = (
-    acc: Temporal.ZonedDateTime[][],
-    day: Temporal.ZonedDateTime
+    acc: CalendarZonedDateTime[][],
+    day: CalendarZonedDateTime
 ) => {
     if (day.dayOfWeek === 1) {
         acc.push([])
@@ -19,48 +24,39 @@ const groupByWeek = (
  * @param dayZdt
  * @returns an array of array of days (each top-level array is a week)
  */
-export const useCalendarWeekDays = (dayZdt: Temporal.ZonedDateTime) => {
+export const useCalendarWeekDays = (dayZdt: CalendarZonedDateTime) => {
     return useMemo(() => {
-        const dateInfo: Temporal.ZonedDateTimeLike = {
-            year: dayZdt.year,
-            month: dayZdt.month,
-            day: dayZdt.day,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            calendar: dayZdt.calendar,
-            timeZone: dayZdt.timeZone,
-        }
+        const firstDayOfMonth = dayZdt.with({ day: 1 })
 
-        // get first day of the month
-        const firstDayOfMonth = Temporal.ZonedDateTime.from({
-            ...dateInfo,
-            day: 1,
-        })
         // get first day of first week to display
         const firstDayToDisplay = firstDayOfMonth.subtract({
             days: firstDayOfMonth.dayOfWeek - 1,
         })
 
-        // get last day of month
-        const lastDayOfMonth = Temporal.ZonedDateTime.from({
-            ...dateInfo,
-            day: dayZdt.daysInMonth,
-        })
+        const lastDayOfMonth = dayZdt.with({ day: dayZdt.daysInMonth })
 
         // get last day of last week of month
         const lastDayToDisplay = lastDayOfMonth.add({
             days: 7 - lastDayOfMonth.dayOfWeek,
         })
 
-        const numberOfDaysInCalendar = lastDayToDisplay
-            .toPlainDate()
-            .since(firstDayToDisplay.toPlainDate()).days
+        const numberOfDaysInCalendar = isNepaliZonedDateTime(lastDayToDisplay)
+            ? lastDayToDisplay
+                  .toPlainDate()
+                  .since(
+                      (firstDayToDisplay as NepaliZonedDateTime).toPlainDate()
+                  ).days
+            : (lastDayToDisplay as Temporal.ZonedDateTime)
+                  .toPlainDate()
+                  .since(
+                      (
+                          firstDayToDisplay as Temporal.ZonedDateTime
+                      ).toPlainDate()
+                  ).days
 
-        let date: Temporal.ZonedDateTime =
-            Temporal.ZonedDateTime.from(firstDayToDisplay)
+        let date: CalendarZonedDateTime = firstDayToDisplay
 
-        const allDates: Temporal.ZonedDateTime[] = []
+        const allDates: CalendarZonedDateTime[] = []
 
         for (let i = 0; i <= numberOfDaysInCalendar; i++) {
             allDates.push(date)

--- a/src/hooks/internal/useNavigation.ts
+++ b/src/hooks/internal/useNavigation.ts
@@ -1,5 +1,5 @@
-import { Temporal } from '@js-temporal/polyfill'
 import { Dispatch, SetStateAction, useMemo } from 'react'
+import { CalendarZonedDateTime, plainDateFrom } from '../../custom-calendars'
 import {
     PickerOptionsWithResolvedCalendar,
     SupportedCalendar,
@@ -44,8 +44,8 @@ export type UseNavigationReturnType = {
 }
 
 type UseNavigationHook = (
-    firstZdtOfVisibleMonth: Temporal.ZonedDateTime,
-    setFirstZdtOfVisibleMonth: Dispatch<SetStateAction<Temporal.ZonedDateTime>>,
+    firstZdtOfVisibleMonth: CalendarZonedDateTime,
+    setFirstZdtOfVisibleMonth: Dispatch<SetStateAction<CalendarZonedDateTime>>,
     localeOptions: PickerOptionsWithResolvedCalendar
 ) => UseNavigationReturnType
 /**
@@ -78,7 +78,7 @@ export const useNavigation: UseNavigationHook = (
 
         const options = {
             locale: localeOptions.locale,
-            calendar: localeOptions.calendar.id as SupportedCalendar,
+            calendar: localeOptions.calendar as SupportedCalendar,
             numberingSystem: localeOptions.numberingSystem,
         }
 
@@ -168,20 +168,21 @@ export const useNavigation: UseNavigationHook = (
                 : getMonthsForCalendar(
                       isCustom ? 'gregory' : options.calendar
                   ).map((month) => {
-                      const calendar = new Temporal.Calendar(
-                          isCustom ? 'gregory' : options.calendar
+                      const calendarForReference = isCustom
+                          ? 'gregory'
+                          : options.calendar
+                      const referenceDate = plainDateFrom(
+                          { year: 2000, month: 1, day: 1 },
+                          calendarForReference
                       )
-                      const referenceDate = calendar.dateFromFields({
-                          year: 2000,
-                          month: 1,
-                          day: 1,
-                      })
-
-                      const date = calendar.dateFromFields({
-                          year: referenceDate.year,
-                          month: month.value,
-                          day: 1,
-                      })
+                      const date = plainDateFrom(
+                          {
+                              year: referenceDate.year,
+                              month: month.value,
+                              day: 1,
+                          },
+                          calendarForReference
+                      )
 
                       return {
                           value: month.value,

--- a/src/hooks/internal/useWeekDayLabels.ts
+++ b/src/hooks/internal/useWeekDayLabels.ts
@@ -1,5 +1,10 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { useMemo } from 'react'
+import {
+    CalendarZonedDateTime,
+    isNepaliCalendar,
+    NepaliZonedDateTime,
+} from '../../custom-calendars'
 import { PickerOptionsWithResolvedCalendar } from '../../types'
 import localisationHelpers from '../../utils/localisationHelpers'
 
@@ -10,9 +15,14 @@ export const useWeekDayLabels = (
         if (!localeOptions.calendar) {
             throw new Error('a calendar must be provided to useWeekDayLabels')
         }
-        const today = Temporal.Now.zonedDateTime(
+        const isoNow = Temporal.Now.zonedDateTimeISO()
+        const today: CalendarZonedDateTime = isNepaliCalendar(
             localeOptions.calendar
-        ).startOfDay()
+        )
+            ? NepaliZonedDateTime.fromIso(isoNow).startOfDay()
+            : isoNow
+                  .withCalendar(localeOptions.calendar as Temporal.CalendarLike)
+                  .startOfDay()
 
         const startOfWeek = today.subtract({ days: today.dayOfWeek - 1 }) // dayOfWeek is 1-based, where 1 is Monday
 
@@ -30,7 +40,7 @@ export const useWeekDayLabels = (
     }, [localeOptions])
 
 const getWeekDayString: (
-    date: Temporal.ZonedDateTime,
+    date: CalendarZonedDateTime,
     localeOptions: PickerOptionsWithResolvedCalendar
 ) => string = (date, localeOptions) => {
     return localisationHelpers.localiseWeekDayLabel(date, localeOptions)

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -1,13 +1,15 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
+import {
+    CalendarZonedDateTime,
+    isNepaliZonedDateTime,
+    zonedDateTimeFrom,
+    zonedDateTimeWithCalendar,
+} from '../custom-calendars'
 import { getNowInCalendar } from '../index'
 import { PickerOptions, SupportedCalendar } from '../types'
-import {
-    formatDate,
-    getCustomCalendarIfExists,
-    extractAndValidateDateString,
-} from '../utils/helpers'
+import { formatDate, extractAndValidateDateString } from '../utils/helpers'
 import localisationHelpers from '../utils/localisationHelpers'
 import { useCalendarWeekDays } from './internal/useCalendarWeekDays'
 import {
@@ -43,11 +45,17 @@ export type UseDatePickerReturn = UseNavigationReturnType & {
     }[][]
 }
 type UseDatePickerHookType = (options: DatePickerOptions) => UseDatePickerReturn
-type ValidatedDate = Temporal.YearOrEraAndEraYear &
-    Temporal.MonthOrMonthCode & {
-        day: number
-        format?: string
-    }
+// 0.5.x dropped the public `YearOrEraAndEraYear` / `MonthOrMonthCode` helper
+// types; re-state the shape inline.
+type ValidatedDate = {
+    year?: number
+    era?: string
+    eraYear?: number
+    month?: number
+    monthCode?: string
+    day: number
+    format?: string
+}
 
 export const useDatePicker: UseDatePickerHookType = ({
     onDateSelect,
@@ -59,10 +67,9 @@ export const useDatePicker: UseDatePickerHookType = ({
     options,
 }) => {
     const optionsWithCustomerCalendar = useMemo(() => {
-        const calendar = getCustomCalendarIfExists(
-            dhis2CalendarsMap[options.calendar ?? 'gregorian'] ??
-                options.calendar
-        ) as SupportedCalendar
+        const requested = options.calendar ?? 'gregorian'
+        const calendar = (dhis2CalendarsMap[requested] ??
+            requested) as SupportedCalendar
         return {
             ...options,
             calendar,
@@ -105,22 +112,51 @@ export const useDatePicker: UseDatePickerHookType = ({
 
     date.format = !date.format ? format : date.format
 
-    const temporalCalendar = useMemo(
-        () => Temporal.Calendar.from(resolvedOptions.calendar),
-        [resolvedOptions.calendar]
-    )
-    const temporalTimeZone = useMemo(
-        () => Temporal.TimeZone.from(resolvedOptions.timeZone),
-        [resolvedOptions.timeZone]
-    )
-
-    const selectedDateZdt = dateString
-        ? Temporal.Calendar.from(temporalCalendar)
-              .dateFromFields(date)
-              .toZonedDateTime({
-                  timeZone: temporalTimeZone,
-              })
-        : null
+    const selectedDateZdt: CalendarZonedDateTime | null = useMemo(() => {
+        if (!dateString) {
+            return null
+        }
+        const era = (date as { era?: string }).era
+        const eraYear = date.eraYear as number | undefined
+        const yearOnly = date.year as number | undefined
+        const month =
+            (date.month as number | undefined) ??
+            (date.monthCode
+                ? Number(String(date.monthCode).replace(/^M/, ''))
+                : undefined)
+        if (month === undefined) {
+            return null
+        }
+        // For calendars with eras (e.g. ethiopic) the validated date is
+        // expressed as `era` + `eraYear`; passing a `year` alongside makes
+        // the polyfill consistency-check raise. Pick one form.
+        const fields =
+            era !== undefined && eraYear !== undefined
+                ? {
+                      eraYear,
+                      era,
+                      month,
+                      day: date.day,
+                      year: undefined as number | undefined,
+                  }
+                : {
+                      year: yearOnly ?? eraYear,
+                      month,
+                      day: date.day,
+                  }
+        if (
+            (fields as { year?: number; eraYear?: number }).year ===
+                undefined &&
+            (fields as { eraYear?: number }).eraYear === undefined
+        ) {
+            return null
+        }
+        return zonedDateTimeFrom(
+            fields as Parameters<typeof zonedDateTimeFrom>[0],
+            resolvedOptions.calendar,
+            resolvedOptions.timeZone
+        )
+    }, [dateString, date, resolvedOptions.calendar, resolvedOptions.timeZone])
 
     const [firstZdtOfVisibleMonth, setFirstZdtOfVisibleMonth] = useState(() => {
         const zdt = selectedDateZdt || todayZdt
@@ -130,30 +166,44 @@ export const useDatePicker: UseDatePickerHookType = ({
     const localeOptions = useMemo(
         () => ({
             locale: resolvedOptions.locale,
-            calendar: temporalCalendar,
-            timeZone: temporalTimeZone,
+            calendar: resolvedOptions.calendar,
+            timeZone: resolvedOptions.timeZone,
             weekDayFormat: resolvedOptions.weekDayFormat,
             numberingSystem: resolvedOptions.numberingSystem,
         }),
-        [resolvedOptions, temporalCalendar, temporalTimeZone]
+        [resolvedOptions]
     )
 
     const weekDayLabels = useWeekDayLabels(localeOptions)
 
+    // Re-project the held ZDT to the active calendar so navigation reads
+    // year/month in the right calendar even after the consumer swaps
+    // `options.calendar` on the same component instance.
+    const reprojectedFirstOfVisibleMonth = useMemo(
+        () =>
+            zonedDateTimeWithCalendar(
+                firstZdtOfVisibleMonth,
+                resolvedOptions.calendar
+            ),
+        [firstZdtOfVisibleMonth, resolvedOptions.calendar]
+    )
+
     const navigation = useNavigation(
-        firstZdtOfVisibleMonth.withCalendar(localeOptions.calendar),
+        reprojectedFirstOfVisibleMonth,
         setFirstZdtOfVisibleMonth,
         { ...localeOptions, pastOnly: options?.pastOnly }
     )
     const selectDate = useCallback(
-        (zdt: Temporal.ZonedDateTime) => {
+        (zdt: CalendarZonedDateTime) => {
             onDateSelect({
                 calendarDateString: formatDate(zdt, undefined, date.format),
             })
         },
         [onDateSelect, date.format]
     )
-    const calendarWeekDaysZdts = useCalendarWeekDays(firstZdtOfVisibleMonth)
+    const calendarWeekDaysZdts = useCalendarWeekDays(
+        reprojectedFirstOfVisibleMonth
+    )
 
     useEffect(() => {
         if (dateString === prevDateStringRef.current) {
@@ -162,17 +212,17 @@ export const useDatePicker: UseDatePickerHookType = ({
 
         prevDateStringRef.current = dateString
 
-        const zdt = Temporal.Calendar.from(temporalCalendar)
-            .dateFromFields(date)
-            .toZonedDateTime({
-                timeZone: temporalTimeZone,
-            })
+        if (!selectedDateZdt) {
+            return
+        }
+
+        const zdt = selectedDateZdt
 
         if (
             (firstZdtOfVisibleMonth.year !== zdt.year ||
                 firstZdtOfVisibleMonth.month !== zdt.month) &&
             !calendarWeekDaysZdts.some((week) =>
-                week.some((day) => day.equals(zdt))
+                week.some((day) => zdtEquals(day, zdt))
             )
         ) {
             setFirstZdtOfVisibleMonth(zdt.subtract({ days: zdt.day - 1 }))
@@ -182,24 +232,21 @@ export const useDatePicker: UseDatePickerHookType = ({
         dateString,
         firstZdtOfVisibleMonth,
         calendarWeekDaysZdts,
-        temporalCalendar,
-        temporalTimeZone,
+        selectedDateZdt,
     ])
     const result: UseDatePickerReturn = {
         calendarWeekDays: calendarWeekDaysZdts.map((week) =>
             week.map((weekDayZdt) => ({
                 dateValue: formatDate(weekDayZdt, undefined, format),
-                label: localisationHelpers.localiseWeekLabel(
-                    weekDayZdt.withCalendar(localeOptions.calendar),
-                    { ...localeOptions, calendar: resolvedOptions.calendar }
-                ),
+                label: localisationHelpers.localiseWeekLabel(weekDayZdt, {
+                    ...localeOptions,
+                    calendar: resolvedOptions.calendar,
+                }),
                 onClick: () => selectDate(weekDayZdt),
                 isSelected: selectedDateZdt
-                    ? selectedDateZdt
-                          ?.withCalendar('iso8601')
-                          .equals(weekDayZdt.withCalendar('iso8601'))
+                    ? zdtSameIsoInstant(selectedDateZdt, weekDayZdt)
                     : false,
-                isToday: todayZdt && weekDayZdt.equals(todayZdt),
+                isToday: todayZdt && zdtEquals(weekDayZdt, todayZdt),
                 isInCurrentMonth:
                     firstZdtOfVisibleMonth &&
                     weekDayZdt.month === firstZdtOfVisibleMonth.month,
@@ -210,4 +257,26 @@ export const useDatePicker: UseDatePickerHookType = ({
     }
 
     return result
+}
+
+const zdtEquals = (a: CalendarZonedDateTime, b: CalendarZonedDateTime) => {
+    if (isNepaliZonedDateTime(a) || isNepaliZonedDateTime(b)) {
+        return a.year === b.year && a.month === b.month && a.day === b.day
+    }
+    return (a as Temporal.ZonedDateTime).equals(b as Temporal.ZonedDateTime)
+}
+
+const zdtSameIsoInstant = (
+    a: CalendarZonedDateTime,
+    b: CalendarZonedDateTime
+) => {
+    const aIso = zonedDateTimeWithCalendar(
+        a,
+        'iso8601'
+    ) as Temporal.ZonedDateTime
+    const bIso = zonedDateTimeWithCalendar(
+        b,
+        'iso8601'
+    ) as Temporal.ZonedDateTime
+    return aIso.equals(bIso)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ts
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
 import getValidLocale from '../../utils/getValidLocale'
-import { fromAnyDate, getCustomCalendarIfExists } from '../../utils/index'
+import { fromAnyDate } from '../../utils/index'
 import { buildDailyFixedPeriod } from '../daily-periods/index'
 import { generateFixedPeriods } from '../generate-fixed-periods/index'
 import {
@@ -28,9 +28,8 @@ const createFixedPeriodFromPeriodId: ParseFixedPeriodId = ({
     calendar: requestedCalendar,
     locale = 'en',
 }) => {
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
-    ) as SupportedCalendar
+    const calendar = (dhis2CalendarsMap[requestedCalendar] ??
+        requestedCalendar) as SupportedCalendar
 
     const validLocale = getValidLocale(locale) ?? 'en'
 

--- a/src/period-calculation/daily-periods/build-daily-fixed-period.ts
+++ b/src/period-calculation/daily-periods/build-daily-fixed-period.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { formatDate, localisationHelpers } from '../../utils/index'
 import { FixedPeriod } from '../types'
@@ -6,7 +6,7 @@ import { FixedPeriod } from '../types'
 const { localiseDateLabel } = localisationHelpers
 
 type BuildDailyFixedPeriod = (args: {
-    date: Temporal.PlainDate
+    date: CalendarPlainDate
     calendar: SupportedCalendar
     locale: string
 }) => FixedPeriod

--- a/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
+++ b/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
@@ -1,10 +1,10 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate, comparePlainDates } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils'
 
 type DoesPeriodEndBefore = (args: {
     period: { startDate: string; endDate: string }
-    date: Temporal.PlainDate
+    date: CalendarPlainDate
     calendar: SupportedCalendar
 }) => boolean
 
@@ -17,11 +17,10 @@ const doesPeriodEndBefore: DoesPeriodEndBefore = ({
     const periodEndDay = fromAnyDate({ calendar, date: period.endDate })
 
     const periodStartsOnOrAfterDate =
-        Temporal.PlainDate.compare(date, periodStartDay) < 1
+        comparePlainDates(date, periodStartDay) < 1
     const endsBeforeAfterPeriodStart =
-        Temporal.PlainDate.compare(periodStartDay, date) === -1
-    const periodEndsOnOrBeforeDate =
-        Temporal.PlainDate.compare(date, periodEndDay) < 1
+        comparePlainDates(periodStartDay, date) === -1
+    const periodEndsOnOrBeforeDate = comparePlainDates(date, periodEndDay) < 1
 
     return (
         periodStartsOnOrAfterDate ||

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-daily.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-daily.ts
@@ -1,4 +1,8 @@
-import { Temporal } from '@js-temporal/polyfill'
+import {
+    CalendarPlainDate,
+    comparePlainDates,
+    plainDateFrom,
+} from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { buildDailyFixedPeriod } from '../daily-periods/index'
@@ -7,7 +11,7 @@ import { FixedPeriod } from '../types'
 type GenerateFixedPeriodsDaily = (options: {
     year: number
     calendar: SupportedCalendar
-    endsBefore?: Temporal.PlainDate
+    endsBefore?: CalendarPlainDate
     locale: string
 }) => Array<FixedPeriod>
 
@@ -20,22 +24,14 @@ const generateFixedPeriodsDaily: GenerateFixedPeriodsDaily = ({
     const endsBefore = _endsBefore
         ? fromAnyDate({ calendar, date: _endsBefore })
         : null
-    const day = Temporal.PlainDate.from({
-        year,
-        month: 1,
-        day: 1,
-        calendar,
-    })
+    const day = plainDateFrom({ year, month: 1, day: 1 }, calendar)
 
     const days: FixedPeriod[] = []
 
     for (let i = 0; i < day.daysInYear; i++) {
         const nextDay = day.add({ days: i })
 
-        if (
-            endsBefore &&
-            Temporal.PlainDate.compare(nextDay, endsBefore) > -1
-        ) {
+        if (endsBefore && comparePlainDates(nextDay, endsBefore) > -1) {
             break
         }
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate, plainDateFrom } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { getStartingMonthByPeriodType } from '../get-starting-month-for-period-type'
@@ -17,7 +17,7 @@ type GenerateFixedPeriodsMonthly = (options: {
     periodType: PeriodType
     calendar: SupportedCalendar
     locale: string
-    endsBefore?: Temporal.PlainDate
+    endsBefore?: CalendarPlainDate
 }) => Array<FixedPeriod>
 
 const generateFixedPeriodsMonthly: GenerateFixedPeriodsMonthly = ({
@@ -27,15 +27,17 @@ const generateFixedPeriodsMonthly: GenerateFixedPeriodsMonthly = ({
     endsBefore,
     locale,
 }) => {
-    let currentMonth = Temporal.PlainDate.from({
-        year,
-        month: getStartingMonth(periodType),
-        // this should really just be 1 but have to set it to 14th because of a
-        // quirk in custom calendars
-        // @TODO: discuss this with the Temporal team
-        day: calendar.toString() === 'nepali' ? 14 : 1,
-        calendar,
-    })
+    let currentMonth: CalendarPlainDate = plainDateFrom(
+        {
+            year,
+            month: getStartingMonth(periodType),
+            // this should really just be 1 but have to set it to 14th because of a
+            // quirk in custom calendars
+            // @TODO: discuss this with the Temporal team
+            day: calendar === 'nepali' ? 14 : 1,
+        },
+        calendar
+    )
 
     const months: FixedPeriod[] = []
 
@@ -79,7 +81,7 @@ const generateFixedPeriodsMonthly: GenerateFixedPeriodsMonthly = ({
 
 const isEthiopic13thMonth = (
     calendar: SupportedCalendar,
-    date: Temporal.PlainDate
+    date: CalendarPlainDate
 ) => {
     return calendar === 'ethiopic' && date.month === 13
 }

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate, plainDateFrom } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate, formatDate, padWithZeroes } from '../../utils/index'
 import { FixedPeriod, PeriodType } from '../types'
@@ -20,7 +20,7 @@ type GenerateFixedPeriodsWeekly = (options: {
     periodType: PeriodType
     calendar: SupportedCalendar
     startingDay: number /** 1 is Monday */
-    endsBefore?: Temporal.PlainDate
+    endsBefore?: CalendarPlainDate
 }) => Array<FixedPeriod>
 
 // Does not need a `locale` as we're displaying the month as number in the
@@ -127,12 +127,10 @@ const getStartingDate = (options: {
     const { year, calendar, startingDay } = options
 
     // first week in every year has the 4th in the first month
-    const fourthOfFirstMonth = Temporal.PlainDate.from({
-        year,
-        month: 1,
-        day: 4,
-        calendar,
-    })
+    const fourthOfFirstMonth = plainDateFrom(
+        { year, month: 1, day: 4 },
+        calendar
+    )
 
     const dayDiff = fourthOfFirstMonth.dayOfWeek - startingDay
 
@@ -172,8 +170,8 @@ const buildValue = ({
 
 type BuildLabelFunc = (options: {
     periodType: PeriodType
-    date: Temporal.PlainDate
-    nextWeek: Temporal.PlainDate
+    date: CalendarPlainDate
+    nextWeek: CalendarPlainDate
     weekIndex: number
 }) => string
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
@@ -1,4 +1,8 @@
-import { Temporal } from '@js-temporal/polyfill'
+import {
+    CalendarPlainDate,
+    plainDateFrom,
+    withCalendar,
+} from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { FixedPeriod, PeriodType } from '../types'
 import {
@@ -11,7 +15,7 @@ type GenerateFixedPeriodsYearly = (options: {
     year: number
     periodType: PeriodType
     calendar: SupportedCalendar
-    endsBefore?: Temporal.PlainDate
+    endsBefore?: CalendarPlainDate
     yearsCount: number | null
     locale: string
 }) => Array<FixedPeriod>
@@ -25,25 +29,25 @@ const generateFixedPeriodsYearly: GenerateFixedPeriodsYearly = ({
     locale,
 }) => {
     const month = getYearlyStartMonthByPeriodType(periodType)
-    const currentYear = Temporal.PlainDate.from({
-        year,
-        month,
-        // this should really just be 1 but have to set it to 14th because of a
-        // quirk in custom calendars
-        // @TODO: discuss this with the Temporal team
-        day: calendar.toString() === 'nepali' ? 14 : 1,
-        calendar,
-    })
+    const currentYear = plainDateFrom(
+        {
+            year,
+            month,
+            // this should really just be 1 but have to set it to 14th because of a
+            // quirk in custom calendars
+            // @TODO: discuss this with the Temporal team
+            day: calendar === 'nepali' ? 14 : 1,
+        },
+        calendar
+    )
 
     // Timestamp "0" is gregorian 1970-01-01, so creating that date in the
     // gregorian calendar and then use the provided, correct calendar to
     // determine the year we need to go back to
-    const startYearDate = Temporal.PlainDate.from({
-        day: 1,
-        month: 1,
-        year: 1970,
-        calendar: 'gregory',
-    }).withCalendar(calendar)
+    const startYearDate = withCalendar(
+        plainDateFrom({ day: 1, month: 1, year: 1970 }, 'gregory'),
+        calendar
+    )
 
     // we need to use eraYear because ethiopic calendar having the "correct"
     // year (as in what users expect to see) as eraYear, while iso8601 (which

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ts
@@ -1,7 +1,7 @@
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
 import getValidLocale from '../../utils/getValidLocale'
-import { fromAnyDate, getCustomCalendarIfExists } from '../../utils/index'
+import { fromAnyDate } from '../../utils/index'
 import {
     monthlyFixedPeriodTypes,
     weeklyFixedPeriodTypes,
@@ -50,9 +50,8 @@ const generateFixedPeriods: GenerateFixedPeriods = ({
         }
     }
 
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
-    ) as SupportedCalendar
+    const calendar = (dhis2CalendarsMap[requestedCalendar] ??
+        requestedCalendar) as SupportedCalendar
 
     const validLocale = getValidLocale(locale) ?? 'en'
 

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ts
@@ -1,6 +1,5 @@
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
-import { getCustomCalendarIfExists } from '../../utils/index'
 import {
     weeklyFixedPeriodTypes,
     monthlyFixedPeriodTypes,
@@ -25,9 +24,8 @@ const getAdjacentFixedPeriods: GetAdjacentFixedPeriods = ({
     steps = 1,
     locale = 'en',
 }) => {
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
-    ) as SupportedCalendar
+    const calendar = (dhis2CalendarsMap[requestedCalendar] ??
+        requestedCalendar) as SupportedCalendar
 
     const { periodType } = period
     const payload = { period, calendar, steps, locale }

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { comparePlainDates } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { generateFixedPeriodsWeekly } from '../generate-fixed-periods/index'
@@ -48,12 +48,7 @@ const getFollowingWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
                           calendar,
                           date: curPeriod.startDate,
                       })
-                      return (
-                          Temporal.PlainDate.compare(
-                              startDate,
-                              curStartDate
-                          ) === -1
-                      )
+                      return comparePlainDates(startDate, curStartDate) === -1
                   })
                 : 0
 
@@ -100,7 +95,7 @@ const getPreviousWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
             })
 
             const startDateIsLowerThanCurStartDate =
-                Temporal.PlainDate.compare(startDate, curStartDate) === -1
+                comparePlainDates(startDate, curStartDate) === -1
 
             return startDateIsLowerThanCurStartDate
         })

--- a/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.ts
+++ b/src/period-calculation/get-fixed-period-by-date/get-fixed-period-by-date.ts
@@ -1,6 +1,5 @@
 import { dhis2CalendarsMap } from '../../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../../types'
-import { getCustomCalendarIfExists } from '../../utils/index'
 import {
     monthlyFixedPeriodTypes,
     weeklyFixedPeriodTypes,
@@ -25,9 +24,8 @@ const getFixedPeriodByDate: GetFixedPeriodByDate = ({
     calendar: requestedCalendar,
     locale = 'en',
 }) => {
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[requestedCalendar] ?? requestedCalendar
-    ) as SupportedCalendar
+    const calendar = (dhis2CalendarsMap[requestedCalendar] ??
+        requestedCalendar) as SupportedCalendar
 
     // const date = fromAnyDate({ date: dateInput, calendar })
     const payload = { periodType, date, calendar, locale }

--- a/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
+++ b/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate, plainDateFrom } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import {
     formatDate,
@@ -18,7 +19,7 @@ import { FixedPeriod, PeriodType } from '../types'
 
 type BuildMonthlyFixedPeriod = (args: {
     periodType: PeriodType
-    month: Temporal.PlainDate
+    month: CalendarPlainDate
     year: number
     calendar: SupportedCalendar
     locale: string
@@ -45,7 +46,7 @@ const buildMonthlyFixedPeriod: BuildMonthlyFixedPeriod = ({
         index,
     })
 
-    if (month.calendar === ('ethiopic' as Temporal.CalendarLike)) {
+    if (calendar === 'ethiopic') {
         // @TODO(jira): Create issue
         // @TODO: Confirm the special cases for the 13th month with Abyot, then
         // update the start/end dates for Ethiopic calendar'
@@ -54,12 +55,14 @@ const buildMonthlyFixedPeriod: BuildMonthlyFixedPeriod = ({
         )
     }
 
-    const endDate = Temporal.PlainDate.from({
-        year: nextMonth.year,
-        month: nextMonth.month,
-        day: 1,
-        calendar: nextMonth.calendar,
-    }).subtract({ days: 1 })
+    const endDate = plainDateFrom(
+        {
+            year: nextMonth.year,
+            month: nextMonth.month,
+            day: 1,
+        },
+        calendar
+    ).subtract({ days: 1 })
 
     const name = buildLabel({
         periodType,
@@ -85,7 +88,7 @@ export default buildMonthlyFixedPeriod
 
 const buildId: (options: {
     periodType: PeriodType
-    currentMonth: Temporal.PlainDate
+    currentMonth: CalendarPlainDate
     year: number
     index: number
 }) => string = ({ periodType, currentMonth, year, index }) => {
@@ -133,8 +136,8 @@ const getMonthsToAdd = (periodType: PeriodType) => {
 
 type BuildLabelFunc = (options: {
     periodType: PeriodType
-    month: Temporal.PlainDate
-    nextMonth: Temporal.PlainDate
+    month: CalendarPlainDate
+    nextMonth: CalendarPlainDate
     index: number
     locale: string
     calendar: SupportedCalendar
@@ -157,17 +160,21 @@ const buildLabel: BuildLabelFunc = (options) => {
         calendar,
     }
 
+    // The non-custom branch never sees a Nepali shadow; cast through the
+    // shared type so we can call `.toLocaleString` without `any`.
+    const monthBuiltIn = month as Temporal.PlainDate
+    const nextMonthBuiltIn = nextMonth as Temporal.PlainDate
     let result = ''
 
     if (multiMonthFixedPeriodTypes.includes(periodType)) {
         const format =
             month.year === nextMonth.year ? monthOnlyFormat : withYearFormat
-        result = `${month.toLocaleString(
+        result = `${monthBuiltIn.toLocaleString(
             locale,
             format
-        )} - ${nextMonth.toLocaleString(locale, withYearFormat)}`
+        )} - ${nextMonthBuiltIn.toLocaleString(locale, withYearFormat)}`
     } else {
-        result = `${month.toLocaleString(locale, withYearFormat)}`
+        result = `${monthBuiltIn.toLocaleString(locale, withYearFormat)}`
     }
 
     // needed for ethiopic calendar - the default formatter adds the era, which is not what we want in DHIS2

--- a/src/period-calculation/yearly-periods/build-yearly-fixed-period.ts
+++ b/src/period-calculation/yearly-periods/build-yearly-fixed-period.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { CalendarPlainDate, plainDateFrom } from '../../custom-calendars'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate, formatDate, isCustomCalendar } from '../../utils/index'
 import localisationHelpers from '../../utils/localisationHelpers'
@@ -77,7 +77,7 @@ const isFinancialYear = (periodType: PeriodType) => {
 
 const buildLabel = (
     periodType: PeriodType,
-    currentYearDate: Temporal.PlainDate,
+    currentYearDate: CalendarPlainDate,
     options: {
         locale: string
         calendar: SupportedCalendar
@@ -116,20 +116,22 @@ const buildLabel = (
 }
 
 const buildLabelForCustomCalendar = (
-    date: Temporal.PlainDate,
+    date: CalendarPlainDate,
     options: { locale: string; calendar: SupportedCalendar }
 ) => {
-    const localiseMonth = (dateToDisplay: Temporal.PlainDate) =>
+    const localiseMonth = (dateToDisplay: CalendarPlainDate) =>
         `${localisationHelpers.localiseMonth(dateToDisplay, options, {})} ${
             dateToDisplay.year
         }`
 
-    const nextYearDate = Temporal.PlainDate.from({
-        year: date.year + 1,
-        month: date.month - 1,
-        day: 1,
-        calendar: options.calendar,
-    })
+    const nextYearDate = plainDateFrom(
+        {
+            year: date.year + 1,
+            month: date.month - 1,
+            day: 1,
+        },
+        options.calendar
+    )
     const result = `${localiseMonth(date)} - ${localiseMonth(nextYearDate)}`
 
     return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { Temporal } from '@js-temporal/polyfill'
 import { calendars } from './constants/calendars'
 import { numberingSystems } from './constants/numberingSystems'
 
@@ -13,14 +12,14 @@ export type PickerOptionsWithResolvedCalendar = Omit<
     PickerOptions,
     'calendar'
 > & {
-    calendar: Temporal.CalendarProtocol
+    calendar: SupportedCalendar
     pastOnly?: boolean
 }
 
 export type ResolvedLocaleOptions = {
     calendar: SupportedCalendar
     locale: string
-    timeZone: Temporal.TimeZoneLike
+    timeZone: string
     numberingSystem: string
     weekDayFormat: WeekDayFormat
     maxDate?: string | undefined

--- a/src/utils/convert-date.ts
+++ b/src/utils/convert-date.ts
@@ -1,8 +1,8 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
+import { isNepaliCalendar, NepaliPlainDate } from '../custom-calendars'
 import { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
-import { getCustomCalendarIfExists } from './helpers'
 
 type PlainDate = {
     year: number
@@ -32,19 +32,27 @@ type ConvertDateFn = (
  * @see https://github.com/tc39/ecma402/issues/534 for more details
  */
 export const convertFromIso8601: ConvertDateFn = (date, userCalendar) => {
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[userCalendar] ?? userCalendar
-    ) as SupportedCalendar
+    const calendar = dhis2CalendarsMap[userCalendar] ?? userCalendar
+    const isoDate = Temporal.PlainDate.from(date)
 
-    const { eraYear, year, month, day } =
-        Temporal.PlainDate.from(date).withCalendar(calendar)
-
-    return {
-        eraYear,
-        year,
-        month,
-        day,
+    if (isNepaliCalendar(calendar)) {
+        const nepali = NepaliPlainDate.fromIso(isoDate)
+        return {
+            year: nepali.year,
+            eraYear: nepali.year,
+            month: nepali.month,
+            day: nepali.day,
+        }
     }
+
+    const { eraYear, year, month, day } = isoDate.withCalendar(
+        calendar as Temporal.CalendarLike
+    )
+    // In `@js-temporal/polyfill` 0.5.x some calendars (e.g. `islamic`) no
+    // longer expose an `eraYear` even when the user-facing year equals it.
+    // Consumers of this function relied on `eraYear ?? year`, so fall back
+    // here to preserve that contract.
+    return { eraYear: eraYear ?? year, year, month, day }
 }
 
 /**
@@ -55,27 +63,36 @@ export const convertFromIso8601: ConvertDateFn = (date, userCalendar) => {
  * @returns an object representing the iso8601 date
  */
 export const convertToIso8601: ConvertDateFn = (date, userCalendar) => {
-    const calendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[userCalendar] ?? userCalendar
-    ) as SupportedCalendar
+    const calendar = dhis2CalendarsMap[userCalendar] ?? userCalendar
 
     const dateParts: Temporal.PlainDateLike =
         typeof date === 'string' ? extractDatePartsFromDateString(date) : date
 
-    // this is a workaround for the ethiopic calendar being in a different
-    // era by default. There is a discussion on Temporal on which should be
-    // considered the default era. For us, we need to manually set it to era1
-    // https://github.com/js-temporal/temporal-polyfill/blob/8fd0dead40de7c31398f4d2d41e145466ca57a16/lib/calendar.ts#L2010
-    if (calendar === 'ethiopic') {
-        dateParts.eraYear = dateParts.year
-        dateParts.era = 'era1'
-        delete dateParts.year
+    if (isNepaliCalendar(calendar)) {
+        const np = NepaliPlainDate.fromNepaliFields({
+            year: dateParts.year as number,
+            month: dateParts.month as number,
+            day: dateParts.day as number,
+        })
+        const iso = np.toIso()
+        return { year: iso.year, month: iso.month, day: iso.day }
     }
 
-    dateParts.calendar = calendar
+    const adjustedParts = { ...dateParts }
+    // The ethiopic calendar has two eras. We want the post-incarnation era.
+    // In `@js-temporal/polyfill` 0.5.x the era codes were renamed from the
+    // generic `era1`/`era2` to the calendar-specific `ethiopic`/`ethioaa`,
+    // matching the names accepted by `Temporal.PlainDate.from`.
+    if (calendar === 'ethiopic') {
+        adjustedParts.eraYear = adjustedParts.year
+        adjustedParts.era = 'ethiopic'
+        delete adjustedParts.year
+    }
+
+    adjustedParts.calendar = calendar as Temporal.CalendarLike
 
     const { year, month, day } =
-        Temporal.PlainDate.from(dateParts).withCalendar('iso8601')
+        Temporal.PlainDate.from(adjustedParts).withCalendar('iso8601')
 
     return { year, month, day }
 }

--- a/src/utils/from-any-date.ts
+++ b/src/utils/from-any-date.ts
@@ -1,12 +1,17 @@
 import i18n from '@dhis2/d2-i18n'
 import { Temporal } from '@js-temporal/polyfill'
+import {
+    CalendarPlainDate,
+    isNepaliPlainDate,
+    plainDateFrom,
+} from '../custom-calendars'
 import { SupportedCalendar } from '../types'
 import fromDateString from './from-date-string'
 
 type FromAnyDate = (args: {
-    date: string | Date | Temporal.PlainDate
+    date: string | Date | CalendarPlainDate
     calendar: SupportedCalendar
-}) => Temporal.PlainDate
+}) => CalendarPlainDate
 
 const fromAnyDate: FromAnyDate = ({ date, calendar }) => {
     if (typeof date === 'string') {
@@ -14,21 +19,21 @@ const fromAnyDate: FromAnyDate = ({ date, calendar }) => {
     }
 
     if (date instanceof Date) {
-        return Temporal.PlainDate.from({
-            year: date.getFullYear(),
-            month: date.getMonth() + 1,
-            day: date.getDate(),
-            calendar,
-        })
+        return plainDateFrom(
+            {
+                year: date.getFullYear(),
+                month: date.getMonth() + 1,
+                day: date.getDate(),
+            },
+            calendar
+        )
     }
 
-    if (date instanceof Temporal.PlainDate) {
-        return Temporal.PlainDate.from({
-            year: date.year,
-            month: date.month,
-            day: date.day,
-            calendar,
-        })
+    if (isNepaliPlainDate(date) || date instanceof Temporal.PlainDate) {
+        return plainDateFrom(
+            { year: date.year, month: date.month, day: date.day },
+            calendar
+        )
     }
 
     throw new Error(i18n.t(`Unrecognized date, received "{{date}}"`, { date }))

--- a/src/utils/from-date-string.ts
+++ b/src/utils/from-date-string.ts
@@ -1,15 +1,15 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { plainDateFrom, CalendarPlainDate } from '../custom-calendars'
 import { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
 
 type FromDateString = (args: {
     date: string
     calendar: SupportedCalendar
-}) => Temporal.PlainDate
+}) => CalendarPlainDate
 
 const fromDateString: FromDateString = ({ date, calendar }) => {
     const { year, month, day } = extractDatePartsFromDateString(date)
-    return Temporal.PlainDate.from({ year, month, day, calendar })
+    return plainDateFrom({ year, month, day }, calendar)
 }
 
 export default fromDateString

--- a/src/utils/getNowInCalendar.ts
+++ b/src/utils/getNowInCalendar.ts
@@ -1,31 +1,31 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
-import { getCustomCalendarIfExists, isCustomCalendar } from '../utils/helpers'
+import {
+    CalendarZonedDateTime,
+    isNepaliCalendar,
+    NepaliZonedDateTime,
+} from '../custom-calendars'
 
 /**
  * Gets the Now DateTime in the specified calendar and timeZone
  *
  * @param calendarToUse the calendar to use
  * @param timeZone the timeZone to use
- * @returns Temporal.ZoneDateTime which can be destructured to .year, .month, .day, .hour etc... (returning the values in the specified calendar) or can .getISOFields() to return the underlying iso8601 date
+ * @returns A `Temporal.ZonedDateTime` (or `NepaliZonedDateTime` for Nepali)
+ * whose `.year`/`.month`/`.day` etc. are in the requested calendar.
  */
 const getNowInCalendar = (
-    calendarToUse: Temporal.CalendarLike = 'gregory',
-    timeZone: Temporal.TimeZoneLike = Intl?.DateTimeFormat?.().resolvedOptions?.()
-        ?.timeZone || 'UTC'
-): Temporal.ZonedDateTime => {
-    const gregorianDate = Temporal.Now.zonedDateTime('gregory', timeZone)
-    let calendar: Temporal.CalendarLike =
-        dhis2CalendarsMap[calendarToUse as string] ?? calendarToUse
+    calendarToUse = 'gregory',
+    timeZone = Intl?.DateTimeFormat?.().resolvedOptions?.()?.timeZone || 'UTC'
+): CalendarZonedDateTime => {
+    const gregorianNow = Temporal.Now.zonedDateTimeISO(timeZone)
+    const resolvedCalendar = dhis2CalendarsMap[calendarToUse] ?? calendarToUse
 
-    if (isCustomCalendar(calendar)) {
-        calendar = getCustomCalendarIfExists(calendar)
+    if (isNepaliCalendar(resolvedCalendar)) {
+        return NepaliZonedDateTime.fromIso(gregorianNow)
     }
 
-    const result =
-        Temporal.ZonedDateTime.from(gregorianDate).withCalendar(calendar)
-
-    return result
+    return gregorianNow.withCalendar(resolvedCalendar)
 }
 
 export default getNowInCalendar

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,13 +1,20 @@
 import { Temporal } from '@js-temporal/polyfill'
 import { months, Month } from '../constants/months'
-import { customCalendars, CustomCalendarTypes } from '../custom-calendars'
+import {
+    customCalendars,
+    CustomCalendarTypes,
+    CalendarPlainDate,
+    CalendarZonedDateTime,
+    isNepaliPlainDate,
+    isNepaliZonedDateTime,
+} from '../custom-calendars'
 import { PickerOptions } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
 import getNowInCalendar from './getNowInCalendar'
 import { validateDateString } from './validate-date-string'
 
-export const isCustomCalendar = (calendar: Temporal.CalendarLike) =>
-    !!customCalendars[calendar as CustomCalendarTypes]
+export const isCustomCalendar = (calendar: string | undefined | null) =>
+    !!calendar && !!customCalendars[calendar as CustomCalendarTypes]
 
 export const padWithZeroes = (number: number, count = 2) =>
     String(number).padStart(count, '0')
@@ -19,11 +26,14 @@ type customDate = Temporal.PlainDateLike & {
 }
 
 export const formatDate = (
-    date: Temporal.PlainDate | Temporal.ZonedDateTime,
+    date: CalendarPlainDate | CalendarZonedDateTime,
     dayType?: DayType,
     format?: string
 ) => {
-    const year = date.eraYear ?? date.year
+    const year =
+        isNepaliPlainDate(date) || isNepaliZonedDateTime(date)
+            ? date.year
+            : date.eraYear ?? date.year
     const month = padWithZeroes(date.month)
     let day = date.day
     if (dayType === 'endOfMonth') {
@@ -46,26 +56,16 @@ export const capitalize = (
     locale = 'en'
 ) => [firstLetter.toLocaleUpperCase(locale), ...rest].join('')
 
+/**
+ * Legacy shim retained for callers that still pass the result through
+ * `Temporal.PlainDate.from({ calendar })`. With 0.5.x, calendars are strings
+ * only; custom calendar identifiers (currently `'nepali'`) flow through
+ * unchanged and dedicated routing helpers in `custom-calendars/` build the
+ * appropriate shadow type.
+ */
 export const getCustomCalendarIfExists = (
-    calendar: Temporal.CalendarLike
-): Temporal.CalendarProtocol | Temporal.CalendarLike => {
-    const isCustom = isCustomCalendar(calendar)
-    if (!isCustom) {
-        return calendar
-    }
-
-    const customCalendar = customCalendars[
-        calendar as keyof typeof customCalendars
-    ]?.calendar as Temporal.CalendarProtocol
-
-    if (!customCalendar) {
-        throw new Error(
-            `No implemenation found for custom calendar ${calendar}`
-        )
-    }
-
-    return customCalendar
-}
+    calendar: string | undefined | null
+): string => (calendar ? String(calendar) : 'iso8601')
 
 export const extractAndValidateDateString = (
     date: string,
@@ -121,7 +121,7 @@ const getInvalidDateResult = (options: PickerOptions) => {
 }
 
 const adjustForEthiopicCalendar = (result: customDate) => {
-    result.era = 'era1'
+    result.era = 'ethiopic'
     result.eraYear = result.year
     delete result.year
     return result

--- a/src/utils/localisationHelpers.ts
+++ b/src/utils/localisationHelpers.ts
@@ -2,8 +2,12 @@ import { Temporal } from '@js-temporal/polyfill'
 import { numberingSystems } from '../constants'
 import {
     CalendarCustomLocale,
+    CalendarPlainDate,
+    CalendarZonedDateTime,
     customCalendars,
     CustomCalendarTypes,
+    isNepaliPlainDate,
+    isNepaliZonedDateTime,
 } from '../custom-calendars'
 import {
     PickerOptions,
@@ -28,7 +32,7 @@ const getPartialLocaleMatch: (
 }
 
 const getCustomCalendarLocale = (
-    calendar: Temporal.CalendarLike,
+    calendar: string | undefined,
     locale: string | undefined
 ): CalendarCustomLocale | undefined => {
     const customCalendar = customCalendars[calendar as CustomCalendarTypes]
@@ -52,7 +56,7 @@ const getCustomCalendarLocale = (
 }
 
 type LocaliseDateLabel = (
-    selectedDateZdt: Temporal.ZonedDateTime | Temporal.PlainDate,
+    selectedDateZdt: CalendarZonedDateTime | CalendarPlainDate,
     localeOptions: {
         calendar: SupportedCalendar
         locale: string
@@ -75,23 +79,26 @@ const localiseDateLabel: LocaliseDateLabel = (
 
     const isCustom = isCustomCalendar(localeOptions.calendar)
 
+    if (isCustom) {
+        return formatDate(selectedDateZdt)
+    }
+
     const nonCustomDate =
         selectedDateZdt instanceof Temporal.ZonedDateTime
-            ? selectedDateZdt?.toPlainDate()
-            : selectedDateZdt
+            ? selectedDateZdt.toPlainDate()
+            : (selectedDateZdt as Temporal.PlainDate)
 
-    return isCustom
-        ? formatDate(selectedDateZdt)
-        : nonCustomDate
-              .toLocaleString(localeOptions.locale, {
-                  calendar: localeOptions.calendar,
-                  dateStyle: options.dateStyle,
-              })
-              .toString()
+    return nonCustomDate
+        .withCalendar(localeOptions.calendar as Temporal.CalendarLike)
+        .toLocaleString(localeOptions.locale, {
+            calendar: localeOptions.calendar,
+            dateStyle: options.dateStyle,
+        })
+        .toString()
 }
 
 const localiseWeekLabel = (
-    zdt: Temporal.ZonedDateTime,
+    zdt: CalendarZonedDateTime,
     localeOptions: PickerOptions
 ) => {
     if (!localeOptions.calendar) {
@@ -103,25 +110,32 @@ const localiseWeekLabel = (
         localeOptions.locale
     )
 
-    return isCustom
-        ? customLocale?.numbers?.[zdt.day] || zdt.day
-        : zdt.toPlainDate().toLocaleString(localeOptions.locale, {
-              calendar: localeOptions.calendar,
-              numberingSystem: numberingSystems.includes(
-                  localeOptions.numberingSystem as typeof numberingSystems[number]
-              )
-                  ? localeOptions.numberingSystem
-                  : undefined,
-              day: 'numeric',
-          })
+    if (isCustom) {
+        return customLocale?.numbers?.[zdt.day] || zdt.day
+    }
+
+    return (zdt as Temporal.ZonedDateTime)
+        .toPlainDate()
+        .withCalendar(localeOptions.calendar as Temporal.CalendarLike)
+        .toLocaleString(localeOptions.locale, {
+            calendar: localeOptions.calendar,
+            numberingSystem: numberingSystems.includes(
+                localeOptions.numberingSystem as typeof numberingSystems[number]
+            )
+                ? localeOptions.numberingSystem
+                : undefined,
+            day: 'numeric',
+        })
 }
 
+type LocaliseMonthInput =
+    | CalendarZonedDateTime
+    | CalendarPlainDate
+    | Temporal.PlainYearMonth
+    | Temporal.PlainDateLike
+
 const localiseMonth = (
-    zdt:
-        | Temporal.ZonedDateTime
-        | Temporal.PlainYearMonth
-        | Temporal.PlainDate
-        | Temporal.PlainDateLike,
+    zdt: LocaliseMonthInput,
     localeOptions: PickerOptions,
     format: Intl.DateTimeFormatOptions
 ) => {
@@ -134,13 +148,25 @@ const localiseMonth = (
         localeOptions.locale
     )
 
-    return isCustom
-        ? customLocale?.monthNames[zdt.month! - 1]
-        : zdt.toLocaleString(localeOptions.locale, format)
+    if (isCustom) {
+        return customLocale?.monthNames[(zdt.month as number) - 1]
+    }
+
+    const targetCalendar =
+        (format as { calendar?: string }).calendar ?? localeOptions.calendar
+    const reprojected =
+        zdt instanceof Temporal.ZonedDateTime
+            ? zdt
+                  .toPlainDate()
+                  .withCalendar(targetCalendar as Temporal.CalendarLike)
+            : zdt instanceof Temporal.PlainDate
+            ? zdt.withCalendar(targetCalendar as Temporal.CalendarLike)
+            : (zdt as Temporal.PlainDate)
+    return reprojected.toLocaleString(localeOptions.locale, format)
 }
 
 export const localiseWeekDayLabel = (
-    zdt: Temporal.ZonedDateTime,
+    zdt: CalendarZonedDateTime,
     localeOptions: PickerOptionsWithResolvedCalendar
 ) => {
     if (!localeOptions.calendar) {
@@ -154,16 +180,21 @@ export const localiseWeekDayLabel = (
     )
     const customDayString = customCalendar?.dayNamesShort[zdt.dayOfWeek - 1] // dayOfWeek is 1-based
 
-    return isCustom && customDayString
-        ? customDayString
-        : zdt.toPlainDate().toLocaleString(localeOptions.locale, {
-              weekday: localeOptions.weekDayFormat,
-              calendar: localeOptions.calendar,
-          })
+    if (isCustom && customDayString) {
+        return customDayString
+    }
+
+    return (zdt as Temporal.ZonedDateTime)
+        .toPlainDate()
+        .withCalendar(localeOptions.calendar as Temporal.CalendarLike)
+        .toLocaleString(localeOptions.locale, {
+            weekday: localeOptions.weekDayFormat,
+            calendar: localeOptions.calendar,
+        })
 }
 
 export const localiseYear = (
-    zdt: Temporal.ZonedDateTime,
+    zdt: CalendarZonedDateTime,
     localeOptions: PickerOptions,
     format: Intl.DateTimeFormatOptions
 ) => {
@@ -172,9 +203,23 @@ export const localiseYear = (
     }
     const isCustom = isCustomCalendar(localeOptions.calendar)
 
-    return isCustom
-        ? zdt.year
-        : zdt.toPlainYearMonth().toLocaleString(localeOptions.locale, format)
+    if (isCustom) {
+        return zdt.year
+    }
+
+    if (isNepaliZonedDateTime(zdt) || isNepaliPlainDate(zdt)) {
+        return zdt.year
+    }
+
+    // `@js-temporal/polyfill` 0.5.x rejects formatting a PlainYearMonth in a
+    // calendar that differs from `format.calendar`, so reproject first.
+    const targetCalendar =
+        (format as { calendar?: string }).calendar ?? localeOptions.calendar
+    return (zdt as Temporal.ZonedDateTime)
+        .toPlainDate()
+        .withCalendar(targetCalendar as Temporal.CalendarLike)
+        .toPlainYearMonth()
+        .toLocaleString(localeOptions.locale, format)
 }
 const localisationHelpers = {
     localiseYear,

--- a/src/utils/validate-date-string.ts
+++ b/src/utils/validate-date-string.ts
@@ -1,9 +1,12 @@
 import i18n from '@dhis2/d2-i18n'
-import { Temporal } from '@js-temporal/polyfill'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
+import {
+    CalendarPlainDate,
+    comparePlainDates,
+    plainDateFrom,
+} from '../custom-calendars'
 import type { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
-import { getCustomCalendarIfExists, isCustomCalendar } from './helpers'
 
 type ValidationOptions = {
     calendar?: SupportedCalendar
@@ -59,9 +62,7 @@ export const validateDateString: ValidateDateStringFn = (
         strictValidation = true,
         format,
     } = options
-    const resolvedCalendar = getCustomCalendarIfExists(
-        dhis2CalendarsMap[calendar] ?? calendar
-    )
+    const resolvedCalendar = dhis2CalendarsMap[calendar] ?? calendar
 
     // Will throw if the format of the date is incorrect
     if (!dateString) {
@@ -91,19 +92,13 @@ export const validateDateString: ValidateDateStringFn = (
         }
     }
 
-    let date: Temporal.PlainDate
+    let date: CalendarPlainDate
 
     // Will throw if the year, month or day is out of range
     try {
-        date = isCustomCalendar(resolvedCalendar)
-            ? Temporal.Calendar.from(resolvedCalendar).dateFromFields(
-                  dateParts,
-                  { overflow: 'reject' }
-              ) // need to be handled separately for custom calendars
-            : Temporal.PlainDate.from(
-                  { ...dateParts, calendar: resolvedCalendar },
-                  { overflow: 'reject' }
-              )
+        date = plainDateFrom(dateParts, resolvedCalendar, {
+            overflow: 'reject',
+        })
     } catch (err) {
         return {
             valid: false,
@@ -119,12 +114,9 @@ export const validateDateString: ValidateDateStringFn = (
 
     if (minDateString) {
         const minDateParts = extractDatePartsFromDateString(minDateString)
-        const minDate = Temporal.PlainDate.from({
-            ...minDateParts,
-            calendar: resolvedCalendar,
-        })
+        const minDate = plainDateFrom(minDateParts, resolvedCalendar)
 
-        if (Temporal.PlainDate.compare(date, minDate) < 0) {
+        if (comparePlainDates(date, minDate) < 0) {
             const result: ValidationResult = {
                 ...validationType,
                 validationCode: DateValidationResult.LESS_THAN_MIN,
@@ -140,12 +132,9 @@ export const validateDateString: ValidateDateStringFn = (
 
     if (maxDateString) {
         const maxDateParts = extractDatePartsFromDateString(maxDateString)
-        const maxDate = Temporal.PlainDate.from({
-            ...maxDateParts,
-            calendar: resolvedCalendar,
-        })
+        const maxDate = plainDateFrom(maxDateParts, resolvedCalendar)
 
-        if (Temporal.PlainDate.compare(date, maxDate) > 0) {
+        if (comparePlainDates(date, maxDate) > 0) {
             const result: ValidationResult = {
                 ...validationType,
                 validationCode: DateValidationResult.MORE_THAN_MAX,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,7 +2872,14 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@js-temporal/polyfill@0.4.3", "@js-temporal/polyfill@^0.4.2":
+"@js-temporal/polyfill@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.5.1.tgz#c9726fdb7fbdbc6419292ba94294b10a08852c32"
+  integrity sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==
+  dependencies:
+    jsbi "^4.3.0"
+
+"@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
   integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==
@@ -9745,6 +9752,11 @@ jsbi@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
   integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
+
+jsbi@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.2.tgz#8a4d05d4e09907d73042135b6aa55a6d161ee955"
+  integrity sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
This is a big AI attempt to upgrade to `@js-temporal/polyfill`, and it required remaking the Nepali calendar since the `Temporal.Calendar` object no longer exists. All the tests and type checks pass, and it seems to be at least mostly working when dropped into the UI library/storybook, but I think there are still things to iron out for the Nepali calendar (like `timeZone is undefined` errors)

Haven't looked through it thoroughly yet, but it might be useful. Here's the full Claude Code output:

---
# Upgrade: `@js-temporal/polyfill` 0.4.3 → 0.5.1

## Validation

- **Jest:** 22 suites, 407 tests passing (matches the 0.4.3 baseline; 4 pre-existing skips)
- **Cucumber:** 52 scenarios, 187 steps passing
- **TypeScript:** `tsc --noEmit` clean
- **Lint:** 0 errors (4 pre-existing `any` warnings in `convert-date.spec.ts` / `validate-date-string.ts`)
- **Build:** `yarn build` succeeds (package + `.d.ts`)

## Breaking changes in 0.5.1 that drove the work

The 0.5.0 release (June 2024 TC39) cut Temporal's scope at engine-implementer request, with cascading effects here:

| 0.4.3 API | 0.5.x replacement |
|---|---|
| `Temporal.Calendar` class + subclassing | **removed entirely** — calendars are strings only |
| `Temporal.CalendarProtocol` / `CalendarLike: object` | only `string \| <existing Temporal value>` |
| `Temporal.TimeZone` class, `Temporal.TimeZone.from` | gone — use string ids |
| `.calendar`, `.timeZone` (object getters) | `.calendarId`, `.timeZoneId` (strings) |
| `getISOFields()` | `.withCalendar('iso8601')` + individual getters |
| `zdt.toPlainYearMonth()` / `toPlainMonthDay()` | go via `.toPlainDate()` first |
| Ethiopic era code `'era1'` | `'ethiopic'` (and `'ethioaa'` for the older era) |
| `Temporal.YearOrEraAndEraYear` / `MonthOrMonthCode` types | not exported anymore |
| Islamic `eraYear` getter | now returns `undefined` (we fall back to `year`) |
| `Temporal.ZonedDateTime.from({...})` without `timeZone` | now throws — `timeZone` is required |
| Mixed-calendar `toLocaleString({calendar: X})` | rejected — date must already be in the target calendar |

## How Nepali (the custom calendar) was preserved

This was the hard part — 0.5.x has **no in-polyfill way** to register a user calendar. The Nepali implementation in `src/custom-calendars/nepaliCalendar.ts` is now a pair of **shadow types** that live outside Temporal:

- `NepaliPlainDate` and `NepaliZonedDateTime` mirror the `Temporal.PlainDate` / `ZonedDateTime` API surface the library uses (year/month/day/eraYear/daysInMonth/dayOfWeek/dayOfYear/monthsInYear/calendarId, plus `with`, `add`, `subtract`, `equals`, `since`, `withCalendar`, `toIso`/`toPlainDate`, `toString`, `toLocaleString`, `toPlainYearMonth`).
- Each instance holds an iso8601-backed Temporal value (for the heavy lifting and timezone math) and cached Nepali fields. The `_isoToNepali` / `_nepaliToIso` conversion logic and the `NEPALI_CALENDAR_DATA` table are unchanged from 0.4.x.
- A new module `src/custom-calendars/calendar-routing.ts` exposes polymorphic helpers — `plainDateFrom`, `zonedDateTimeFrom`, `withCalendar`, `zonedDateTimeWithCalendar`, `comparePlainDates` — that branch on `'nepali'` and return the right type. The rest of the library (hooks, period generation, validators) consumes these instead of `Temporal.PlainDate.from({calendar: ...})` or `.withCalendar(...)`.

## Public-API impact for downstream consumers

Most exports are calendar-agnostic and unchanged. Two surface-level changes affect anyone who imports types directly:

1. **`NepaliCalendar` class is gone.** It was a `Temporal.Calendar` subclass that can't exist in 0.5.x. Replaced by `NepaliPlainDate` / `NepaliZonedDateTime` shadow classes (not currently re-exported from `src/index.ts` — they're internal). The `customCalendars` map no longer contains a `calendar:` field; only `locales` + `defaultLocale`.
2. **`PickerOptionsWithResolvedCalendar.calendar`** is now `SupportedCalendar` (string) instead of `Temporal.CalendarProtocol`. Consumers passing this type need to update.

Likely consumer code (`@dhis2/ui` Calendar / CalendarInput) shouldn't be affected unless it imports `NepaliCalendar` directly. Worth a manual smoke-test against `@dhis2/ui` before publishing.

## Behavioral notes worth flagging

- `convertFromIso8601` now returns `eraYear: year` as a fallback when the polyfill omits it (Islamic calendar in particular), preserving the existing contract.
- `useDatePicker` re-projects `firstZdtOfVisibleMonth` to the active calendar before passing it into `useNavigation` / `useCalendarWeekDays`. This was implicit in 0.4.x (because `.toLocaleString({calendar:X})` did silent reprojection) and is now explicit.
- `Temporal.ZonedDateTime.from({calendar: 'ethiopic', year, era: 'ethiopic'})` raises if both `year` and `era`/`eraYear` are present and inconsistent. `useDatePicker` now picks one form per calendar.
