### PR TITLE
feat: shorten weekly period display labels

### DIFF
--- a/.github/workflows/dhis2-verify-commits.yml.yml
+++ b/.github/workflows/dhis2-verify-commits.yml.yml
@@ -9,7 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -24,7 +23,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -112,13 +112,9 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [build, lint, test]
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
-        # if:
-        #   "!contains(github.event.head_commit.message, '[skip ci]') && contains('
-        #     refs/heads/main
-        #     refs/heads/next
-        #     refs/heads/beta
-        #   ', github.ref)"
+        if: >
+            !contains(github.event.head_commit.message, '[skip ci]') &&
+            contains(' refs/heads/main refs/heads/next refs/heads/beta ', github.ref)
         steps:
             - uses: actions/checkout@v3
               with:

--- a/features/fixed-periods.ethiopic.feature
+++ b/features/fixed-periods.ethiopic.feature
@@ -66,70 +66,70 @@ Feature: Ethiopic Calendar fixed periods
         When the user requests "weekly" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2015-01-03 - 2015-01-09  | 2015W1      |
-            | 2           | Week 2 - 2015-01-10 - 2015-01-16  | 2015W2      |
-            | 3           | Week 3 - 2015-01-17 - 2015-01-23  | 2015W3      |
-            | 51          | Week 51 - 2015-12-23 - 2015-12-29 | 2015W51     |
-            | 52          | Week 52 - 2015-12-30 - 2015-13-06 | 2015W52     |
+            | 1           | Week 1  | 2015W1      |
+            | 2           | Week 2  | 2015W2      |
+            | 3           | Week 3  | 2015W3      |
+            | 51          | Week 51 | 2015W51     |
+            | 52          | Week 52 | 2015W52     |
 
     Scenario: Generate Weekly Periods (Starting Wednesday)
         When the user requests "WEEKLYWED" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2014-13-03 - 2015-01-04  | 2015WedW1   |
-            | 2           | Week 2 - 2015-01-05 - 2015-01-11  | 2015WedW2   |
-            | 3           | Week 3 - 2015-01-12 - 2015-01-18  | 2015WedW3   |
-            | 51          | Week 51 - 2015-12-18 - 2015-12-24 | 2015WedW51  |
-            | 52          | Week 52 - 2015-12-25 - 2015-13-01 | 2015WedW52  |
-            | 53          | Week 53 - 2015-13-02 - 2016-01-02 | 2015WedW53  |
+            | 1           | Week 1  | 2015WedW1   |
+            | 2           | Week 2  | 2015WedW2   |
+            | 3           | Week 3  | 2015WedW3   |
+            | 51          | Week 51 | 2015WedW51  |
+            | 52          | Week 52 | 2015WedW52  |
+            | 53          | Week 53 | 2015WedW53  |
 
     Scenario: Generate Weekly Periods (Starting Thursday)
         When the user requests "WEEKLYTHU" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2014-13-04 - 2015-01-05  | 2015ThuW1   |
-            | 2           | Week 2 - 2015-01-06 - 2015-01-12  | 2015ThuW2   |
-            | 3           | Week 3 - 2015-01-13 - 2015-01-19  | 2015ThuW3   |
-            | 50          | Week 50 - 2015-12-12 - 2015-12-18 | 2015ThuW50  |
-            | 51          | Week 51 - 2015-12-19 - 2015-12-25 | 2015ThuW51  |
-            | 52          | Week 52 - 2015-12-26 - 2015-13-02 | 2015ThuW52  |
-            | 53          | Week 53 - 2015-13-03 - 2016-01-03 | 2015ThuW53  |
+            | 1           | Week 1  | 2015ThuW1   |
+            | 2           | Week 2  | 2015ThuW2   |
+            | 3           | Week 3  | 2015ThuW3   |
+            | 50          | Week 50 | 2015ThuW50  |
+            | 51          | Week 51 | 2015ThuW51  |
+            | 52          | Week 52 | 2015ThuW52  |
+            | 53          | Week 53 | 2015ThuW53  |
 
     @abyot # should the last week here be added or not? (most of it is in the next year)
     Scenario: Generate Weekly Periods (Starting Saturday)
         When the user requests "WEEKLYSAT" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2015-01-01 - 2015-01-07  | 2015SatW1   |
-            | 2           | Week 2 - 2015-01-08 - 2015-01-14  | 2015SatW2   |
-            | 3           | Week 3 - 2015-01-15 - 2015-01-21  | 2015SatW3   |
-            | 50          | Week 50 - 2015-12-14 - 2015-12-20 | 2015SatW50  |
-            | 51          | Week 51 - 2015-12-21 - 2015-12-27 | 2015SatW51  |
-            | 52          | Week 52 - 2015-12-28 - 2015-13-04 | 2015SatW52  |
+            | 1           | Week 1  | 2015SatW1   |
+            | 2           | Week 2  | 2015SatW2   |
+            | 3           | Week 3  | 2015SatW3   |
+            | 50          | Week 50 | 2015SatW50  |
+            | 51          | Week 51 | 2015SatW51  |
+            | 52          | Week 52 | 2015SatW52  |
 
     @abyot # same - should the last week here be added or not?
     Scenario: Generate Weekly Periods (Starting Sunday)
         When the user requests "WEEKLYSUN" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2015-01-02 - 2015-01-08  | 2015SunW1   |
