### PR TITLE
fix: exclude current year-end weekly period [DHIS2-21585]

### DIFF
--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
@@ -219,6 +219,31 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
                 endDate: '2023-01-08',
             })
         })
+
+        it('should return the previous period when the current period is the last week of the year', () => {
+            const actual = getAdjacentFixedPeriods({
+                calendar: 'gregory',
+                locale: 'en',
+                period: createFixedPeriodFromPeriodId({
+                    periodId: '2023W52',
+                    calendar: 'gregory',
+                    locale: 'en',
+                }),
+                steps: -1,
+            })
+
+            expect(actual).toEqual([
+                {
+                    periodType: 'WEEKLY',
+                    name: 'Week 51 - 2023-12-18 - 2023-12-24',
+                    displayName: 'Week 51 - 2023-12-18 - 2023-12-24',
+                    id: '2023W51',
+                    iso: '2023W51',
+                    startDate: '2023-12-18',
+                    endDate: '2023-12-24',
+                },
+            ])
+        })
     })
 
     describe('period type: MONTHLY', () => {

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
@@ -112,11 +112,11 @@ const getPreviousWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
         )
 
         const previousPeriodsEndIndex =
-            firstCurrentOrFollowingPeriodIndex !== -1
-                ? firstCurrentOrFollowingPeriodIndex
-                : // This is the case when the "startDate" is the first day of the
+            firstCurrentOrFollowingPeriodIndex === -1
+                ? // This is the case when the "startDate" is the first day of the
                   // first period of the next year
                   periodsForYear.length
+                : firstCurrentOrFollowingPeriodIndex
         const startIndex = Math.max(0, previousPeriodsEndIndex - nextCount)
         const prevPeriods = periodsForYear.slice(
             startIndex,

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
@@ -41,7 +41,7 @@ const getFollowingWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
             startingDay: 1,
         })
 
-        const index =
+        const firstFollowingPeriodIndex =
             curYear === startYear
                 ? periodsForYear.findIndex((curPeriod) => {
                       const curStartDate = fromAnyDate({
@@ -57,8 +57,15 @@ const getFollowingWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
                   })
                 : 0
 
+        const followingPeriodsStartIndex =
+            firstFollowingPeriodIndex === -1
+                ? periodsForYear.length
+                : firstFollowingPeriodIndex
         const nextCount = steps - followingPeriods.length
-        const nextPeriods = periodsForYear.slice(index, index + nextCount)
+        const nextPeriods = periodsForYear.slice(
+            followingPeriodsStartIndex,
+            followingPeriodsStartIndex + nextCount
+        )
 
         followingPeriods.push(...nextPeriods)
         curYear++
@@ -93,27 +100,28 @@ const getPreviousWeeklyFixedPeriods: GetAdjacentWeeklyFixedPeriods = ({
             continue
         }
 
-        const foundIndex = periodsForYear.findIndex((curPeriod) => {
-            const curStartDate = fromAnyDate({
-                calendar,
-                date: curPeriod.startDate,
-            })
+        const firstCurrentOrFollowingPeriodIndex = periodsForYear.findIndex(
+            (curPeriod) => {
+                const curStartDate = fromAnyDate({
+                    calendar,
+                    date: curPeriod.startDate,
+                })
 
-            const startDateIsLowerThanCurStartDate =
-                Temporal.PlainDate.compare(startDate, curStartDate) === -1
+                return Temporal.PlainDate.compare(curStartDate, startDate) >= 0
+            }
+        )
 
-            return startDateIsLowerThanCurStartDate
-        })
-
-        const endIndex =
-            foundIndex !== -1
-                ? // have to remove 1 to exclude the current one
-                  foundIndex - 1
+        const previousPeriodsEndIndex =
+            firstCurrentOrFollowingPeriodIndex !== -1
+                ? firstCurrentOrFollowingPeriodIndex
                 : // This is the case when the "startDate" is the first day of the
                   // first period of the next year
                   periodsForYear.length
-        const startIndex = Math.max(0, endIndex - nextCount)
-        const prevPeriods = periodsForYear.slice(startIndex, endIndex)
+        const startIndex = Math.max(0, previousPeriodsEndIndex - nextCount)
+        const prevPeriods = periodsForYear.slice(
+            startIndex,
+            previousPeriodsEndIndex
+        )
         previousPeriods.push(...prevPeriods)
         curYear--
     }


### PR DESCRIPTION
## Summary

Fixes DHIS2-21585 by preventing getAdjacentFixedPeriods from returning the current weekly period when stepping backwards from the final week of a year.

## Root Cause

The weekly backward traversal searched for the first period with a start date after the current period. When the current period was the last generated week in the year, no later start date existed, so the slice boundary fell at the end of the year and included the current period again.

## Changes

- Treat the first current-or-following weekly period as the exclusive end boundary when collecting previous periods.
- Normalize the following-period boundary when no later period exists in the current generated year.
- Add a Gregorian regression test for stepping back from 2023W52 to 2023W51.

## Validation

- yarn test get-adjacent-fixed-periods.gregorian.spec.ts --watchAll=false --runInBand --watchman=false
- yarn test get-adjacent-fixed-periods --watchAll=false --runInBand --watchman=false
- yarn test --watchAll=false --runInBand --watchman=false
- yarn build:types
- yarn d2-style check changed files