### PR TITLE
fix: correct previous monthly period for December [DHIS2-21584]

### DIFF
--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts
@@ -283,6 +283,31 @@ describe('Gregorian/getAdjacentFixedPeriods', () => {
                 endDate: '2023-01-31',
             })
         })
+
+        it('should return the previous period when the current period is December', () => {
+            const actual = getAdjacentFixedPeriods({
+                calendar: 'gregory',
+                locale: 'en',
+                period: createFixedPeriodFromPeriodId({
+                    periodId: '202412',
+                    calendar: 'gregory',
+                    locale: 'en',
+                }),
+                steps: -1,
+            })
+
+            expect(actual).toEqual([
+                {
+                    periodType: 'MONTHLY',
+                    name: 'November 2024',
+                    displayName: 'November 2024',
+                    id: '202411',
+                    iso: '202411',
+                    startDate: '2024-11-01',
+                    endDate: '2024-11-30',
+                },
+            ])
+        })
     })
 
     describe('period type: YEARLY', () => {

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-monthly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-monthly-fixed-periods.ts
@@ -64,10 +64,7 @@ const getPreviousMonthlyFixedPeriods: GetAdjacentMonthlyFixedPeriods = ({
     calendar,
     locale,
 }) => {
-    // This is different from the startYear calculation in
-    // `getFollowingMonthlyFixedPeriods` as a period might start in a year
-    // following the year specified in the period's id
-    const startYear = parseInt(period.startDate.substring(0, 4), 10)
+    const startYear = parseInt(period.id.substring(0, 4), 10)
     const previousPeriods: FixedPeriod[] = []
 
     let curYear = startYear
@@ -88,13 +85,17 @@ const getPreviousMonthlyFixedPeriods: GetAdjacentMonthlyFixedPeriods = ({
             continue
         }
 
-        const endIndex =
-            periodsForYear.findIndex(
-                (curPeriod) => period.startDate < curPeriod.startDate
-            ) - 1 // have to remove 1 to exclude the current one
+        const endIndex = periodsForYear.findIndex(
+            (curPeriod) => curPeriod.startDate >= period.startDate
+        )
 
-        const startIndex = Math.max(0, endIndex - nextCount)
-        const prevPeriods = periodsForYear.slice(startIndex, endIndex)
+        const previousPeriodsEndIndex =
+            endIndex === -1 ? periodsForYear.length : endIndex
+        const startIndex = Math.max(0, previousPeriodsEndIndex - nextCount)
+        const prevPeriods = periodsForYear.slice(
+            startIndex,
+            previousPeriodsEndIndex
+        )
         previousPeriods.push(...prevPeriods)
         curYear--
     }

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-monthly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-monthly-fixed-periods.ts
@@ -64,7 +64,7 @@ const getPreviousMonthlyFixedPeriods: GetAdjacentMonthlyFixedPeriods = ({
     calendar,
     locale,
 }) => {
-    const startYear = parseInt(period.id.substring(0, 4), 10)
+    const startYear = Number.parseInt(period.id.substring(0, 4), 10)
     const previousPeriods: FixedPeriod[] = []
 
     let curYear = startYear


### PR DESCRIPTION
## Summary

Fixes DHIS2-21584 by preventing getAdjacentFixedPeriods from returning the current monthly period when stepping backwards from December.

## Root Cause

Monthly backward traversal used the period start date year and a slice boundary based on the first later period. For December, there is no later monthly period in the generated year, so the boundary calculation could include the current December period instead of ending before it.

## Changes

- Use the year encoded in the period id when walking backwards through monthly periods.
- Treat the first current-or-following monthly period as the exclusive end boundary when collecting previous periods.
- Add a Gregorian regression test for stepping back from 202412 to 202411.

## Validation

- yarn test get-adjacent-fixed-periods.gregorian.spec.ts --watchAll=false --runInBand --watchman=false
- yarn test get-adjacent-fixed-periods --watchAll=false --runInBand --watchman=false
- yarn d2-style check src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.gregorian.spec.ts src/period-calculation/get-adjacent-fixed-periods/get-adjacent-monthly-fixed-periods.ts