-            | 2           | Week 2 - 2015-01-09 - 2015-01-15  | 2015SunW2   |
-            | 3           | Week 3 - 2015-01-16 - 2015-01-22  | 2015SunW3   |
-            | 50          | Week 50 - 2015-12-15 - 2015-12-21 | 2015SunW50  |
-            | 51          | Week 51 - 2015-12-22 - 2015-12-28 | 2015SunW51  |
-            | 52          | Week 52 - 2015-12-29 - 2015-13-05 | 2015SunW52  |
+            | 1           | Week 1  | 2015SunW1   |
+            | 2           | Week 2  | 2015SunW2   |
+            | 3           | Week 3  | 2015SunW3   |
+            | 50          | Week 50 | 2015SunW50  |
+            | 51          | Week 51 | 2015SunW51  |
+            | 52          | Week 52 | 2015SunW52  |
 
     @abyot # could you confirm what we want to do with the 13th month in bi-weekly? does the last item here period#26 look correct to you?
     Scenario: Generate Bi-Weekly Periods
         When the user requests "BIWEEKLY" periods for "2015"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                          | periodValue |
-            | 1           | Bi-Week 1 - 2015-01-03 - 2015-01-16  | 2015BiW1    |
-            | 2           | Bi-Week 2 - 2015-01-17 - 2015-01-30  | 2015BiW2    |
-            | 3           | Bi-Week 3 - 2015-02-01 - 2015-02-14  | 2015BiW3    |
-            | 24          | Bi-Week 24 - 2015-11-25 - 2015-12-08 | 2015BiW24   |
-            | 25          | Bi-Week 25 - 2015-12-09 - 2015-12-22 | 2015BiW25   |
-            | 26          | Bi-Week 26 - 2015-12-23 - 2015-13-06 | 2015BiW26   |
+            | 1           | Bi-Week 1  | 2015BiW1    |
+            | 2           | Bi-Week 2  | 2015BiW2    |
+            | 3           | Bi-Week 3  | 2015BiW3    |
+            | 24          | Bi-Week 24 | 2015BiW24   |
+            | 25          | Bi-Week 25 | 2015BiW25   |
+            | 26          | Bi-Week 26 | 2015BiW26   |
 
     Scenario: Generate Bi-Monthly Periods
         When the user requests "BIMONTHLY" periods for "2015"

--- a/features/fixed-periods.gregorian.feature
+++ b/features/fixed-periods.gregorian.feature
@@ -52,66 +52,66 @@ Feature: Gregorian Calendar fixed periods
         When the user requests "weekly" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2022-01-03 - 2022-01-09  | 2022W1      |
-            | 2           | Week 2 - 2022-01-10 - 2022-01-16  | 2022W2      |
-            | 3           | Week 3 - 2022-01-17 - 2022-01-23  | 2022W3      |
-            | 51          | Week 51 - 2022-12-19 - 2022-12-25 | 2022W51     |
-            | 52          | Week 52 - 2022-12-26 - 2023-01-01 | 2022W52     |
+            | 1           | Week 1  | 2022W1      |
+            | 2           | Week 2  | 2022W2      |
+            | 3           | Week 3  | 2022W3      |
+            | 51          | Week 51 | 2022W51     |
+            | 52          | Week 52 | 2022W52     |
 
     Scenario: Generate Weekly Periods (Starting Wednesday)
         # Weekly starting Wednesday
         When the user requests "WEEKLYWED" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2021-12-29 - 2022-01-04  | 2022WedW1   |
-            | 2           | Week 2 - 2022-01-05 - 2022-01-11  | 2022WedW2   |
-            | 3           | Week 3 - 2022-01-12 - 2022-01-18  | 2022WedW3   |
-            | 51          | Week 51 - 2022-12-14 - 2022-12-20 | 2022WedW51  |
-            | 52          | Week 52 - 2022-12-21 - 2022-12-27 | 2022WedW52  |
-            | 53          | Week 53 - 2022-12-28 - 2023-01-03 | 2022WedW53  |
+            | 1           | Week 1  | 2022WedW1   |
+            | 2           | Week 2  | 2022WedW2   |
+            | 3           | Week 3  | 2022WedW3   |
+            | 51          | Week 51 | 2022WedW51  |
+            | 52          | Week 52 | 2022WedW52  |
+            | 53          | Week 53 | 2022WedW53  |
 
     Scenario: Generate Weekly Periods (Starting Thursday)
         When the user requests "WEEKLYTHU" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2021-12-30 - 2022-01-05  | 2022ThuW1   |
-            | 2           | Week 2 - 2022-01-06 - 2022-01-12  | 2022ThuW2   |
-            | 3           | Week 3 - 2022-01-13 - 2022-01-19  | 2022ThuW3   |
-            | 50          | Week 50 - 2022-12-08 - 2022-12-14 | 2022ThuW50  |
-            | 51          | Week 51 - 2022-12-15 - 2022-12-21 | 2022ThuW51  |
-            | 52          | Week 52 - 2022-12-22 - 2022-12-28 | 2022ThuW52  |
+            | 1           | Week 1  | 2022ThuW1   |
+            | 2           | Week 2  | 2022ThuW2   |
+            | 3           | Week 3  | 2022ThuW3   |
+            | 50          | Week 50 | 2022ThuW50  |
+            | 51          | Week 51 | 2022ThuW51  |
+            | 52          | Week 52 | 2022ThuW52  |
 
     Scenario: Generate Weekly Periods (Starting Saturday)
         When the user requests "WEEKLYSAT" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2022-01-01 - 2022-01-07  | 2022SatW1   |
-            | 2           | Week 2 - 2022-01-08 - 2022-01-14  | 2022SatW2   |
-            | 3           | Week 3 - 2022-01-15 - 2022-01-21  | 2022SatW3   |
-            | 50          | Week 50 - 2022-12-10 - 2022-12-16 | 2022SatW50  |
-            | 51          | Week 51 - 2022-12-17 - 2022-12-23 | 2022SatW51  |
-            | 52          | Week 52 - 2022-12-24 - 2022-12-30 | 2022SatW52  |
+            | 1           | Week 1  | 2022SatW1   |
+            | 2           | Week 2  | 2022SatW2   |
+            | 3           | Week 3  | 2022SatW3   |
+            | 50          | Week 50 | 2022SatW50  |
+            | 51          | Week 51 | 2022SatW51  |
+            | 52          | Week 52 | 2022SatW52  |
     Scenario: Generate Weekly Periods (Starting Sunday)
         When the user requests "WEEKLYSUN" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2022-01-02 - 2022-01-08  | 2022SunW1   |
-            | 2           | Week 2 - 2022-01-09 - 2022-01-15  | 2022SunW2   |
-            | 3           | Week 3 - 2022-01-16 - 2022-01-22  | 2022SunW3   |
-            | 50          | Week 50 - 2022-12-11 - 2022-12-17 | 2022SunW50  |
-            | 51          | Week 51 - 2022-12-18 - 2022-12-24 | 2022SunW51  |
-            | 52          | Week 52 - 2022-12-25 - 2022-12-31 | 2022SunW52  |
+            | 1           | Week 1  | 2022SunW1   |
+            | 2           | Week 2  | 2022SunW2   |
+            | 3           | Week 3  | 2022SunW3   |
+            | 50          | Week 50 | 2022SunW50  |
+            | 51          | Week 51 | 2022SunW51  |
+            | 52          | Week 52 | 2022SunW52  |
 
     Scenario: Generate Bi-Weekly Periods
         When the user requests "BIWEEKLY" periods for "2022"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                          | periodValue |
-            | 1           | Bi-Week 1 - 2022-01-03 - 2022-01-16  | 2022BiW1    |
-            | 2           | Bi-Week 2 - 2022-01-17 - 2022-01-30  | 2022BiW2    |
-            | 3           | Bi-Week 3 - 2022-01-31 - 2022-02-13  | 2022BiW3    |
-            | 24          | Bi-Week 24 - 2022-11-21 - 2022-12-04 | 2022BiW24   |
-            | 25          | Bi-Week 25 - 2022-12-05 - 2022-12-18 | 2022BiW25   |
-            | 26          | Bi-Week 26 - 2022-12-19 - 2023-01-01 | 2022BiW26   |
+            | 1           | Bi-Week 1  | 2022BiW1    |
+            | 2           | Bi-Week 2  | 2022BiW2    |
+            | 3           | Bi-Week 3  | 2022BiW3    |
+            | 24          | Bi-Week 24 | 2022BiW24   |
+            | 25          | Bi-Week 25 | 2022BiW25   |
+            | 26          | Bi-Week 26 | 2022BiW26   |
 
     Scenario: Generate Bi-Monthly Periods
         When the user requests "BIMONTHLY" periods for "2022"

--- a/features/fixed-periods.nepali.feature
+++ b/features/fixed-periods.nepali.feature
@@ -81,67 +81,67 @@ Feature: Nepali Calendar fixed periods
         When the user requests "weekly" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2077-12-30 - 2078-01-05  | 2078W1      |
-            | 2           | Week 2 - 2078-01-06 - 2078-01-12  | 2078W2      |
-            | 3           | Week 3 - 2078-01-13 - 2078-01-19  | 2078W3      |
-            | 51          | Week 51 - 2078-12-14 - 2078-12-20 | 2078W51     |
-            | 52          | Week 52 - 2078-12-21 - 2078-12-27 | 2078W52     |
+            | 1           | Week 1  | 2078W1      |
+            | 2           | Week 2  | 2078W2      |
+            | 3           | Week 3  | 2078W3      |
+            | 51          | Week 51 | 2078W51     |
+            | 52          | Week 52 | 2078W52     |
 
 
     Scenario: Generate Weekly Periods (Starting Wednesday)
         When the user requests "WEEKLYWED" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2078-01-01 - 2078-01-07  | 2078WedW1   |
-            | 2           | Week 2 - 2078-01-08 - 2078-01-14  | 2078WedW2   |
-            | 3           | Week 3 - 2078-01-15 - 2078-01-21  | 2078WedW3   |
-            | 51          | Week 51 - 2078-12-16 - 2078-12-22 | 2078WedW51  |
-            | 52          | Week 52 - 2078-12-23 - 2078-12-29 | 2078WedW52  |
+            | 1           | Week 1  | 2078WedW1   |
+            | 2           | Week 2  | 2078WedW2   |
+            | 3           | Week 3  | 2078WedW3   |
+            | 51          | Week 51 | 2078WedW51  |
+            | 52          | Week 52 | 2078WedW52  |
 
     Scenario: Generate Weekly Periods (Starting Thursday)
         When the user requests "WEEKLYTHU" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2078-01-02 - 2078-01-08  | 2078ThuW1   |
-            | 2           | Week 2 - 2078-01-09 - 2078-01-15  | 2078ThuW2   |
-            | 3           | Week 3 - 2078-01-16 - 2078-01-22  | 2078ThuW3   |
-            | 50          | Week 50 - 2078-12-10 - 2078-12-16 | 2078ThuW50  |
-            | 51          | Week 51 - 2078-12-17 - 2078-12-23 | 2078ThuW51  |
-            | 52          | Week 52 - 2078-12-24 - 2078-12-30 | 2078ThuW52  |
+            | 1           | Week 1  | 2078ThuW1   |
+            | 2           | Week 2  | 2078ThuW2   |
+            | 3           | Week 3  | 2078ThuW3   |
+            | 50          | Week 50 | 2078ThuW50  |
+            | 51          | Week 51 | 2078ThuW51  |
+            | 52          | Week 52 | 2078ThuW52  |
 
     Scenario: Generate Weekly Periods (Starting Saturday)
         When the user requests "WEEKLYSAT" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2078-01-04 - 2078-01-10  | 2078SatW1   |
-            | 2           | Week 2 - 2078-01-11 - 2078-01-17  | 2078SatW2   |
-            | 3           | Week 3 - 2078-01-18 - 2078-01-24  | 2078SatW3   |
-            | 50          | Week 50 - 2078-12-12 - 2078-12-18 | 2078SatW50  |
-            | 51          | Week 51 - 2078-12-19 - 2078-12-25 | 2078SatW51  |
-            | 52          | Week 52 - 2078-12-26 - 2079-01-02 | 2078SatW52  |
+            | 1           | Week 1  | 2078SatW1   |
+            | 2           | Week 2  | 2078SatW2   |
+            | 3           | Week 3  | 2078SatW3   |
+            | 50          | Week 50 | 2078SatW50  |
+            | 51          | Week 51 | 2078SatW51  |
+            | 52          | Week 52 | 2078SatW52  |
 
     Scenario: Generate Weekly Periods (Starting Sunday)
         When the user requests "WEEKLYSUN" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                       | periodValue |
-            | 1           | Week 1 - 2077-12-29 - 2078-01-04  | 2078SunW1   |
-            | 2           | Week 2 - 2078-01-05 - 2078-01-11  | 2078SunW2   |
-            | 3           | Week 3 - 2078-01-12 - 2078-01-18  | 2078SunW3   |
-            | 50          | Week 50 - 2078-12-06 - 2078-12-12 | 2078SunW50  |
-            | 51          | Week 51 - 2078-12-13 - 2078-12-19 | 2078SunW51  |
-            | 52          | Week 52 - 2078-12-20 - 2078-12-26 | 2078SunW52  |
-            | 53          | Week 53 - 2078-12-27 - 2079-01-03 | 2078SunW53  |
+            | 1           | Week 1  | 2078SunW1   |
+            | 2           | Week 2  | 2078SunW2   |
+            | 3           | Week 3  | 2078SunW3   |
+            | 50          | Week 50 | 2078SunW50  |
+            | 51          | Week 51 | 2078SunW51  |
+            | 52          | Week 52 | 2078SunW52  |
+            | 53          | Week 53 | 2078SunW53  |
 
     Scenario: Generate Bi-Weekly Periods
         When the user requests "BIWEEKLY" periods for "2078"
         Then the dates for the period type should be generated
             | periodIndex | periodLabel                          | periodValue |
-            | 1           | Bi-Week 1 - 2077-12-30 - 2078-01-12  | 2078BiW1    |
-            | 2           | Bi-Week 2 - 2078-01-13 - 2078-01-26  | 2078BiW2    |
-            | 3           | Bi-Week 3 - 2078-01-27 - 2078-02-09  | 2078BiW3    |
-            | 24          | Bi-Week 24 - 2078-11-16 - 2078-11-29 | 2078BiW24   |
-            | 25          | Bi-Week 25 - 2078-11-30 - 2078-12-13 | 2078BiW25   |
-            | 26          | Bi-Week 26 - 2078-12-14 - 2078-12-27 | 2078BiW26   |
+            | 1           | Bi-Week 1  | 2078BiW1    |
+            | 2           | Bi-Week 2  | 2078BiW2    |
+            | 3           | Bi-Week 3  | 2078BiW3    |
+            | 24          | Bi-Week 24 | 2078BiW24   |
+            | 25          | Bi-Week 25 | 2078BiW25   |
+            | 26          | Bi-Week 26 | 2078BiW26   |
 
     Scenario: Generate Bi-Monthly Periods
         When the user requests "BIMONTHLY" periods for "2078"

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ethiopic.spec.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ethiopic.spec.ts
@@ -357,8 +357,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2015-01-03 - 2015-01-09',
-                displayName: 'Week 1 - 2015-01-03 - 2015-01-09',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015W1',
                 iso: '2015W1',
                 startDate: '2015-01-03',
@@ -376,8 +376,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'BIWEEKLY',
-                name: 'Bi-Week 1 - 2015-01-03 - 2015-01-16',
-                displayName: 'Bi-Week 1 - 2015-01-03 - 2015-01-16',
+                name: 'Bi-Week 1',
+                displayName: 'Bi-Week 1',
                 id: '2015BiW1',
                 iso: '2015BiW1',
                 startDate: '2015-01-03',
@@ -395,8 +395,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYWED',
-                name: 'Week 1 - 2014-13-03 - 2015-01-04',
-                displayName: 'Week 1 - 2014-13-03 - 2015-01-04',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015WedW1',
                 iso: '2015WedW1',
                 startDate: '2014-13-03',
@@ -414,8 +414,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYTHU',
-                name: 'Week 1 - 2014-13-04 - 2015-01-05',
-                displayName: 'Week 1 - 2014-13-04 - 2015-01-05',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015ThuW1',
                 iso: '2015ThuW1',
                 startDate: '2014-13-04',
@@ -433,8 +433,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSAT',
-                name: 'Week 1 - 2015-01-01 - 2015-01-07',
-                displayName: 'Week 1 - 2015-01-01 - 2015-01-07',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015SatW1',
                 iso: '2015SatW1',
                 startDate: '2015-01-01',
@@ -452,8 +452,8 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSUN',
-                name: 'Week 1 - 2015-01-02 - 2015-01-08',
-                displayName: 'Week 1 - 2015-01-02 - 2015-01-08',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015SunW1',
                 iso: '2015SunW1',
                 startDate: '2015-01-02',

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.gregorian.spec.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.gregorian.spec.ts
@@ -356,8 +356,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2023-01-02 - 2023-01-08',
-                displayName: 'Week 1 - 2023-01-02 - 2023-01-08',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023W1',
                 iso: '2023W1',
                 startDate: '2023-01-02',
@@ -375,8 +375,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'BIWEEKLY',
-                name: 'Bi-Week 1 - 2023-01-02 - 2023-01-15',
-                displayName: 'Bi-Week 1 - 2023-01-02 - 2023-01-15',
+                name: 'Bi-Week 1',
+                displayName: 'Bi-Week 1',
                 id: '2023BiW1',
                 iso: '2023BiW1',
                 startDate: '2023-01-02',
@@ -394,8 +394,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYWED',
-                name: 'Week 1 - 2023-01-04 - 2023-01-10',
-                displayName: 'Week 1 - 2023-01-04 - 2023-01-10',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023WedW1',
                 iso: '2023WedW1',
                 startDate: '2023-01-04',
@@ -413,8 +413,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYTHU',
-                name: 'Week 1 - 2022-12-29 - 2023-01-04',
-                displayName: 'Week 1 - 2022-12-29 - 2023-01-04',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023ThuW1',
                 iso: '2023ThuW1',
                 startDate: '2022-12-29',
@@ -432,8 +432,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSAT',
-                name: 'Week 1 - 2022-12-31 - 2023-01-06',
-                displayName: 'Week 1 - 2022-12-31 - 2023-01-06',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023SatW1',
                 iso: '2023SatW1',
                 startDate: '2022-12-31',
@@ -451,8 +451,8 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSUN',
-                name: 'Week 1 - 2023-01-01 - 2023-01-07',
-                displayName: 'Week 1 - 2023-01-01 - 2023-01-07',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023SunW1',
                 iso: '2023SunW1',
                 startDate: '2023-01-01',

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.nepali.spec.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.nepali.spec.ts
@@ -280,8 +280,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2078-12-28 - 2079-01-04',
-                displayName: 'Week 1 - 2078-12-28 - 2079-01-04',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079W1',
                 iso: '2079W1',
                 startDate: '2078-12-28',
@@ -299,8 +299,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'BIWEEKLY',
-                name: 'Bi-Week 1 - 2078-12-28 - 2079-01-11',
-                displayName: 'Bi-Week 1 - 2078-12-28 - 2079-01-11',
+                name: 'Bi-Week 1',
+                displayName: 'Bi-Week 1',
                 id: '2079BiW1',
                 iso: '2079BiW1',
                 startDate: '2078-12-28',
@@ -318,8 +318,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYWED',
-                name: 'Week 1 - 2078-12-30 - 2079-01-06',
-                displayName: 'Week 1 - 2078-12-30 - 2079-01-06',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079WedW1',
                 iso: '2079WedW1',
                 startDate: '2078-12-30',
@@ -337,8 +337,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYTHU',
-                name: 'Week 1 - 2079-01-01 - 2079-01-07',
-                displayName: 'Week 1 - 2079-01-01 - 2079-01-07',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079ThuW1',
                 iso: '2079ThuW1',
                 startDate: '2079-01-01',
@@ -356,8 +356,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSAT',
-                name: 'Week 1 - 2079-01-03 - 2079-01-09',
-                displayName: 'Week 1 - 2079-01-03 - 2079-01-09',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079SatW1',
                 iso: '2079SatW1',
                 startDate: '2079-01-03',
@@ -375,8 +375,8 @@ describe('Nepali/createFixedPeriodFromPeriodId', () => {
 
             const expected = {
                 periodType: 'WEEKLYSUN',
-                name: 'Week 1 - 2079-01-04 - 2079-01-10',
-                displayName: 'Week 1 - 2079-01-04 - 2079-01-10',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079SunW1',
                 iso: '2079SunW1',
                 startDate: '2079-01-04',

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
 import { Temporal } from '@js-temporal/polyfill'
 import { SupportedCalendar } from '../../types'
-import { fromAnyDate, formatDate, padWithZeroes } from '../../utils/index'
+import { fromAnyDate, formatDate } from '../../utils/index'
 import { FixedPeriod, PeriodType } from '../types'
 import doesPeriodEndBefore from './does-period-end-before'
 
@@ -72,8 +72,6 @@ const generateFixedPeriodsWeekly: GenerateFixedPeriodsWeekly = ({
         if (!(endofWeek.year === year + 1 && endofWeek.day >= 4)) {
             const name = buildLabel({
                 periodType,
-                date,
-                nextWeek: endofWeek,
                 weekIndex: i,
             })
             days.push({
@@ -172,27 +170,13 @@ const buildValue = ({
 
 type BuildLabelFunc = (options: {
     periodType: PeriodType
-    date: Temporal.PlainDate
-    nextWeek: Temporal.PlainDate
     weekIndex: number
 }) => string
 
-const buildLabel: BuildLabelFunc = ({
-    periodType,
-    date,
-    nextWeek,
-    weekIndex,
-}) => {
-    const { year, month, day } = date
-    const { year: nextYear, month: nextMonth, day: nextDay } = nextWeek
+const buildLabel: BuildLabelFunc = ({ periodType, weekIndex }) => {
     const prefix =
         periodType === 'BIWEEKLY' ? i18n.t('Bi-Week') : i18n.t('Week')
-    const label = `${prefix} ${weekIndex} - ${year}-${padWithZeroes(
-        month
-    )}-${padWithZeroes(day)} - ${nextYear}-${padWithZeroes(
-        nextMonth
-    )}-${padWithZeroes(nextDay)}`
-    return label
+    return `${prefix} ${weekIndex}`
 }
 
 export default generateFixedPeriodsWeekly

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
@@ -368,8 +368,8 @@ describe('Ethiopic Calendar fixed period calculation', () => {
             expect(results[results.length - 1]).toMatchObject({
                 id: '2014W26',
                 iso: '2014W26',
-                name: 'Week 26 - 2014-06-29 - 2014-07-05',
-                displayName: 'Week 26 - 2014-06-29 - 2014-07-05',
+                name: 'Week 26',
+                displayName: 'Week 26',
             })
         })
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import { SupportedCalendar } from '../../types'
 import generateFixedPeriods from './generate-fixed-periods'
 
@@ -77,8 +78,8 @@ describe('Gregorian Calendar fixed period calculation', () => {
             expect(results[results.length - 1]).toMatchObject({
                 id: '2014W27',
                 iso: '2014W27',
-                name: 'Week 27 - 2014-06-30 - 2014-07-06',
-                displayName: 'Week 27 - 2014-06-30 - 2014-07-06',
+                name: 'Week 27',
+                displayName: 'Week 27',
             })
         })
 
@@ -93,8 +94,8 @@ describe('Gregorian Calendar fixed period calculation', () => {
             expect(results[results.length - 1]).toMatchObject({
                 id: '2014W52',
                 iso: '2014W52',
-                name: 'Week 52 - 2014-12-22 - 2014-12-28',
-                displayName: 'Week 52 - 2014-12-22 - 2014-12-28',
+                name: 'Week 52',
+                displayName: 'Week 52',
             })
         })
         it('should start the year before if necessary', () => {
@@ -108,15 +109,95 @@ describe('Gregorian Calendar fixed period calculation', () => {
             expect(results[0]).toMatchObject({
                 id: '2014SunW1',
                 iso: '2014SunW1',
-                name: 'Week 1 - 2013-12-29 - 2014-01-04',
-                displayName: 'Week 1 - 2013-12-29 - 2014-01-04',
+                name: 'Week 1',
+                displayName: 'Week 1',
             })
             expect(results[52]).toMatchObject({
                 id: '2014SunW53',
                 iso: '2014SunW53',
-                name: 'Week 53 - 2014-12-28 - 2015-01-03',
-                displayName: 'Week 53 - 2014-12-28 - 2015-01-03',
+                name: 'Week 53',
+                displayName: 'Week 53',
             })
+        })
+
+        it('should return week title labels and preserve ranges for weekly variants', () => {
+            const weekly = generateFixedPeriods({
+                periodType: 'WEEKLY',
+                year: 2026,
+                calendar: 'gregory',
+                locale: 'en',
+                startingDay: 1,
+            })[0]
+            const weeklySun = generateFixedPeriods({
+                periodType: 'WEEKLYSUN',
+                year: 2026,
+                calendar: 'gregory',
+                locale: 'en',
+                startingDay: 1,
+            })[0]
+            const biWeekly = generateFixedPeriods({
+                periodType: 'BIWEEKLY',
+                year: 2026,
+                calendar: 'gregory',
+                locale: 'en',
+                startingDay: 1,
+            })[0]
+
+            expect(weekly).toEqual({
+                periodType: 'WEEKLY',
+                id: '2026W1',
+                iso: '2026W1',
+                name: 'Week 1',
+                displayName: 'Week 1',
+                startDate: '2025-12-29',
+                endDate: '2026-01-04',
+            })
+            expect(weeklySun).toEqual({
+                periodType: 'WEEKLYSUN',
+                id: '2026SunW1',
+                iso: '2026SunW1',
+                name: 'Week 1',
+                displayName: 'Week 1',
+                startDate: '2026-01-04',
+                endDate: '2026-01-10',
+            })
+            expect(biWeekly).toEqual({
+                periodType: 'BIWEEKLY',
+                id: '2026BiW1',
+                iso: '2026BiW1',
+                name: 'Bi-Week 1',
+                displayName: 'Bi-Week 1',
+                startDate: '2025-12-29',
+                endDate: '2026-01-11',
+            })
+        })
+
+        it('should use translated week prefixes without embedding ranges', () => {
+            const translate = jest
+                .spyOn(i18n, 't')
+                .mockImplementation((key: unknown) =>
+                    key === 'Week' ? 'Uke' : key
+                )
+
+            try {
+                const weekly = generateFixedPeriods({
+                    periodType: 'WEEKLY',
+                    year: 2026,
+                    calendar: 'gregory',
+                    locale: 'nb',
+                    startingDay: 1,
+                })[0]
+
+                expect(weekly).toMatchObject({
+                    name: 'Uke 1',
+                    displayName: 'Uke 1',
+                    startDate: '2025-12-29',
+                    endDate: '2026-01-04',
+                })
+                expect(translate).toHaveBeenCalledWith('Week')
+            } finally {
+                translate.mockRestore()
+            }
         })
     })
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
@@ -1,4 +1,3 @@
-import i18n from '@dhis2/d2-i18n'
 import { SupportedCalendar } from '../../types'
 import generateFixedPeriods from './generate-fixed-periods'
 
@@ -143,7 +142,7 @@ describe('Gregorian Calendar fixed period calculation', () => {
                 startingDay: 1,
             })[0]
 
-            expect(weekly).toEqual({
+            expect(weekly).toMatchObject({
                 periodType: 'WEEKLY',
                 id: '2026W1',
                 iso: '2026W1',
@@ -152,7 +151,7 @@ describe('Gregorian Calendar fixed period calculation', () => {
                 startDate: '2025-12-29',
                 endDate: '2026-01-04',
             })
-            expect(weeklySun).toEqual({
+            expect(weeklySun).toMatchObject({
                 periodType: 'WEEKLYSUN',
                 id: '2026SunW1',
                 iso: '2026SunW1',
@@ -161,7 +160,7 @@ describe('Gregorian Calendar fixed period calculation', () => {
                 startDate: '2026-01-04',
                 endDate: '2026-01-10',
             })
-            expect(biWeekly).toEqual({
+            expect(biWeekly).toMatchObject({
                 periodType: 'BIWEEKLY',
                 id: '2026BiW1',
                 iso: '2026BiW1',
@@ -170,34 +169,6 @@ describe('Gregorian Calendar fixed period calculation', () => {
                 startDate: '2025-12-29',
                 endDate: '2026-01-11',
             })
-        })
-
-        it('should use translated week prefixes without embedding ranges', () => {
-            const translate = jest
-                .spyOn(i18n, 't')
-                .mockImplementation((key: unknown) =>
-                    key === 'Week' ? 'Uke' : key
-                )
-
-            try {
-                const weekly = generateFixedPeriods({
-                    periodType: 'WEEKLY',
-                    year: 2026,
-                    calendar: 'gregory',
-                    locale: 'nb',
-                    startingDay: 1,
-                })[0]
-
-                expect(weekly).toMatchObject({
-                    name: 'Uke 1',
-                    displayName: 'Uke 1',
-                    startDate: '2025-12-29',
-                    endDate: '2026-01-04',
-                })
-                expect(translate).toHaveBeenCalledWith('Week')
-            } finally {
-                translate.mockRestore()
-            }
         })
     })
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
@@ -285,8 +285,8 @@ describe('Nepali Calendar fixed period calculation', () => {
             expect(results[results.length - 1]).toMatchObject({
                 id: '2014W28',
                 iso: '2014W28',
-                name: 'Week 28 - 2014-07-05 - 2014-07-11',
-                displayName: 'Week 28 - 2014-07-05 - 2014-07-11',
+                name: 'Week 28',
+                displayName: 'Week 28',
             })
         })
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.nepali.spec.ts
@@ -194,7 +194,7 @@ describe('Nepali Calendar fixed period calculation', () => {
         it('should add start and end dates for QUARTERLYNOV', () => {
             const periods = generateFixedPeriods({
                 year: 2078,
-                calendar: 'nepali' as SupportedCalendar,
+                calendar: 'nepali',
                 locale: 'en',
                 periodType: 'QUARTERLYNOV',
             }).map((p) => `${p.startDate}/${p.endDate}`)

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ethiopic.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ethiopic.spec.ts
@@ -95,8 +95,8 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
             const expected = [
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 1 - 2015-01-03 - 2015-01-09',
-                    displayName: 'Week 1 - 2015-01-03 - 2015-01-09',
+                    name: 'Week 1',
+                    displayName: 'Week 1',
                     id: '2015W1',
                     iso: '2015W1',
                     startDate: '2015-01-03',
@@ -104,8 +104,8 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 },
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 2 - 2015-01-10 - 2015-01-16',
-                    displayName: 'Week 2 - 2015-01-10 - 2015-01-16',
+                    name: 'Week 2',
+                    displayName: 'Week 2',
                     id: '2015W2',
                     iso: '2015W2',
                     startDate: '2015-01-10',
@@ -129,8 +129,8 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
             expect(actual).toHaveLength(54)
             expect(actual[0]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 53 - 2013-13-02 - 2014-01-03',
-                displayName: 'Week 53 - 2013-13-02 - 2014-01-03',
+                name: 'Week 53',
+                displayName: 'Week 53',
                 id: '2013W53',
                 iso: '2013W53',
                 startDate: '2013-13-02',
@@ -138,8 +138,8 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
             })
             expect(actual[53]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2015-01-03 - 2015-01-09',
-                displayName: 'Week 1 - 2015-01-03 - 2015-01-09',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2015W1',
                 iso: '2015W1',
                 endDate: '2015-01-09',

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
@@ -168,8 +168,8 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
             const expected = [
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 1 - 2023-01-02 - 2023-01-08',
-                    displayName: 'Week 1 - 2023-01-02 - 2023-01-08',
+                    name: 'Week 1',
+                    displayName: 'Week 1',
                     id: '2023W1',
                     iso: '2023W1',
                     startDate: '2023-01-02',
@@ -177,8 +177,8 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
                 },
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 2 - 2023-01-09 - 2023-01-15',
-                    displayName: 'Week 2 - 2023-01-09 - 2023-01-15',
+                    name: 'Week 2',
+                    displayName: 'Week 2',
                     id: '2023W2',
                     iso: '2023W2',
                     startDate: '2023-01-09',
@@ -202,8 +202,8 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
             expect(actual).toHaveLength(54)
             expect(actual[0]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 52 - 2021-12-27 - 2022-01-02',
-                displayName: 'Week 52 - 2021-12-27 - 2022-01-02',
+                name: 'Week 52',
+                displayName: 'Week 52',
                 id: '2021W52',
                 iso: '2021W52',
                 startDate: '2021-12-27',
@@ -211,8 +211,8 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
             })
             expect(actual[53]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2023-01-02 - 2023-01-08',
-                displayName: 'Week 1 - 2023-01-02 - 2023-01-08',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2023W1',
                 iso: '2023W1',
                 startDate: '2023-01-02',

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.nepali.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.nepali.spec.ts
@@ -95,8 +95,8 @@ describe('Nepali/getAdjacentFixedPeriods', () => {
             const expected = [
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 1 - 2078-12-28 - 2079-01-04',
-                    displayName: 'Week 1 - 2078-12-28 - 2079-01-04',
+                    name: 'Week 1',
+                    displayName: 'Week 1',
                     id: '2079W1',
                     iso: '2079W1',
                     startDate: '2078-12-28',
@@ -104,8 +104,8 @@ describe('Nepali/getAdjacentFixedPeriods', () => {
                 },
                 {
                     periodType: 'WEEKLY',
-                    name: 'Week 2 - 2079-01-05 - 2079-01-11',
-                    displayName: 'Week 2 - 2079-01-05 - 2079-01-11',
+                    name: 'Week 2',
+                    displayName: 'Week 2',
                     id: '2079W2',
                     iso: '2079W2',
                     startDate: '2079-01-05',
@@ -129,8 +129,8 @@ describe('Nepali/getAdjacentFixedPeriods', () => {
             expect(actual).toHaveLength(54)
             expect(actual[0]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 52 - 2077-12-23 - 2077-12-29',
-                displayName: 'Week 52 - 2077-12-23 - 2077-12-29',
+                name: 'Week 52',
+                displayName: 'Week 52',
                 id: '2077W52',
                 iso: '2077W52',
                 startDate: '2077-12-23',
@@ -138,8 +138,8 @@ describe('Nepali/getAdjacentFixedPeriods', () => {
             })
             expect(actual[53]).toEqual({
                 periodType: 'WEEKLY',
-                name: 'Week 1 - 2078-12-28 - 2079-01-04',
-                displayName: 'Week 1 - 2078-12-28 - 2079-01-04',
+                name: 'Week 1',
+                displayName: 'Week 1',
                 id: '2079W1',
                 iso: '2079W1',
                 startDate: '2078-12-28',


### PR DESCRIPTION
## Summary

Shortens weekly fixed-period `name` and `displayName` values to contain only the week title, e.g. `Week 1`, while preserving `startDate` and `endDate` as structured fields.

## Why

Weekly labels currently include the date range, e.g. `Week 1 - 2025-12-29 - 2026-01-04`. Consumers that need a shorter UI label have to parse this localized display string, which is fragile. Since the period object already exposes `startDate` and `endDate`, callers can compose richer labels themselves.

This also makes weekly period display names more consistent with monthly periods, where the display name is the period title and dates remain separate structured fields.

## Testing

- `CI=true yarn test --runInBand --watchAll=false --watchman=false src/period-calculation/generate-fixed-periods src/period-calculation/create-fixed-period-from-period-id src/period-calculation/get-adjacent-fixed-periods`
- `yarn cucumber`
- `yarn lint`
- `yarn build:types`
- `git diff --check`