### PR TITLE
fix: vendor @js-temporal/polyfill to patch CLDR 48 Ethiopic era-code breakage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,9 @@ module.exports = {
         'react-hooks/exhaustive-deps': 'error',
         'import/extensions': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
-        'import/no-unresolved': ['error', { ignore: ['^@js-temporal/polyfill-patched$'] }],
+        'import/no-unresolved': [
+            'error',
+            { ignore: ['^@js-temporal/polyfill-patched$'] },
+        ],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
         'react-hooks/exhaustive-deps': 'error',
         'import/extensions': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
+        'import/no-unresolved': ['error', { ignore: ['^@js-temporal/polyfill-patched$'] }],
     },
 }

--- a/.github/workflows/dhis2-verify-commits.yml.yml
+++ b/.github/workflows/dhis2-verify-commits.yml.yml
@@ -8,11 +8,14 @@ jobs:
     lint-pr-title:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
-              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
+              run: echo "config_path=$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")" >> $GITHUB_OUTPUT
             - uses: JulienKode/pull-request-name-linter-action@v0.5.0
               with:
                   configuration-path: ${{ steps.commitlint.outputs.config_path }}
@@ -21,13 +24,16 @@ jobs:
         runs-on: ubuntu-latest
         if: ${{ !contains(github.event.pull_request.title, '[skip commit-lint]') }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
-              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
+              run: echo "config_path=$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")" >> $GITHUB_OUTPUT
             - uses: wagoid/commitlint-github-action@v4
               with:
                   configFile: ${{ steps.commitlint.outputs.config_path }}

--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 20.x
 
             - uses: actions/cache@v3
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -44,7 +44,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 20.x
 
             - uses: actions/cache@v3
               id: yarn-cache
@@ -71,7 +71,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 20.x
 
             - uses: actions/cache@v3
               id: yarn-cache
@@ -90,7 +90,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 20.x
 
             - uses: actions/cache@v3
               id: yarn-cache
@@ -125,7 +125,7 @@ jobs:
                   token: ${{env.GH_TOKEN}}
             - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 20.x
 
             - uses: actions/download-artifact@v4
               with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# multi-calendar-dates
+
+A library used to work with dates across multiple calendrical systems (Gregorian, Ethiopic, Nepali, Islamic, …) in DHIS2 applications. It exposes two things: hooks like `useDatePicker` for building UI components (consumed by `@dhis2/ui`'s Calendar and CalendarInput), and helper functions like `generateFixedPeriods` and `getNowInCalendar` for period generation, date arithmetic, and conversions across calendars. Internally it uses the [Temporal API](https://tc39.es/proposal-temporal) via `@js-temporal/polyfill`, but that is an implementation detail — one of the goals is to be able to swap Temporal for another engine (e.g. Kotlin multiplatform) without changing the public interface.
+
+## Public interface
+
+Everything exported from `src/index.ts` is public. Nothing else is.
+
+**Hooks**
+- `useDatePicker(options: DatePickerOptions)` — returns a week-grid, day-name labels, and navigation state for building a calendar picker
+- `useResolvedDirection(options)` — resolves text direction (LTR/RTL) from locale or an explicit override
+
+**Period calculation**
+- `generateFixedPeriods` — all periods of a given type for a year and calendar
+- `getFixedPeriodByDate` — the period that contains a given date
+- `createFixedPeriodFromPeriodId` — reconstructs a `FixedPeriod` from its ID string (e.g. `"202301"`)
+- `getAdjacentFixedPeriods` — N periods before or after a given period
+- `periodTypes` — const array of all 53 supported period type identifiers
+
+**Utilities**
+- `getNowInCalendar` — today's date in any supported calendar
+- `convertFromIso8601` / `convertToIso8601` — convert between ISO 8601 and any calendar
+- `validateDateString` — validates a date string against format, range, and calendar rules
+
+**Constants**
+- `constants.calendars` — 21 supported calendar IDs
+- `constants.numberingSystems` — 87 CLDR numbering system codes
+
+**Implicit Temporal contract.** The Temporal API (`@js-temporal/polyfill`) is described as an internal implementation detail, but it leaks into the public interface in two specific places:
+
+- **`getNowInCalendar`** — returns `Temporal.ZonedDateTime` directly. Callers access `.year`, `.month`, `.day`, `.eraYear`, `.startOfDay()`, `.withCalendar()`, and other Temporal methods on the result. Any rename or signature change in the proposal breaks these call sites.
+- **`convertFromIso8601` / `convertToIso8601`** — accept `string | Temporal.PlainDateLike` as their `date` parameter. Callers who pass a `Temporal.PlainDateLike` object are coupled to that type.
+
+`useDatePicker` and the period-calculation functions (`generateFixedPeriods`, `getFixedPeriodByDate`, etc.) are insulated — their return types use plain strings and numbers, not Temporal objects.
+
+The polyfill tracks TC39 proposal stage 3, which is not yet finalised or natively available in all environments. When upgrading `@js-temporal/polyfill`, treat it as a potentially breaking change and audit the two affected functions above.
+
+## Domain-specific gotchas
+
+**Date format convention.** Dates are always sent to the backend in the active calendar system formatted as `yyyy-MM-dd`. This is ISO-like but not ISO 8601 — `2015-01-01` from an Ethiopic system means year 2015 in Ethiopic (≈ 2022 Gregorian). The backend expects this format and handles any conversion it needs.
+
+**Ethiopic 13th month.** The Ethiopic calendar has 13 months: 12 × 30 days, plus a 5- or 6-day 13th month. For period types smaller than monthly (daily, weekly, bi-weekly), the 13th month is shown. For monthly and above it is hidden — the backend lumps its data into the following month's analytics.
+
+**Period IDs use Gregorian month names.** Period IDs are dictated by the backend and always reference Gregorian month names (e.g. `QUARTERLYNOV`, `FYDEC`). In a non-Gregorian calendar `NOV` is translated to the 11th month of that system (e.g. Hamle in Ethiopic).
+
+**Ethiopic `.eraYear` vs `.year`.** When reading a year from a Temporal object in the Ethiopic calendar, use `.eraYear` not `.year`. The default era is browser-dependent, so `.year` may return unexpected values.
+
+**Nepali custom calendar.** Nepali is not in the Temporal/CLDR spec and is implemented as a custom calendar (`src/custom-calendars/nepaliCalendar.ts`). It is a luni-solar calendar — month lengths vary year to year. Temporal does arithmetic by converting to Gregorian first, which produces wrong results for Nepali; to work around this, period generation sets the day to the 14th before performing month arithmetic.
+
+**Nepali locale limitations.** Nepali is not a supported locale in major browsers. Month and day names are provided via a hardcoded map. Only `ne-NP` (Devanagari) and `en-NP` (transliterated into English) are supported — it is not possible to display Nepali month names in other languages the way you can with Ethiopic or Islamic.
+
+**DHIS2 calendar/locale aliases.** `"ethiopian"` is accepted everywhere `"ethiopic"` is — it is a DHIS2 non-standard name normalised internally. Java-style locale codes with underscores (e.g. `ar_SD`) are normalised to dash-separated form (`ar-SD`).
+
+## Testing approach
+
+Test the public interface thoroughly. Internal helpers and hooks are not tested directly — they are covered as side effects of public-interface tests. Do not add unit tests for internals to increase coverage numbers.
+
+**At minimum, test Gregorian, Ethiopic, and a custom calendar (Nepali).** Gregorian is the baseline. Ethiopic exercises extended-calendar behaviour (13th month, `.eraYear`). Nepali exercises the custom-calendar code path. Islamic is also included in the hook and conversion tests as a locale/RTL check. Other calendars listed in `constants.calendars` are not tested and that is expected.
+
+Period-calculation specs are split per calendar — e.g. `generate-fixed-periods.gregorian.spec.ts`, `.ethiopic.spec.ts`, `.nepali.spec.ts`. Follow this pattern when adding period tests.
+
+**Known gaps in public-interface coverage** (see `doc/test-coverage.md`):
+- `useDatePicker` with `minDate`, `maxDate`, `strictValidation`, `format` options
+- `useDatePicker` with `pastOnly` option
+
+## Commands
+
+```bash
+yarn test              # Jest (watch mode)
+yarn test --coverage   # Jest with coverage report (thresholds: 85% branches, 92% functions/lines/statements)
+yarn cucumber          # Cucumber BDD specs in features/
+yarn build             # ESM + CJS bundles + TypeScript declarations
+yarn lint              # ESLint via d2-style
+yarn format            # Auto-format via d2-style
+```
+
+## Project structure
+
+```
+src/
+  index.ts                  # single public entry point
+  types.ts                  # shared types (SupportedCalendar, ResolvedLocaleOptions, …)
+  hooks/                    # useDatePicker, useResolvedDirection + internal hooks
+  period-calculation/       # one subdirectory per exported function
+  utils/                    # getNowInCalendar, convertFromIso8601, validateDateString, …
+  custom-calendars/         # Nepali calendar engine + data tables
+  constants/                # calendars[], numberingSystems[]
+features/                   # Cucumber BDD feature files (fixed-period scenarios)
+doc/                        # architecture notes, test coverage overview
+```

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,21 @@
+// Rewrites @js-temporal/polyfill-patched imports to the vendored copy that
+// includes the CLDR 48 era-code fix (see src/vendor/temporal/calendar.ts).
+// This runs during both the d2-app-scripts lib build (Babel per-file) and
+// Jest, so consumers receive the patched version without any extra setup.
+//
+// tsconfig.json "paths" handles the same alias for the TypeScript type checker
+// and IDE, but does NOT rewrite import strings in the emitted JS — that is
+// what this file does.
+module.exports = {
+    plugins: [
+        [
+            'module-resolver',
+            {
+                alias: {
+                    '@js-temporal/polyfill-patched':
+                        './src/vendor/temporal/index',
+                },
+            },
+        ],
+    ],
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint:staged": "yarn lint --staged",
         "format": "yarn d2-style apply",
         "format:staged": "yarn format --staged",
-        "cucumber": "NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node\" cucumber-js --require-module ts-node/register --require **/features/**/*.ts --tags=\"not @skip\""
+        "cucumber": "NODE_OPTIONS=\"--loader ts-node/esm --no-warnings --experimental-specifier-resolution=node --require ./scripts/cucumber-polyfill-alias.cjs\" cucumber-js --require-module ts-node/register --require **/features/**/*.ts --tags=\"not @skip\""
     },
     "eslintConfig": {
         "extends": [

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
         ],
         "coverageThreshold": {
             "global": {
-                "branches": 80,
-                "functions": 90,
-                "lines": 90,
-                "statements": 90
+                "branches": 85,
+                "functions": 92,
+                "lines": 92,
+                "statements": 92
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "react-dom": "^16.14",
         "react-scripts": "5.0.1",
         "ts-node": "^10.9.1",
-        "typescript": "4.4"
+        "typescript": "^6.0.3"
     },
     "release": {
         "branches": [

--- a/package.json
+++ b/package.json
@@ -51,10 +51,14 @@
         "transformIgnorePatterns": [
             "/!node_modules\\/@js-temporal/"
         ],
+        "moduleNameMapper": {
+            "^@js-temporal/polyfill-patched$": "<rootDir>/src/vendor/temporal/index.ts"
+        },
         "collectCoverageFrom": [
             "**/*.{js,jsx,ts,tsx}",
             "!<rootDir>/node_modules/",
             "!<rootDir>/*.ts",
+            "!<rootDir>/src/vendor/**",
             "!<rootDir>/coverage/**/*.*"
         ],
         "coverageThreshold": {
@@ -89,6 +93,7 @@
         "@types/react-dom": "^16.8",
         "@types/testing-library__react": "^10.2.0",
         "@types/testing-library__react-hooks": "^4.0.0",
+        "babel-plugin-module-resolver": "^5.0.3",
         "jest-cucumber": "^3.0.1",
         "react": "^16.14",
         "react-dom": "^16.14",

--- a/scripts/cucumber-polyfill-alias.cjs
+++ b/scripts/cucumber-polyfill-alias.cjs
@@ -1,0 +1,13 @@
+// Remaps @js-temporal/polyfill-patched to the vendored patched copy for the
+// cucumber / ts-node runner. Jest uses moduleNameMapper and the build uses
+// babel-plugin-module-resolver; this shim covers the remaining entry point.
+const Module = require('module')
+const path = require('path')
+const vendorIndex = path.resolve(__dirname, '../src/vendor/temporal/index.ts')
+const original = Module._resolveFilename
+Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request === '@js-temporal/polyfill-patched') {
+        return vendorIndex
+    }
+    return original(request, parent, isMain, options)
+}

--- a/src/custom-calendars/index.ts
+++ b/src/custom-calendars/index.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../types'
 import calendarLocalisations from './calendarLocalisations'
 import { NepaliCalendar } from './nepaliCalendar'

--- a/src/custom-calendars/nepaliCalendar.spec.ts
+++ b/src/custom-calendars/nepaliCalendar.spec.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { NepaliCalendar } from './nepaliCalendar'
 
 const calendar = new NepaliCalendar()

--- a/src/custom-calendars/nepaliCalendar.ts
+++ b/src/custom-calendars/nepaliCalendar.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { NEPALI_CALENDAR_DATA } from './nepaliCalendarData'
 type CalendarYMD = { year: number; month: number; day: number }
 

--- a/src/hooks/internal/useCalendarWeekDays.spec.ts
+++ b/src/hooks/internal/useCalendarWeekDays.spec.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { renderHook } from '@testing-library/react-hooks'
 import { useCalendarWeekDays } from './useCalendarWeekDays'
 

--- a/src/hooks/internal/useCalendarWeekDays.ts
+++ b/src/hooks/internal/useCalendarWeekDays.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { useMemo } from 'react'
 
 const groupByWeek = (

--- a/src/hooks/internal/useNavigation.ts
+++ b/src/hooks/internal/useNavigation.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { Dispatch, SetStateAction, useMemo } from 'react'
 import {
     PickerOptionsWithResolvedCalendar,

--- a/src/hooks/internal/useResolvedLocaleOptions.spec.ts
+++ b/src/hooks/internal/useResolvedLocaleOptions.spec.ts
@@ -1,10 +1,10 @@
-import { Intl } from '@js-temporal/polyfill'
+import { Intl } from '@js-temporal/polyfill-patched'
 import { renderHook } from '@testing-library/react-hooks'
 import { PickerOptions } from '../../types'
 import getValidLocale from '../../utils/getValidLocale'
 import { useResolvedLocaleOptions } from './useResolvedLocaleOptions'
 
-jest.mock('@js-temporal/polyfill')
+jest.mock('@js-temporal/polyfill-patched')
 jest.mock('../../utils/getValidLocale')
 
 const renderResolvedLocaleHook = ({

--- a/src/hooks/internal/useResolvedLocaleOptions.ts
+++ b/src/hooks/internal/useResolvedLocaleOptions.ts
@@ -1,4 +1,4 @@
-import { Intl } from '@js-temporal/polyfill'
+import { Intl } from '@js-temporal/polyfill-patched'
 import { useMemo } from 'react'
 import {
     PickerOptions,

--- a/src/hooks/internal/useWeekDayLabels.ts
+++ b/src/hooks/internal/useWeekDayLabels.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { useMemo } from 'react'
 import { PickerOptionsWithResolvedCalendar } from '../../types'
 import localisationHelpers from '../../utils/localisationHelpers'

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -1,4 +1,4 @@
-import { Intl } from '@js-temporal/polyfill'
+import { Intl } from '@js-temporal/polyfill-patched'
 import { render } from '@testing-library/react'
 import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
@@ -14,10 +14,10 @@ beforeEach(() => {
 
 afterEach(jest.clearAllMocks)
 
-jest.mock('@js-temporal/polyfill', () => ({
-    ...jest.requireActual('@js-temporal/polyfill'),
+jest.mock('@js-temporal/polyfill-patched', () => ({
+    ...jest.requireActual('@js-temporal/polyfill-patched'),
     Intl: {
-        ...jest.requireActual('@js-temporal/polyfill').Intl,
+        ...jest.requireActual('@js-temporal/polyfill-patched').Intl,
     }, // this is needed, otherwise jest spying fails with " Cannot assign to read only property 'DateTimeFormat'"
 }))
 

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -832,7 +832,11 @@ describe('format option', () => {
             useDatePicker({
                 onDateSelect: jest.fn(),
                 date: '22-01-2018', // input must match the declared format
-                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                },
                 format: 'DD-MM-YYYY',
             })
         )
@@ -848,7 +852,11 @@ describe('format option', () => {
             useDatePicker({
                 onDateSelect,
                 date: '22-01-2018',
-                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                },
                 format: 'DD-MM-YYYY',
             })
         )
@@ -929,7 +937,9 @@ describe('pastOnly option', () => {
         )
         // mocked today is 2021-10-13; visible year is 2021
         expect(result.current.years.every((y) => y.value <= 2021)).toBe(true)
-        expect(result.current.years.at(-1)?.value).toEqual(2021)
+        expect(
+            result.current.years[result.current.years.length - 1]?.value
+        ).toEqual(2021)
     })
 
     it('should include future years in the years list by default', () => {
@@ -954,7 +964,11 @@ describe('navigation callbacks', () => {
             useDatePicker({
                 onDateSelect: jest.fn(),
                 date: '2021-03-15',
-                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                },
             })
         )
 

--- a/src/hooks/useDatePicker.spec.tsx
+++ b/src/hooks/useDatePicker.spec.tsx
@@ -1,6 +1,6 @@
 import { Intl } from '@js-temporal/polyfill'
 import { render } from '@testing-library/react'
-import { renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { SupportedCalendar } from '../types'
 import { convertToIso8601 } from '../utils'
@@ -823,5 +823,244 @@ describe('month labels in useDatePicker hook', () => {
             expect(nepaliMonths[0]).toEqual({ value: 1, label: 'बैशाख' })
             expect(nepaliMonths[11]).toEqual({ value: 12, label: 'चैत' })
         })
+    })
+})
+
+describe('format option', () => {
+    it('should format dateValue on each cell in DD-MM-YYYY when specified', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '22-01-2018', // input must match the declared format
+                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+                format: 'DD-MM-YYYY',
+            })
+        )
+        const selectedDay = result.current.calendarWeekDays
+            .flat()
+            .find((d) => d.isSelected)
+        expect(selectedDay?.dateValue).toEqual('22-01-2018')
+    })
+
+    it('should call onDateSelect with DD-MM-YYYY string when input date is in that format', () => {
+        const onDateSelect = jest.fn()
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect,
+                date: '22-01-2018',
+                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+                format: 'DD-MM-YYYY',
+            })
+        )
+        const selectedDay = result.current.calendarWeekDays
+            .flat()
+            .find((d) => d.isSelected)
+        selectedDay?.onClick()
+        expect(onDateSelect).toHaveBeenCalledWith({
+            calendarDateString: '22-01-2018',
+        })
+    })
+})
+
+describe('date range options', () => {
+    const baseOptions = {
+        locale: 'en-GB',
+        calendar: 'gregory' as const,
+        timeZone: 'UTC',
+    }
+
+    it('should fall back to today when date is before minDate', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2018-01-22',
+                options: baseOptions,
+                minDate: '2020-01-01',
+            })
+        )
+        // validation error → falls back to mocked today: 2021-10-13
+        expect(result.current.currYear.label).toEqual('2021')
+        expect(result.current.currMonth.label).toEqual('October')
+    })
+
+    it('should use the provided date when before minDate but strictValidation is false', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2018-01-22',
+                options: baseOptions,
+                minDate: '2020-01-01',
+                strictValidation: false,
+            })
+        )
+        // warning only → date is still used
+        expect(result.current.currYear.label).toEqual('2018')
+        expect(result.current.currMonth.label).toEqual('January')
+    })
+
+    it('should fall back to today when date is after maxDate', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2025-06-15',
+                options: baseOptions,
+                maxDate: '2022-12-31',
+            })
+        )
+        // validation error → falls back to mocked today: 2021-10-13
+        expect(result.current.currYear.label).toEqual('2021')
+        expect(result.current.currMonth.label).toEqual('October')
+    })
+})
+
+describe('pastOnly option', () => {
+    it('should exclude future years from the years list when pastOnly is true', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2021-10-01',
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                    pastOnly: true,
+                },
+            })
+        )
+        // mocked today is 2021-10-13; visible year is 2021
+        expect(result.current.years.every((y) => y.value <= 2021)).toBe(true)
+        expect(result.current.years.at(-1)?.value).toEqual(2021)
+    })
+
+    it('should include future years in the years list by default', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2021-10-01',
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                },
+            })
+        )
+        expect(result.current.years.some((y) => y.value > 2021)).toBe(true)
+    })
+})
+
+describe('navigation callbacks', () => {
+    const setup = () =>
+        renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '2021-03-15',
+                options: { locale: 'en-GB', calendar: 'gregory', timeZone: 'UTC' },
+            })
+        )
+
+    it('navigateToMonth changes the visible month', () => {
+        const { result } = setup()
+        expect(result.current.currMonth.label).toEqual('March')
+        act(() => result.current.navigateToMonth(8))
+        expect(result.current.currMonth.label).toEqual('August')
+    })
+
+    it('navigateToYear changes the visible year', () => {
+        const { result } = setup()
+        expect(result.current.currYear.label).toEqual('2021')
+        act(() => result.current.navigateToYear(2019))
+        expect(result.current.currYear.label).toEqual('2019')
+    })
+
+    it('prevMonth.navigateTo moves back one month', () => {
+        const { result } = setup()
+        expect(result.current.currMonth.label).toEqual('March')
+        act(() => result.current.prevMonth.navigateTo())
+        expect(result.current.currMonth.label).toEqual('February')
+    })
+
+    it('nextMonth.navigateTo moves forward one month', () => {
+        const { result } = setup()
+        expect(result.current.currMonth.label).toEqual('March')
+        act(() => result.current.nextMonth.navigateTo())
+        expect(result.current.currMonth.label).toEqual('April')
+    })
+
+    it('prevYear.navigateTo moves back one year', () => {
+        const { result } = setup()
+        expect(result.current.currYear.label).toEqual('2021')
+        act(() => result.current.prevYear.navigateTo())
+        expect(result.current.currYear.label).toEqual('2020')
+    })
+
+    it('nextYear.navigateTo moves forward one year', () => {
+        const { result } = setup()
+        expect(result.current.currYear.label).toEqual('2021')
+        act(() => result.current.nextYear.navigateTo())
+        expect(result.current.currYear.label).toEqual('2022')
+    })
+})
+
+describe('dateString change re-centres the calendar view', () => {
+    it('should update the visible month when date prop changes to a different month', () => {
+        const { result, rerender } = renderHook(
+            ({ date }: { date: string }) =>
+                useDatePicker({
+                    onDateSelect: jest.fn(),
+                    date,
+                    options: {
+                        locale: 'en-GB',
+                        calendar: 'gregory',
+                        timeZone: 'UTC',
+                    },
+                }),
+            { initialProps: { date: '2021-03-15' } }
+        )
+        expect(result.current.currMonth.label).toEqual('March')
+        rerender({ date: '2021-08-15' })
+        expect(result.current.currMonth.label).toEqual('August')
+    })
+
+    it('should not re-centre the view when date prop changes within the same month', () => {
+        const { result, rerender } = renderHook(
+            ({ date }: { date: string }) =>
+                useDatePicker({
+                    onDateSelect: jest.fn(),
+                    date,
+                    options: {
+                        locale: 'en-GB',
+                        calendar: 'gregory',
+                        timeZone: 'UTC',
+                    },
+                }),
+            { initialProps: { date: '2021-03-15' } }
+        )
+        expect(result.current.currMonth.label).toEqual('March')
+        rerender({ date: '2021-03-20' })
+        expect(result.current.currMonth.label).toEqual('March')
+    })
+})
+
+describe('empty date string', () => {
+    it('should show today when no date is provided', () => {
+        const { result } = renderHook(() =>
+            useDatePicker({
+                onDateSelect: jest.fn(),
+                date: '',
+                options: {
+                    locale: 'en-GB',
+                    calendar: 'gregory',
+                    timeZone: 'UTC',
+                },
+            })
+        )
+        // today is mocked to 2021-10-13
+        expect(result.current.currMonth.label).toEqual('October')
+        expect(result.current.currYear.label).toEqual('2021')
+        // no date is selected so isSelected is false/undefined for all days
+        const allSelected = result.current.calendarWeekDays
+            .flat()
+            .filter((d) => d.isSelected)
+        expect(allSelected).toHaveLength(0)
     })
 })

--- a/src/hooks/useDatePicker.ts
+++ b/src/hooks/useDatePicker.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
 import { getNowInCalendar } from '../index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import './locales/index.js'
 export * from './hooks'
 export * as constants from './constants'

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ethiopic.spec.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.ethiopic.spec.ts
@@ -474,7 +474,7 @@ describe('Ethiopic/createFixedPeriodFromPeriodId', () => {
             const expected = {
                 periodType: 'DAILY',
                 name: '2015-01-01',
-                displayName: 'Meskerem 1, 2015 ERA0',
+                displayName: 'Meskerem 1, 2015',
                 id: '20150101',
                 iso: '20150101',
                 startDate: '2015-01-01',

--- a/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.gregorian.spec.ts
+++ b/src/period-calculation/create-fixed-period-from-period-id/create-fixed-period-from-period-id.gregorian.spec.ts
@@ -483,4 +483,13 @@ describe('Gregorian/createFixedPeriodFromPeriodId', () => {
             expect(actual).toEqual(expected)
         })
     })
+
+    it('should throw for an unrecognised period id', () => {
+        expect(() =>
+            createFixedPeriodFromPeriodId({
+                periodId: 'NOT_A_VALID_PERIOD_ID',
+                calendar: 'gregory',
+            })
+        ).toThrow("Couldn't handle unknown period id")
+    })
 })

--- a/src/period-calculation/daily-periods/build-daily-fixed-period.ts
+++ b/src/period-calculation/daily-periods/build-daily-fixed-period.ts
@@ -25,7 +25,9 @@ const buildDailyFixedPeriod: BuildDailyFixedPeriod = ({
         date,
         { calendar, locale },
         { dateStyle: 'long' }
-    ).replace(/\b(ERA\d+|AA|AM)\b\s*/g, '').trim()
+    )
+        .replace(/\b(ERA\d+|AA|AM)\b\s*/g, '')
+        .trim()
 
     return {
         periodType: 'DAILY',

--- a/src/period-calculation/daily-periods/build-daily-fixed-period.ts
+++ b/src/period-calculation/daily-periods/build-daily-fixed-period.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { formatDate, localisationHelpers } from '../../utils/index'
 import { FixedPeriod } from '../types'
@@ -20,11 +20,12 @@ const buildDailyFixedPeriod: BuildDailyFixedPeriod = ({
     const nextDayMonthLabel = String(date.month).padStart(2, '0')
     const nextDayLabel = String(date.day).padStart(2, '0')
     const value = `${year}${nextDayMonthLabel}${nextDayLabel}`
+    // ERA\d+ is the old CLDR format (e.g. ERA0); AA/AM are the CLDR 48+ abbreviations (Amete Alem/Amete Mihret)
     const displayName = localiseDateLabel(
         date,
         { calendar, locale },
         { dateStyle: 'long' }
-    )
+    ).replace(/\b(ERA\d+|AA|AM)\b\s*/g, '').trim()
 
     return {
         periodType: 'DAILY',

--- a/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
+++ b/src/period-calculation/generate-fixed-periods/does-period-end-before.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils'
 

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-daily.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-daily.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { buildDailyFixedPeriod } from '../daily-periods/index'

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-monthly.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { getStartingMonthByPeriodType } from '../get-starting-month-for-period-type'

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-weekly.ts
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate, formatDate, padWithZeroes } from '../../utils/index'
 import { FixedPeriod, PeriodType } from '../types'

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods-yearly.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { FixedPeriod, PeriodType } from '../types'
 import {

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.ethiopic.spec.ts
@@ -306,7 +306,7 @@ describe('Ethiopic Calendar fixed period calculation', () => {
 
             expect(results.length).toBe(62)
             expect(results[0]).toMatchObject({
-                displayName: 'Meskerem 1, 2016 ERA0',
+                displayName: 'Meskerem 1, 2016',
                 endDate: '2016-01-01',
                 id: '20160101',
                 iso: '20160101',
@@ -315,7 +315,7 @@ describe('Ethiopic Calendar fixed period calculation', () => {
                 startDate: '2016-01-01',
             })
             expect(results[results.length - 1]).toMatchObject({
-                displayName: 'Hedar 2, 2016 ERA0',
+                displayName: 'Hedar 2, 2016',
                 endDate: '2016-03-02',
                 id: '20160302',
                 iso: '20160302',

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
@@ -492,46 +492,71 @@ describe('Gregorian Calendar fixed period calculation', () => {
     })
 
     describe('fiscal year starting months', () => {
-        const base = { year: 2015, calendar: 'gregory' as SupportedCalendar, locale: 'en' }
+        const base = {
+            year: 2015,
+            calendar: 'gregory' as SupportedCalendar,
+            locale: 'en',
+        }
 
         it('FYFEB starts on February 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYFEB' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYFEB',
+            })
             expect(result[0].startDate).toEqual('2015-02-01')
             expect(result[0].endDate).toEqual('2016-01-31')
         })
 
         it('FYMAR starts on March 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYMAR' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYMAR',
+            })
             expect(result[0].startDate).toEqual('2015-03-01')
             expect(result[0].endDate).toEqual('2016-02-29')
         })
 
         it('FYMAY starts on May 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYMAY' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYMAY',
+            })
             expect(result[0].startDate).toEqual('2015-05-01')
             expect(result[0].endDate).toEqual('2016-04-30')
         })
 
         it('FYJUN starts on June 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYJUN' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYJUN',
+            })
             expect(result[0].startDate).toEqual('2015-06-01')
             expect(result[0].endDate).toEqual('2016-05-31')
         })
 
         it('FYAUG starts on August 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYAUG' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYAUG',
+            })
             expect(result[0].startDate).toEqual('2015-08-01')
             expect(result[0].endDate).toEqual('2016-07-31')
         })
 
         it('FYSEP starts on September 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYSEP' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYSEP',
+            })
             expect(result[0].startDate).toEqual('2015-09-01')
             expect(result[0].endDate).toEqual('2016-08-31')
         })
 
         it('FYDEC starts on December 1', () => {
-            const result = generateFixedPeriods({ ...base, periodType: 'FYDEC' })
+            const result = generateFixedPeriods({
+                ...base,
+                periodType: 'FYDEC',
+            })
             expect(result[0].startDate).toEqual('2015-12-01')
             expect(result[0].endDate).toEqual('2016-11-30')
         })

--- a/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
+++ b/src/period-calculation/generate-fixed-periods/generate-fixed-periods.gregorian.spec.ts
@@ -388,6 +388,34 @@ describe('Gregorian Calendar fixed period calculation', () => {
             expect(periods[0]).toEqual('2013-12-29/2014-01-04')
             expect(periods[periods.length - 1]).toEqual('2014-12-28/2015-01-03')
         })
+        it('should add start and end dates for WEEKLYFRI', () => {
+            // Jan 4, 2022 is a Tuesday (dayOfWeek=2), Friday start (5)
+            // dayDiff = 2 - 5 = -3 → subtract (−3 + 7) = 4 days from Jan 4 → Dec 31, 2021
+            const periods = generateFixedPeriods({
+                ...date,
+                periodType: 'WEEKLYFRI',
+                year: 2022,
+            }).map((p) => `${p.startDate}/${p.endDate}`)
+            expect(periods[0]).toEqual('2021-12-31/2022-01-06')
+        })
+        it('should add start and end dates for WEEKLYMON', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                periodType: 'WEEKLYMON',
+                year: 2022,
+            })
+            expect(periods[0].periodType).toEqual('WEEKLYMON')
+            expect(periods.length).toBeGreaterThan(0)
+        })
+        it('should add start and end dates for WEEKLYTUE', () => {
+            const periods = generateFixedPeriods({
+                ...date,
+                periodType: 'WEEKLYTUE',
+                year: 2022,
+            })
+            expect(periods[0].periodType).toEqual('WEEKLYTUE')
+            expect(periods.length).toBeGreaterThan(0)
+        })
         it('should add start and end dates for BIWEEKLY', () => {
             const periods = generateFixedPeriods({
                 ...date,
@@ -437,6 +465,75 @@ describe('Gregorian Calendar fixed period calculation', () => {
             }).map((p) => `${p.startDate}/${p.endDate}`)
             expect(periods[0]).toEqual('2015-01-01/2015-02-28')
             expect(periods[periods.length - 1]).toEqual('2015-11-01/2015-12-31')
+        })
+    })
+
+    describe('generateFixedPeriods input handling', () => {
+        it('should accept year as a numeric string', () => {
+            const result = generateFixedPeriods({
+                year: '2022' as unknown as number,
+                periodType: 'MONTHLY',
+                calendar: 'gregory',
+                locale: 'en',
+            })
+            expect(result).toHaveLength(12)
+            expect(result[0].startDate).toEqual('2022-01-01')
+        })
+
+        it('should throw for an unrecognised period type', () => {
+            expect(() =>
+                generateFixedPeriods({
+                    year: 2022,
+                    periodType: 'UNKNOWN' as never,
+                    calendar: 'gregory',
+                })
+            ).toThrow('unrecognised period type')
+        })
+    })
+
+    describe('fiscal year starting months', () => {
+        const base = { year: 2015, calendar: 'gregory' as SupportedCalendar, locale: 'en' }
+
+        it('FYFEB starts on February 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYFEB' })
+            expect(result[0].startDate).toEqual('2015-02-01')
+            expect(result[0].endDate).toEqual('2016-01-31')
+        })
+
+        it('FYMAR starts on March 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYMAR' })
+            expect(result[0].startDate).toEqual('2015-03-01')
+            expect(result[0].endDate).toEqual('2016-02-29')
+        })
+
+        it('FYMAY starts on May 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYMAY' })
+            expect(result[0].startDate).toEqual('2015-05-01')
+            expect(result[0].endDate).toEqual('2016-04-30')
+        })
+
+        it('FYJUN starts on June 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYJUN' })
+            expect(result[0].startDate).toEqual('2015-06-01')
+            expect(result[0].endDate).toEqual('2016-05-31')
+        })
+
+        it('FYAUG starts on August 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYAUG' })
+            expect(result[0].startDate).toEqual('2015-08-01')
+            expect(result[0].endDate).toEqual('2016-07-31')
+        })
+
+        it('FYSEP starts on September 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYSEP' })
+            expect(result[0].startDate).toEqual('2015-09-01')
+            expect(result[0].endDate).toEqual('2016-08-31')
+        })
+
+        it('FYDEC starts on December 1', () => {
+            const result = generateFixedPeriods({ ...base, periodType: 'FYDEC' })
+            expect(result[0].startDate).toEqual('2015-12-01')
+            expect(result[0].endDate).toEqual('2016-11-30')
         })
     })
 })

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ethiopic.spec.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-fixed-periods.ethiopic.spec.ts
@@ -17,7 +17,7 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 {
                     periodType: 'DAILY',
                     name: '2014-13-05',
-                    displayName: 'Pagumen 5, 2014 ERA0',
+                    displayName: 'Pagumen 5, 2014',
                     id: '20141305',
                     iso: '20141305',
                     startDate: '2014-13-05',
@@ -26,7 +26,7 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 {
                     periodType: 'DAILY',
                     name: '2015-01-01',
-                    displayName: 'Meskerem 1, 2015 ERA0',
+                    displayName: 'Meskerem 1, 2015',
                     id: '20150101',
                     iso: '20150101',
                     startDate: '2015-01-01',
@@ -51,7 +51,7 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 {
                     periodType: 'DAILY',
                     name: '2014-13-04',
-                    displayName: 'Pagumen 4, 2014 ERA0',
+                    displayName: 'Pagumen 4, 2014',
                     id: '20141304',
                     iso: '20141304',
                     startDate: '2014-13-04',
@@ -60,7 +60,7 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 {
                     periodType: 'DAILY',
                     name: '2014-13-05',
-                    displayName: 'Pagumen 5, 2014 ERA0',
+                    displayName: 'Pagumen 5, 2014',
                     id: '20141305',
                     iso: '20141305',
                     startDate: '2014-13-05',
@@ -69,7 +69,7 @@ describe('Ethiopic/getAdjacentFixedPeriods', () => {
                 {
                     periodType: 'DAILY',
                     name: '2015-01-01',
-                    displayName: 'Meskerem 1, 2015 ERA0',
+                    displayName: 'Meskerem 1, 2015',
                     id: '20150101',
                     iso: '20150101',
                     startDate: '2015-01-01',

--- a/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
+++ b/src/period-calculation/get-adjacent-fixed-periods/get-adjacent-weekly-fixed-periods.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate } from '../../utils/index'
 import { generateFixedPeriodsWeekly } from '../generate-fixed-periods/index'

--- a/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
+++ b/src/period-calculation/monthly-periods/build-monthly-fixed-period.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import {
     formatDate,
@@ -171,7 +171,8 @@ const buildLabel: BuildLabelFunc = (options) => {
     }
 
     // needed for ethiopic calendar - the default formatter adds the era, which is not what we want in DHIS2
-    result = result.replace(/ERA\d+\s*/g, '').trim()
+    // ERA\d+ is the old CLDR format (e.g. ERA0); AA/AM are the CLDR 48+ abbreviations (Amete Alem/Amete Mihret)
+    result = result.replace(/\b(ERA\d+|AA|AM)\b\s*/g, '').trim()
     return result
 }
 

--- a/src/period-calculation/yearly-periods/build-yearly-fixed-period.ts
+++ b/src/period-calculation/yearly-periods/build-yearly-fixed-period.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../../types'
 import { fromAnyDate, formatDate, isCustomCalendar } from '../../utils/index'
 import localisationHelpers from '../../utils/localisationHelpers'
@@ -110,7 +110,8 @@ const buildLabel = (
     let result = `${fromYear} - ${toYear}`
 
     // needed for Ethiopic calendar
-    result = result.replace(/ERA\d+\s*/g, '').trim()
+    // ERA\d+ is the old CLDR format (e.g. ERA0); AA/AM are the CLDR 48+ abbreviations (Amete Alem/Amete Mihret)
+    result = result.replace(/\b(ERA\d+|AA|AM)\b\s*/g, '').trim()
 
     return result
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { calendars } from './constants/calendars'
 import { numberingSystems } from './constants/numberingSystems'
 

--- a/src/utils/convert-date.ts
+++ b/src/utils/convert-date.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
 import { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'

--- a/src/utils/from-any-date.ts
+++ b/src/utils/from-any-date.ts
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../types'
 import fromDateString from './from-date-string'
 

--- a/src/utils/from-date-string.ts
+++ b/src/utils/from-date-string.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'
 

--- a/src/utils/getNowInCalendar.spec.ts
+++ b/src/utils/getNowInCalendar.spec.ts
@@ -53,4 +53,16 @@ describe('getting Now', () => {
             year: 1400,
         })
     })
+    it('should return a valid date when no timezone is provided', () => {
+        const result = getNowInCalendar('gregory')
+        expect(result.year).toBeTruthy()
+        expect(result.month).toBeGreaterThanOrEqual(1)
+        expect(result.day).toBeGreaterThanOrEqual(1)
+    })
+    it('should default to Gregorian when called with no arguments', () => {
+        // exercises the calendarToUse = 'gregory' parameter default
+        const result = getNowInCalendar()
+        expect(result.year).toBeTruthy()
+        expect((result.calendar as { id?: string }).id).toEqual('gregory')
+    })
 })

--- a/src/utils/getNowInCalendar.ts
+++ b/src/utils/getNowInCalendar.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
 import { getCustomCalendarIfExists, isCustomCalendar } from '../utils/helpers'
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { months, Month } from '../constants/months'
 import { customCalendars, CustomCalendarTypes } from '../custom-calendars'
 import { PickerOptions } from '../types'

--- a/src/utils/localisationHelpers.ts
+++ b/src/utils/localisationHelpers.ts
@@ -1,4 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { numberingSystems } from '../constants'
 import {
     CalendarCustomLocale,

--- a/src/utils/validate-date-string.ts
+++ b/src/utils/validate-date-string.ts
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Temporal } from '@js-temporal/polyfill'
+import { Temporal } from '@js-temporal/polyfill-patched'
 import { dhis2CalendarsMap } from '../constants/dhis2CalendarsMap'
 import type { SupportedCalendar } from '../types'
 import { extractDatePartsFromDateString } from './extract-date-parts-from-date-string'

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -1,0 +1,69 @@
+# Vendored `@js-temporal/polyfill`
+
+This directory contains a verbatim copy of `@js-temporal/polyfill` v0.4.3
+(`node_modules/@js-temporal/polyfill/lib/*.ts`) with a targeted patch applied.
+
+## Why it is vendored
+
+`@js-temporal/polyfill` v0.4.3 does not handle the CLDR 48 / ICU 76 era-code
+rename for the Ethiopic calendar. ICU 76 renamed the `Intl.DateTimeFormat`
+era codes from `era0`/`era1` to `aa` (Amete Alem) and `am` (Amete Mihret).
+The polyfill only knows the old codes, so any Ethiopic date operation that
+goes through `Intl` throws a `RangeError`.
+
+The fix (adding `reviseIntlEra` to `EthiopicHelper`) is in open PR
+[js-temporal/temporal-polyfill#357](https://github.com/js-temporal/temporal-polyfill/pull/357),
+but the PR targets the v0.5 master branch, not v0.4.3. Until an upstream
+release ships the fix we carry the patched source here so all consumers of
+this library get the fix automatically.
+
+## Patch applied
+
+**File:** `temporal/calendar.ts`
+
+Added `reviseIntlEra` to `EthiopicHelper`. When `Intl.DateTimeFormat`
+returns the new CLDR 48 era codes, this method maps them back to the
+polyfill's internal names before further processing:
+
+```typescript
+override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T): T {
+  let { era, eraYear } = calendarDate
+  if (era === 'aa') era = 'era0'
+  if (era === 'am') era = 'era1'
+  return { era, eraYear } as T
+}
+```
+
+## Other modifications
+
+**All vendored files:** The TypeScript class-field declarations
+`[Symbol.toStringTag]!: 'Temporal.XXX'` were removed from every class that
+had one (`Calendar`, `PlainDate`, `PlainDateTime`, `ZonedDateTime`,
+`PlainYearMonth`, `PlainMonthDay`, `PlainTime`, `Instant`, `Duration`,
+`TimeZone`). These are type-only annotations; the runtime value is set by
+`MakeIntrinsicClass` on the prototype. Create React App's Babel compiles
+class fields in loose mode (`this[Symbol.toStringTag] = …`) which throws
+because the prototype property has `writable: false`.
+
+## Import alias
+
+All library source files import from `@js-temporal/polyfill-patched` (not
+`@js-temporal/polyfill`). The alias is resolved to this directory by:
+
+- **TypeScript / IDE:** `tsconfig.json` `paths`
+- **Jest:** `moduleNameMapper` in `package.json`
+- **Build output:** `babel-plugin-module-resolver` in `babel.config.js`
+  rewrites the import strings to relative paths so consumers receive the
+  patched code without any extra setup.
+
+## Removing the vendor copy
+
+Once an upstream release of `@js-temporal/polyfill` ships the CLDR 48 fix:
+
+1. Delete this directory (`src/vendor/`).
+2. Remove `babel.config.js`.
+3. Remove `paths` from `tsconfig.json`.
+4. Remove `moduleNameMapper` from `package.json`.
+5. Change all `from '@js-temporal/polyfill-patched'` imports back to
+   `from '@js-temporal/polyfill'`.
+6. Bump the `@js-temporal/polyfill` dependency to the fixed version.

--- a/src/vendor/index.ts
+++ b/src/vendor/index.ts
@@ -1,0 +1,4 @@
+// Satisfies `import type { Temporal } from '..'` in the vendored polyfill files.
+// In the original package those resolve to the package root; here they land in
+// this directory (src/vendor/), so we re-export from the vendored entry point.
+export * from './temporal/index'

--- a/src/vendor/temporal/calendar.ts
+++ b/src/vendor/temporal/calendar.ts
@@ -1,0 +1,2516 @@
+import { DEBUG } from './debug';
+import * as ES from './ecmascript';
+import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
+import {
+  CALENDAR_ID,
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  YEARS,
+  MONTHS,
+  WEEKS,
+  DAYS,
+  HOURS,
+  MINUTES,
+  SECONDS,
+  MILLISECONDS,
+  MICROSECONDS,
+  NANOSECONDS,
+  CreateSlots,
+  GetSlot,
+  HasSlot,
+  SetSlot
+} from './slots';
+import type { Temporal } from '..';
+import type { BuiltinCalendarId, CalendarParams as Params, CalendarReturn as Return } from './internaltypes';
+
+const ArrayIncludes = Array.prototype.includes;
+const ArrayPrototypePush = Array.prototype.push;
+const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
+const ArraySort = Array.prototype.sort;
+const MathAbs = Math.abs;
+const MathFloor = Math.floor;
+const ObjectEntries = Object.entries;
+const ObjectKeys = Object.keys;
+
+/**
+ * Shape of internal implementation of each built-in calendar. Note that
+ * parameter types are simpler than CalendarProtocol because the `Calendar`
+ * class performs validation and parameter normalization before handing control
+ * over to CalendarImpl.
+ *
+ * There are two instances of this interface: one for the ISO calendar and
+ * another that handles logic that's the same across all non-ISO calendars. The
+ * latter is cloned for each non-ISO calendar at the end of this file.
+ */
+interface CalendarImpl {
+  year(date: Temporal.PlainDate | Temporal.PlainYearMonth): number;
+  month(date: Temporal.PlainDate | Temporal.PlainYearMonth | Temporal.PlainMonthDay): number;
+  monthCode(date: Temporal.PlainDate | Temporal.PlainYearMonth | Temporal.PlainMonthDay): string;
+  day(date: Temporal.PlainDate | Temporal.PlainMonthDay): number;
+  era(date: Temporal.PlainDate | Temporal.PlainYearMonth): string | undefined;
+  eraYear(date: Temporal.PlainDate | Temporal.PlainYearMonth): number | undefined;
+  dayOfWeek(date: Temporal.PlainDate): number;
+  dayOfYear(date: Temporal.PlainDate): number;
+  weekOfYear(date: Temporal.PlainDate): number;
+  daysInWeek(date: Temporal.PlainDate): number;
+  daysInMonth(date: Temporal.PlainDate | Temporal.PlainYearMonth): number;
+  daysInYear(date: Temporal.PlainDate | Temporal.PlainYearMonth): number;
+  monthsInYear(date: Temporal.PlainDate | Temporal.PlainYearMonth): number;
+  inLeapYear(date: Temporal.PlainDate | Temporal.PlainYearMonth): boolean;
+  dateFromFields(
+    fields: Params['dateFromFields'][0],
+    options: NonNullable<Params['dateFromFields'][1]>,
+    calendar: Temporal.Calendar
+  ): Temporal.PlainDate;
+  yearMonthFromFields(
+    fields: Params['yearMonthFromFields'][0],
+    options: NonNullable<Params['yearMonthFromFields'][1]>,
+    calendar: Temporal.Calendar
+  ): Temporal.PlainYearMonth;
+  monthDayFromFields(
+    fields: Params['monthDayFromFields'][0],
+    options: NonNullable<Params['monthDayFromFields'][1]>,
+    calendar: Temporal.Calendar
+  ): Temporal.PlainMonthDay;
+  dateAdd(
+    date: Temporal.PlainDate,
+    years: number,
+    months: number,
+    weeks: number,
+    days: number,
+    overflow: Overflow,
+    calendar: Temporal.Calendar
+  ): Temporal.PlainDate;
+  dateUntil(
+    one: Temporal.PlainDate,
+    two: Temporal.PlainDate,
+    largestUnit: 'year' | 'month' | 'week' | 'day'
+  ): { years: number; months: number; weeks: number; days: number };
+  fields(fields: string[]): string[];
+  mergeFields(fields: Record<string, unknown>, additionalFields: Record<string, unknown>): Record<string, unknown>;
+}
+
+/**
+ * Implementations for each calendar. Non-ISO calendars have an extra `helper`
+ * property that provides additional per-calendar logic.
+ */
+const impl = {} as {
+  iso8601: CalendarImpl;
+} & {
+  [id in Exclude<BuiltinCalendarId, 'iso8601'>]: NonIsoImpl;
+};
+
+/**
+ * Thin wrapper around the implementation of each built-in calendar. This
+ * class's methods follow a similar pattern:
+ * 1. Validate parameters
+ * 2. Fill in default options (for methods where options are present)
+ * 3. Simplify and/or normalize parameters. For example, some methods accept
+ *    PlainDate, PlainDateTime, ZonedDateTime, etc. and these are normalized to
+ *    PlainDate.
+ * 4. Look up the ID of the built-in calendar
+ * 5. Fetch the implementation object for that ID.
+ * 6. Call the corresponding method in the implementation object.
+ */
+export class Calendar implements Temporal.Calendar {
+  constructor(idParam: Params['constructor'][0]) {
+    // Note: if the argument is not passed, IsBuiltinCalendar("undefined") will fail. This check
+    //       exists only to improve the error message.
+    if (arguments.length < 1) {
+      throw new RangeError('missing argument: id is required');
+    }
+
+    const id = ES.ToString(idParam);
+    if (!ES.IsBuiltinCalendar(id)) throw new RangeError(`invalid calendar identifier ${id}`);
+    CreateSlots(this);
+    SetSlot(this, CALENDAR_ID, id);
+
+    if (DEBUG) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${id}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+  get id(): Return['id'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.ToString(this);
+  }
+  dateFromFields(
+    fields: Params['dateFromFields'][0],
+    optionsParam: Params['dateFromFields'][1] = undefined
+  ): Return['dateFromFields'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
+    const options = ES.GetOptionsObject(optionsParam);
+    return impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, options, this);
+  }
+  yearMonthFromFields(
+    fields: Params['yearMonthFromFields'][0],
+    optionsParam: Params['yearMonthFromFields'][1] = undefined
+  ): Return['yearMonthFromFields'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
+    const options = ES.GetOptionsObject(optionsParam);
+    return impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, options, this);
+  }
+  monthDayFromFields(
+    fields: Params['monthDayFromFields'][0],
+    optionsParam: Params['monthDayFromFields'][1] = undefined
+  ): Return['monthDayFromFields'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
+    const options = ES.GetOptionsObject(optionsParam);
+    return impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, options, this);
+  }
+  fields(fields: Params['fields'][0]): Return['fields'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const fieldsArray = [] as string[];
+    const allowed = new Set([
+      'year',
+      'month',
+      'monthCode',
+      'day',
+      'hour',
+      'minute',
+      'second',
+      'millisecond',
+      'microsecond',
+      'nanosecond'
+    ]);
+    for (const name of fields) {
+      if (typeof name !== 'string') throw new TypeError('invalid fields');
+      if (!allowed.has(name)) throw new RangeError(`invalid field name ${name}`);
+      allowed.delete(name);
+      ArrayPrototypePush.call(fieldsArray, name);
+    }
+    return impl[GetSlot(this, CALENDAR_ID)].fields(fieldsArray);
+  }
+  mergeFields(fields: Params['mergeFields'][0], additionalFields: Params['mergeFields'][1]): Return['mergeFields'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return impl[GetSlot(this, CALENDAR_ID)].mergeFields(fields, additionalFields);
+  }
+  dateAdd(
+    dateParam: Params['dateAdd'][0],
+    durationParam: Params['dateAdd'][1],
+    optionsParam: Params['dateAdd'][2] = undefined
+  ): Return['dateAdd'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const date = ES.ToTemporalDate(dateParam);
+    const duration = ES.ToTemporalDuration(durationParam);
+    const options = ES.GetOptionsObject(optionsParam);
+    const overflow = ES.ToTemporalOverflow(options);
+    const { days } = ES.BalanceDuration(
+      GetSlot(duration, DAYS),
+      GetSlot(duration, HOURS),
+      GetSlot(duration, MINUTES),
+      GetSlot(duration, SECONDS),
+      GetSlot(duration, MILLISECONDS),
+      GetSlot(duration, MICROSECONDS),
+      GetSlot(duration, NANOSECONDS),
+      'day'
+    );
+    return impl[GetSlot(this, CALENDAR_ID)].dateAdd(
+      date,
+      GetSlot(duration, YEARS),
+      GetSlot(duration, MONTHS),
+      GetSlot(duration, WEEKS),
+      days,
+      overflow,
+      this
+    );
+  }
+  dateUntil(
+    oneParam: Params['dateUntil'][0],
+    twoParam: Params['dateUntil'][1],
+    optionsParam: Params['dateUntil'][2] = undefined
+  ): Return['dateUntil'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const one = ES.ToTemporalDate(oneParam);
+    const two = ES.ToTemporalDate(twoParam);
+    const options = ES.GetOptionsObject(optionsParam);
+    let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
+    if (largestUnit === 'auto') largestUnit = 'day';
+    const { years, months, weeks, days } = impl[GetSlot(this, CALENDAR_ID)].dateUntil(one, two, largestUnit);
+    const Duration = GetIntrinsic('%Temporal.Duration%');
+    return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  }
+  year(dateParam: Params['year'][0]): Return['year'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].year(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  month(dateParam: Params['month'][0]): Return['month'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (ES.IsTemporalMonthDay(date)) throw new TypeError('use monthCode on PlainMonthDay instead');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].month(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  monthCode(dateParam: Params['monthCode'][0]): Return['monthCode'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date) && !ES.IsTemporalMonthDay(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].monthCode(
+      date as Temporal.PlainDate | Temporal.PlainMonthDay | Temporal.PlainYearMonth
+    );
+  }
+  day(dateParam: Params['day'][0]): Return['day'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].day(date as Temporal.PlainDate | Temporal.PlainMonthDay);
+  }
+  era(dateParam: Params['era'][0]): Return['era'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].era(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  eraYear(dateParam: Params['eraYear'][0]): Return['eraYear'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].eraYear(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  dayOfWeek(dateParam: Params['dayOfWeek'][0]): Return['dayOfWeek'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const date = ES.ToTemporalDate(dateParam);
+    return impl[GetSlot(this, CALENDAR_ID)].dayOfWeek(date);
+  }
+  dayOfYear(dateParam: Params['dayOfYear'][0]): Return['dayOfYear'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const date = ES.ToTemporalDate(dateParam);
+    return impl[GetSlot(this, CALENDAR_ID)].dayOfYear(date);
+  }
+  weekOfYear(dateParam: Params['weekOfYear'][0]): Return['weekOfYear'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const date = ES.ToTemporalDate(dateParam);
+    return impl[GetSlot(this, CALENDAR_ID)].weekOfYear(date);
+  }
+  daysInWeek(dateParam: Params['daysInWeek'][0]): Return['daysInWeek'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const date = ES.ToTemporalDate(dateParam);
+    return impl[GetSlot(this, CALENDAR_ID)].daysInWeek(date);
+  }
+  daysInMonth(dateParam: Params['daysInMonth'][0]): Return['daysInMonth'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].daysInMonth(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  daysInYear(dateParam: Params['daysInYear'][0]): Return['daysInYear'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].daysInYear(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  monthsInYear(dateParam: Params['monthsInYear'][0]): Return['monthsInYear'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].monthsInYear(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  inLeapYear(dateParam: Params['inLeapYear'][0]): Return['inLeapYear'] {
+    let date = dateParam;
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(date)) date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].inLeapYear(date as Temporal.PlainDate | Temporal.PlainYearMonth);
+  }
+  toString(): string {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR_ID);
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.ToString(this);
+  }
+  static from(item: Params['from'][0]): Return['from'] {
+    return ES.ToTemporalCalendar(item);
+  }
+}
+
+MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
+DefineIntrinsic('Temporal.Calendar.from', Calendar.from);
+
+/**
+ * Implementation for the ISO 8601 calendar. This is the only calendar that's
+ * guaranteed to be supported by all ECMAScript implementations, including those
+ * without Intl (ECMA-402) support.
+ */
+impl['iso8601'] = {
+  dateFromFields(fieldsParam, options, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
+    let fields = ES.PrepareTemporalFields(fieldsParam, ['day', 'month', 'monthCode', 'year'], ['year', 'day']);
+    fields = resolveNonLunisolarMonth(fields);
+    let { year, month, day } = fields;
+    ({ year, month, day } = ES.RegulateISODate(year, month, day, overflow));
+    return ES.CreateTemporalDate(year, month, day, calendar);
+  },
+  yearMonthFromFields(fieldsParam, options, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
+    let fields = ES.PrepareTemporalFields(fieldsParam, ['month', 'monthCode', 'year'], ['year']);
+    fields = resolveNonLunisolarMonth(fields);
+    let { year, month } = fields;
+    ({ year, month } = ES.RegulateISOYearMonth(year, month, overflow));
+    return ES.CreateTemporalYearMonth(year, month, calendar, /* referenceISODay = */ 1);
+  },
+  monthDayFromFields(fieldsParam, options, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
+    let fields = ES.PrepareTemporalFields(fieldsParam, ['day', 'month', 'monthCode', 'year'], ['day']);
+    if (fields.month !== undefined && fields.year === undefined && fields.monthCode === undefined) {
+      throw new TypeError('either year or monthCode required with month');
+    }
+    const useYear = fields.monthCode === undefined;
+    const referenceISOYear = 1972;
+    fields = resolveNonLunisolarMonth(fields);
+    let { month, day, year } = fields;
+    ({ month, day } = ES.RegulateISODate(useYear ? year : referenceISOYear, month, day, overflow));
+    return ES.CreateTemporalMonthDay(month, day, calendar, referenceISOYear);
+  },
+  fields(fields) {
+    return fields;
+  },
+  mergeFields(fields, additionalFields) {
+    const merged: typeof fields = {};
+    for (const nextKey of ObjectKeys(fields)) {
+      if (nextKey === 'month' || nextKey === 'monthCode') continue;
+      merged[nextKey] = fields[nextKey];
+    }
+    const newKeys = ObjectKeys(additionalFields);
+    for (const nextKey of newKeys) {
+      merged[nextKey] = additionalFields[nextKey];
+    }
+    if (!ArrayIncludes.call(newKeys, 'month') && !ArrayIncludes.call(newKeys, 'monthCode')) {
+      const { month, monthCode } = fields;
+      if (month !== undefined) merged.month = month;
+      if (monthCode !== undefined) merged.monthCode = monthCode;
+    }
+    return merged;
+  },
+  dateAdd(date, years, months, weeks, days, overflow, calendar) {
+    let year = GetSlot(date, ISO_YEAR);
+    let month = GetSlot(date, ISO_MONTH);
+    let day = GetSlot(date, ISO_DAY);
+    ({ year, month, day } = ES.AddISODate(year, month, day, years, months, weeks, days, overflow));
+    return ES.CreateTemporalDate(year, month, day, calendar);
+  },
+  dateUntil(one, two, largestUnit) {
+    return ES.DifferenceISODate(
+      GetSlot(one, ISO_YEAR),
+      GetSlot(one, ISO_MONTH),
+      GetSlot(one, ISO_DAY),
+      GetSlot(two, ISO_YEAR),
+      GetSlot(two, ISO_MONTH),
+      GetSlot(two, ISO_DAY),
+      largestUnit
+    );
+  },
+  year(date) {
+    return GetSlot(date, ISO_YEAR);
+  },
+  era() {
+    return undefined;
+  },
+  eraYear() {
+    return undefined;
+  },
+  month(date) {
+    return GetSlot(date, ISO_MONTH);
+  },
+  monthCode(date) {
+    return buildMonthCode(GetSlot(date, ISO_MONTH));
+  },
+  day(date) {
+    return GetSlot(date, ISO_DAY);
+  },
+  dayOfWeek(date) {
+    return ES.DayOfWeek(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  },
+  dayOfYear(date) {
+    return ES.DayOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  },
+  weekOfYear(date) {
+    return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  },
+  daysInWeek() {
+    return 7;
+  },
+  daysInMonth(date) {
+    return ES.ISODaysInMonth(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH));
+  },
+  daysInYear(dateParam) {
+    let date = dateParam;
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date);
+    return ES.LeapYear(GetSlot(date, ISO_YEAR)) ? 366 : 365;
+  },
+  monthsInYear() {
+    return 12;
+  },
+  inLeapYear(dateParam) {
+    let date = dateParam;
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date);
+    return ES.LeapYear(GetSlot(date, ISO_YEAR));
+  }
+};
+
+// Note: Built-in calendars other than iso8601 are not part of the Temporal
+// proposal for ECMA-262. These calendars will be standardized as part of
+// ECMA-402. Code below here includes an implementation of these calendars to
+// validate the Temporal API and to get feedback. However, native non-ISO
+// calendar behavior is at least somewhat implementation-defined, so may not
+// match this polyfill's output exactly.
+//
+// Some ES implementations don't include ECMA-402. For this reason, it's helpful
+// to ensure a clean separation between the ISO calendar implementation which is
+// a part of ECMA-262 and the non-ISO calendar implementation which requires
+// ECMA-402.
+//
+// To ensure this separation, the implementation is split. A `CalendarImpl`
+// interface powers both ISO and non-ISO calendars. That interface is extended
+// (as `NonIsoImpl`) with a `helper` property that implements logic that varies
+// between each non-ISO calendar.
+
+/**
+ * Interface for non-ISO calendar implementations. The `helper` is an abstract
+ * base class that's extended for each non-ISO calendar, e.g. `HebrewHelper`.
+ */
+interface NonIsoImpl extends CalendarImpl {
+  helper: HelperBase;
+}
+
+/**
+ * This type is passed through from Calendar#dateFromFields().
+ * `monthExtra` is additional information used internally to identify lunisolar leap months.
+ */
+type CalendarDateFields = Params['dateFromFields'][0] & { monthExtra?: string };
+
+/**
+ * This is a "fully populated" calendar date record. It's only lacking
+ * `era`/`eraYear` (which may not be present in all calendars) and `monthExtra`
+ * which is only used in some cases.
+ */
+type FullCalendarDate = {
+  era?: string;
+  eraYear?: number;
+  year: number;
+  month: number;
+  monthCode: string;
+  day: number;
+  monthExtra?: string;
+};
+
+// The types below are various subsets of calendar dates
+type CalendarYMD = { year: number; month: number; day: number };
+type CalendarYM = { year: number; month: number };
+type CalendarYearOnly = { year: number };
+type EraAndEraYear = { era: string; eraYear: number };
+
+/** Record representing YMD of an ISO calendar date */
+type IsoYMD = { year: number; month: number; day: number };
+
+type Overflow = NonNullable<Temporal.AssignmentOptions['overflow']>;
+
+function monthCodeNumberPart(monthCode: string) {
+  if (!monthCode.startsWith('M')) {
+    throw new RangeError(`Invalid month code: ${monthCode}.  Month codes must start with M.`);
+  }
+  const month = +monthCode.slice(1);
+  if (isNaN(month)) throw new RangeError(`Invalid month code: ${monthCode}`);
+  return month;
+}
+
+function buildMonthCode(month: number | string, leap = false) {
+  return `M${month.toString().padStart(2, '0')}${leap ? 'L' : ''}`;
+}
+
+/**
+ * Safely merge a month, monthCode pair into an integer month.
+ * If both are present, make sure they match.
+ * This logic doesn't work for lunisolar calendars!
+ * */
+function resolveNonLunisolarMonth<T extends { monthCode?: string; month?: number }>(
+  calendarDate: T,
+  overflow: Overflow | undefined = undefined,
+  monthsPerYear = 12
+) {
+  let { month, monthCode } = calendarDate;
+  if (monthCode === undefined) {
+    if (month === undefined) throw new TypeError('Either month or monthCode are required');
+    // The ISO calendar uses the default (undefined) value because it does
+    // constrain/reject after this method returns. Non-ISO calendars, however,
+    // rely on this function to constrain/reject out-of-range `month` values.
+    if (overflow === 'reject') ES.RejectToRange(month, 1, monthsPerYear);
+    if (overflow === 'constrain') month = ES.ConstrainToRange(month, 1, monthsPerYear);
+    monthCode = buildMonthCode(month);
+  } else {
+    const numberPart = monthCodeNumberPart(monthCode);
+    if (month !== undefined && month !== numberPart) {
+      throw new RangeError(`monthCode ${monthCode} and month ${month} must match if both are present`);
+    }
+    if (monthCode !== buildMonthCode(numberPart)) {
+      throw new RangeError(`Invalid month code: ${monthCode}`);
+    }
+    month = numberPart;
+    if (month < 1 || month > monthsPerYear) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+  }
+  return { ...calendarDate, month, monthCode };
+}
+
+type CachedTypes = Temporal.PlainYearMonth | Temporal.PlainDate | Temporal.PlainMonthDay;
+
+/**
+ * This prototype implementation of non-ISO calendars makes many repeated calls
+ * to Intl APIs which may be slow (e.g. >0.2ms). This trivial cache will speed
+ * up these repeat accesses. Each cache instance is associated (via a WeakMap)
+ * to a specific Temporal object, which speeds up multiple calendar calls on the
+ * same Temporal object instance.  No invalidation or pruning is necessary
+ * because each object's cache is thrown away when the object is GC-ed.
+ */
+class OneObjectCache {
+  map = new Map();
+  calls = 0;
+  now: number;
+  hits = 0;
+  misses = 0;
+  constructor(cacheToClone?: OneObjectCache) {
+    this.now = globalThis.performance ? globalThis.performance.now() : Date.now();
+    if (cacheToClone !== undefined) {
+      let i = 0;
+      for (const entry of cacheToClone.map.entries()) {
+        if (++i > OneObjectCache.MAX_CACHE_ENTRIES) break;
+        this.map.set(...entry);
+      }
+    }
+  }
+  get(key: string) {
+    const result = this.map.get(key);
+    if (result) {
+      this.hits++;
+      this.report();
+    }
+    this.calls++;
+    return result;
+  }
+  set(key: string, value: unknown) {
+    this.map.set(key, value);
+    this.misses++;
+    this.report();
+  }
+  report() {
+    /*
+    if (this.calls === 0) return;
+    const ms = (globalThis.performance ? globalThis.performance.now() : Date.now()) - this.now;
+    const hitRate = ((100 * this.hits) / this.calls).toFixed(0);
+    console.log(`${this.calls} calls in ${ms.toFixed(2)}ms. Hits: ${this.hits} (${hitRate}%). Misses: ${this.misses}.`);
+    */
+  }
+  setObject(obj: CachedTypes) {
+    if (OneObjectCache.objectMap.get(obj)) throw new RangeError('object already cached');
+    OneObjectCache.objectMap.set(obj, this);
+    this.report();
+  }
+
+  static objectMap = new WeakMap();
+  static MAX_CACHE_ENTRIES = 1000;
+
+  /**
+   * Returns a WeakMap-backed cache that's used to store expensive results
+   * that are associated with a particular Temporal object instance.
+   *
+   * @param obj - object to associate with the cache
+   */
+  static getCacheForObject(obj: CachedTypes) {
+    let cache = OneObjectCache.objectMap.get(obj);
+    if (!cache) {
+      cache = new OneObjectCache();
+      OneObjectCache.objectMap.set(obj, cache);
+    }
+    return cache;
+  }
+}
+
+function toUtcIsoDateString({ isoYear, isoMonth, isoDay }: { isoYear: number; isoMonth: number; isoDay: number }) {
+  const yearString = ES.ISOYearString(isoYear);
+  const monthString = ES.ISODateTimePartString(isoMonth);
+  const dayString = ES.ISODateTimePartString(isoDay);
+  return `${yearString}-${monthString}-${dayString}T00:00Z`;
+}
+
+function simpleDateDiff(one: CalendarYMD, two: CalendarYMD) {
+  return {
+    years: one.year - two.year,
+    months: one.month - two.month,
+    days: one.day - two.day
+  };
+}
+
+/**
+ * Implementation helper that's common to all non-ISO calendars
+ */
+abstract class HelperBase {
+  abstract id: BuiltinCalendarId;
+  abstract monthsInYear(calendarDate: CalendarYearOnly, cache?: OneObjectCache): number;
+  abstract maximumMonthLength(calendarDate?: CalendarYM): number;
+  abstract minimumMonthLength(calendarDate?: CalendarYM): number;
+  abstract estimateIsoDate(calendarDate: CalendarYMD): IsoYMD;
+  abstract inLeapYear(calendarDate: CalendarYearOnly, cache?: OneObjectCache): boolean;
+  abstract calendarType: 'solar' | 'lunar' | 'lunisolar';
+  reviseIntlEra?<T extends Partial<EraAndEraYear>>(calendarDate: T, isoDate: IsoYMD): T;
+  constantEra?: string;
+  checkIcuBugs?(isoDate: IsoYMD): void;
+  private formatter?: globalThis.Intl.DateTimeFormat;
+  getFormatter() {
+    // `new Intl.DateTimeFormat()` is amazingly slow and chews up RAM. Per
+    // https://bugs.chromium.org/p/v8/issues/detail?id=6528#c4, we cache one
+    // DateTimeFormat instance per calendar. Caching is lazy so we only pay for
+    // calendars that are used. Note that the nonIsoHelperBase object is spread
+    // into each each calendar's implementation before any cache is created, so
+    // each calendar gets its own separate cached formatter.
+    if (typeof this.formatter === 'undefined') {
+      this.formatter = new IntlDateTimeFormat(`en-US-u-ca-${this.id}`, {
+        day: 'numeric',
+        month: 'numeric',
+        year: 'numeric',
+        era: this.eraLength,
+        timeZone: 'UTC'
+      });
+    }
+    return this.formatter;
+  }
+  isoToCalendarDate(isoDate: IsoYMD, cache: OneObjectCache): FullCalendarDate {
+    const { year: isoYear, month: isoMonth, day: isoDay } = isoDate;
+    const key = JSON.stringify({ func: 'isoToCalendarDate', isoYear, isoMonth, isoDay, id: this.id });
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const dateTimeFormat = this.getFormatter();
+    let parts, isoString;
+    try {
+      isoString = toUtcIsoDateString({ isoYear, isoMonth, isoDay });
+      parts = dateTimeFormat.formatToParts(new Date(isoString));
+    } catch (e: unknown) {
+      throw new RangeError(`Invalid ISO date: ${JSON.stringify({ isoYear, isoMonth, isoDay })}`);
+    }
+    const result: Partial<FullCalendarDate> = {};
+    for (let { type, value } of parts) {
+      if (type === 'year') result.eraYear = +value;
+      // TODO: remove this type annotation when `relatedYear` gets into TS lib types
+      if (type === ('relatedYear' as Intl.DateTimeFormatPartTypes)) result.eraYear = +value;
+      if (type === 'month') {
+        const matches = /^([0-9]*)(.*?)$/.exec(value);
+        if (!matches || matches.length != 3 || (!matches[1] && !matches[2])) {
+          throw new RangeError(`Unexpected month: ${value}`);
+        }
+        // If the month has no numeric part (should only see this for the Hebrew
+        // calendar with newer FF / Chromium versions; see
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1751833) then set a
+        // placeholder month index of `1` and rely on the derived class to
+        // calculate the correct month index from the month name stored in
+        // `monthExtra`.
+        result.month = matches[1] ? +matches[1] : 1;
+        if (result.month < 1) {
+          throw new RangeError(
+            `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
+              ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10527)'
+          );
+        }
+        if (result.month > 13) {
+          throw new RangeError(
+            `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
+              ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
+          );
+        }
+
+        // The ICU formats for the Hebrew calendar no longer support a numeric
+        // month format. So we'll rely on the derived class to interpret it.
+        // `monthExtra` is also used on the Chinese calendar to handle a suffix
+        // "bis" indicating a leap month.
+        if (matches[2]) result.monthExtra = matches[2];
+      }
+      if (type === 'day') result.day = +value;
+      if (this.hasEra && type === 'era' && value != null && value !== '') {
+        // The convention for Temporal era values is lowercase, so following
+        // that convention in this prototype. Punctuation is removed, accented
+        // letters are normalized, and spaces are replaced with dashes.
+        // E.g.: "ERA0" => "era0", "Before R.O.C." => "before-roc", "En’ō" => "eno"
+        // The call to normalize() and the replacement regex deals with era
+        // names that contain non-ASCII characters like Japanese eras. Also
+        // ignore extra content in parentheses like JPN era date ranges.
+        value = value.split(' (')[0];
+        result.era = value
+          .normalize('NFD')
+          .replace(/[^-0-9 \p{L}]/gu, '')
+          .replace(' ', '-')
+          .toLowerCase();
+      }
+    }
+    if (result.eraYear === undefined) {
+      // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
+      // output of Intl.DateTimeFormat.formatToParts.
+      throw new RangeError(
+        `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
+      );
+    }
+    // Translate eras that may be handled differently by Temporal vs. by Intl
+    // (e.g. Japanese pre-Meiji eras). See https://github.com/tc39/proposal-temporal/issues/526.
+    if (this.reviseIntlEra) {
+      const { era, eraYear } = this.reviseIntlEra(result, isoDate);
+      result.era = era;
+      result.eraYear = eraYear;
+    }
+    if (this.checkIcuBugs) this.checkIcuBugs(isoDate);
+
+    const calendarDate = this.adjustCalendarDate(result, cache, 'constrain', true);
+    if (calendarDate.year === undefined) throw new RangeError(`Missing year converting ${JSON.stringify(isoDate)}`);
+    if (calendarDate.month === undefined) throw new RangeError(`Missing month converting ${JSON.stringify(isoDate)}`);
+    if (calendarDate.day === undefined) throw new RangeError(`Missing day converting ${JSON.stringify(isoDate)}`);
+    cache.set(key, calendarDate);
+    // Also cache the reverse mapping
+    ['constrain', 'reject'].forEach((overflow) => {
+      const keyReverse = JSON.stringify({
+        func: 'calendarToIsoDate',
+        year: calendarDate.year,
+        month: calendarDate.month,
+        day: calendarDate.day,
+        overflow,
+        id: this.id
+      });
+      cache.set(keyReverse, isoDate);
+    });
+    return calendarDate;
+  }
+  validateCalendarDate(calendarDate: Partial<FullCalendarDate>): asserts calendarDate is FullCalendarDate {
+    const { era, month, year, day, eraYear, monthCode, monthExtra } = calendarDate as Partial<FullCalendarDate>;
+    // When there's a suffix (e.g. "5bis" for a leap month in Chinese calendar)
+    // the derived class must deal with it.
+    if (monthExtra !== undefined) throw new RangeError('Unexpected `monthExtra` value');
+    if (year === undefined && eraYear === undefined) throw new TypeError('year or eraYear is required');
+    if (month === undefined && monthCode === undefined) throw new TypeError('month or monthCode is required');
+    if (day === undefined) throw new RangeError('Missing day');
+    if (monthCode !== undefined) {
+      if (typeof monthCode !== 'string') {
+        throw new RangeError(`monthCode must be a string, not ${typeof monthCode}`);
+      }
+      if (!/^M([01]?\d)(L?)$/.test(monthCode)) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+    }
+    if (this.constantEra) {
+      if (era !== undefined && era !== this.constantEra) {
+        throw new RangeError(`era must be ${this.constantEra}, not ${era}`);
+      }
+      if (eraYear !== undefined && year !== undefined && eraYear !== year) {
+        throw new RangeError(`eraYear ${eraYear} does not match year ${year}`);
+      }
+    }
+  }
+  /**
+   * Allows derived calendars to add additional fields and/or to make
+   * adjustments e.g. to set the era based on the date or to revise the month
+   * number in lunisolar calendars per
+   * https://github.com/tc39/proposal-temporal/issues/1203.
+   *
+   * The base implementation fills in missing values by assuming the simplest
+   * possible calendar:
+   * - no eras or a constant era defined in `.constantEra`
+   * - non-lunisolar calendar (no leap months)
+   * */
+  adjustCalendarDate(
+    calendarDateParam: Partial<FullCalendarDate>,
+    cache: OneObjectCache | undefined = undefined,
+    overflow: Overflow = 'constrain',
+    // This param is only used by derived classes
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    fromLegacyDate = false
+  ): FullCalendarDate {
+    if (this.calendarType === 'lunisolar') throw new RangeError('Override required for lunisolar calendars');
+    let calendarDate = calendarDateParam;
+    this.validateCalendarDate(calendarDate);
+    // For calendars that always use the same era, set it here so that derived
+    // calendars won't need to implement this method simply to set the era.
+    if (this.constantEra) {
+      // year and eraYear always match when there's only one possible era
+      const { year, eraYear } = calendarDate;
+      calendarDate = {
+        ...calendarDate,
+        era: this.constantEra,
+        year: year !== undefined ? year : eraYear,
+        eraYear: eraYear !== undefined ? eraYear : year
+      };
+    }
+
+    const largestMonth = this.monthsInYear(calendarDate as CalendarYearOnly, cache);
+    let { month, monthCode } = calendarDate;
+
+    ({ month, monthCode } = resolveNonLunisolarMonth(calendarDate, overflow, largestMonth));
+    return { ...(calendarDate as typeof calendarDate & CalendarYMD), month, monthCode };
+  }
+  regulateMonthDayNaive(calendarDate: FullCalendarDate, overflow: Overflow, cache: OneObjectCache): FullCalendarDate {
+    const largestMonth = this.monthsInYear(calendarDate, cache);
+    let { month, day } = calendarDate;
+    if (overflow === 'reject') {
+      ES.RejectToRange(month, 1, largestMonth);
+      ES.RejectToRange(day, 1, this.maximumMonthLength(calendarDate));
+    } else {
+      month = ES.ConstrainToRange(month, 1, largestMonth);
+      day = ES.ConstrainToRange(day, 1, this.maximumMonthLength({ ...calendarDate, month }));
+    }
+    return { ...calendarDate, month, day };
+  }
+  calendarToIsoDate(dateParam: CalendarDateFields, overflow: Overflow = 'constrain', cache: OneObjectCache): IsoYMD {
+    const originalDate = dateParam as Partial<FullCalendarDate>;
+    // First, normalize the calendar date to ensure that (year, month, day)
+    // are all present, converting monthCode and eraYear if needed.
+    let date = this.adjustCalendarDate(dateParam, cache, overflow, false);
+
+    // Fix obviously out-of-bounds values. Values that are valid generally, but
+    // not in this particular year, may not be caught here for some calendars.
+    // If so, these will be handled lower below.
+    date = this.regulateMonthDayNaive(date, overflow, cache);
+
+    const { year, month, day } = date;
+    const key = JSON.stringify({ func: 'calendarToIsoDate', year, month, day, overflow, id: this.id });
+    let cached = cache.get(key);
+    if (cached) return cached;
+    // If YMD are present in the input but the input has been constrained
+    // already, then cache both the original value and the constrained value.
+    let keyOriginal;
+    if (
+      originalDate.year !== undefined &&
+      originalDate.month !== undefined &&
+      originalDate.day !== undefined &&
+      (originalDate.year !== date.year || originalDate.month !== date.month || originalDate.day !== date.day)
+    ) {
+      keyOriginal = JSON.stringify({
+        func: 'calendarToIsoDate',
+        year: originalDate.year,
+        month: originalDate.month,
+        day: originalDate.day,
+        overflow,
+        id: this.id
+      });
+      cached = cache.get(keyOriginal);
+      if (cached) return cached;
+    }
+
+    // First, try to roughly guess the result
+    let isoEstimate = this.estimateIsoDate({ year, month, day });
+    const calculateSameMonthResult = (diffDays: number) => {
+      // If the estimate is in the same year & month as the target, then we can
+      // calculate the result exactly and short-circuit any additional logic.
+      // This optimization assumes that months are continuous. It would break if
+      // a calendar skipped days, like the Julian->Gregorian switchover. But the
+      // only ICU calendars that currently skip days (japanese/roc/buddhist) is
+      // a bug (https://bugs.chromium.org/p/chromium/issues/detail?id=1173158)
+      // that's currently detected by `checkIcuBugs()` which will throw. So
+      // this optimization should be safe for all ICU calendars.
+      let testIsoEstimate = this.addDaysIso(isoEstimate, diffDays);
+      if (date.day > this.minimumMonthLength(date)) {
+        // There's a chance that the calendar date is out of range. Throw or
+        // constrain if so.
+        let testCalendarDate = this.isoToCalendarDate(testIsoEstimate, cache);
+        while (testCalendarDate.month !== month || testCalendarDate.year !== year) {
+          if (overflow === 'reject') {
+            throw new RangeError(`day ${day} does not exist in month ${month} of year ${year}`);
+          }
+          // Back up a day at a time until we're not hanging over the month end
+          testIsoEstimate = this.addDaysIso(testIsoEstimate, -1);
+          testCalendarDate = this.isoToCalendarDate(testIsoEstimate, cache);
+        }
+      }
+      return testIsoEstimate;
+    };
+    let sign = 0;
+    let roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+    let diff = simpleDateDiff(date, roundtripEstimate);
+    if (diff.years !== 0 || diff.months !== 0 || diff.days !== 0) {
+      const diffTotalDaysEstimate = diff.years * 365 + diff.months * 30 + diff.days;
+      isoEstimate = this.addDaysIso(isoEstimate, diffTotalDaysEstimate);
+      roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+      diff = simpleDateDiff(date, roundtripEstimate);
+      if (diff.years === 0 && diff.months === 0) {
+        isoEstimate = calculateSameMonthResult(diff.days);
+      } else {
+        sign = this.compareCalendarDates(date, roundtripEstimate);
+      }
+    }
+    // If the initial guess is not in the same month, then then bisect the
+    // distance to the target, starting with 8 days per step.
+    let increment = 8;
+    let maybeConstrained = false;
+    while (sign) {
+      isoEstimate = this.addDaysIso(isoEstimate, sign * increment);
+      const oldRoundtripEstimate = roundtripEstimate;
+      roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+      const oldSign = sign;
+      sign = this.compareCalendarDates(date, roundtripEstimate);
+      if (sign) {
+        diff = simpleDateDiff(date, roundtripEstimate);
+        if (diff.years === 0 && diff.months === 0) {
+          isoEstimate = calculateSameMonthResult(diff.days);
+          // Signal the loop condition that there's a match.
+          sign = 0;
+          // If the calendar day is larger than the minimal length for this
+          // month, then it might be larger than the actual length of the month.
+          // So we won't cache it as the correct calendar date for this ISO
+          // date.
+          maybeConstrained = date.day > this.minimumMonthLength(date);
+        } else if (oldSign && sign !== oldSign) {
+          if (increment > 1) {
+            // If the estimate overshot the target, try again with a smaller increment
+            // in the reverse direction.
+            increment /= 2;
+          } else {
+            // Increment is 1, and neither the previous estimate nor the new
+            // estimate is correct. The only way that can happen is if the
+            // original date was an invalid value that will be constrained or
+            // rejected here.
+            if (overflow === 'reject') {
+              throw new RangeError(`Can't find ISO date from calendar date: ${JSON.stringify({ ...originalDate })}`);
+            } else {
+              // To constrain, pick the earliest value
+              const order = this.compareCalendarDates(roundtripEstimate, oldRoundtripEstimate);
+              // If current value is larger, then back up to the previous value.
+              if (order > 0) isoEstimate = this.addDaysIso(isoEstimate, -1);
+              maybeConstrained = true;
+              sign = 0;
+            }
+          }
+        }
+      }
+    }
+    cache.set(key, isoEstimate);
+    if (keyOriginal) cache.set(keyOriginal, isoEstimate);
+    if (
+      date.year === undefined ||
+      date.month === undefined ||
+      date.day === undefined ||
+      date.monthCode === undefined ||
+      (this.hasEra && (date.era === undefined || date.eraYear === undefined))
+    ) {
+      throw new RangeError('Unexpected missing property');
+    }
+    if (!maybeConstrained) {
+      // Also cache the reverse mapping
+      const keyReverse = JSON.stringify({
+        func: 'isoToCalendarDate',
+        isoYear: isoEstimate.year,
+        isoMonth: isoEstimate.month,
+        isoDay: isoEstimate.day,
+        id: this.id
+      });
+      cache.set(keyReverse, date);
+    }
+    return isoEstimate;
+  }
+  temporalToCalendarDate(
+    date: Temporal.PlainDate | Temporal.PlainMonthDay | Temporal.PlainYearMonth,
+    cache: OneObjectCache
+  ): FullCalendarDate {
+    const isoDate = { year: GetSlot(date, ISO_YEAR), month: GetSlot(date, ISO_MONTH), day: GetSlot(date, ISO_DAY) };
+    const result = this.isoToCalendarDate(isoDate, cache);
+    return result;
+  }
+  compareCalendarDates(date1Param: Partial<CalendarYMD>, date2Param: Partial<CalendarYMD>): 0 | 1 | -1 {
+    // `date1` and `date2` are already records. The calls below simply validate
+    // that all three required fields are present.
+    const date1 = ES.PrepareTemporalFields(date1Param, ['day', 'month', 'year'], ['day', 'month', 'year']);
+    const date2 = ES.PrepareTemporalFields(date2Param, ['day', 'month', 'year'], ['day', 'month', 'year']);
+    if (date1.year !== date2.year) return ES.ComparisonResult(date1.year - date2.year);
+    if (date1.month !== date2.month) return ES.ComparisonResult(date1.month - date2.month);
+    if (date1.day !== date2.day) return ES.ComparisonResult(date1.day - date2.day);
+    return 0;
+  }
+  /** Ensure that a calendar date actually exists. If not, return the closest earlier date. */
+  regulateDate(calendarDate: CalendarYMD, overflow: Overflow = 'constrain', cache: OneObjectCache): FullCalendarDate {
+    const isoDate = this.calendarToIsoDate(calendarDate, overflow, cache);
+    return this.isoToCalendarDate(isoDate, cache);
+  }
+  addDaysIso(isoDate: IsoYMD, days: number): IsoYMD {
+    const added = ES.AddISODate(isoDate.year, isoDate.month, isoDate.day, 0, 0, 0, days, 'constrain');
+    return added;
+  }
+  addDaysCalendar(calendarDate: CalendarYMD, days: number, cache: OneObjectCache): FullCalendarDate {
+    const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    const addedIso = this.addDaysIso(isoDate, days);
+    const addedCalendar = this.isoToCalendarDate(addedIso, cache);
+    return addedCalendar;
+  }
+  addMonthsCalendar(
+    calendarDateParam: CalendarYMD,
+    months: number,
+    overflow: Overflow,
+    cache: OneObjectCache
+  ): CalendarYMD {
+    let calendarDate = calendarDateParam;
+    const { day } = calendarDate;
+    for (let i = 0, absMonths = MathAbs(months); i < absMonths; i++) {
+      const { month } = calendarDate;
+      const oldCalendarDate = calendarDate;
+      const days =
+        months < 0
+          ? -Math.max(day, this.daysInPreviousMonth(calendarDate, cache))
+          : this.daysInMonth(calendarDate, cache);
+      const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+      let addedIso = this.addDaysIso(isoDate, days);
+      calendarDate = this.isoToCalendarDate(addedIso, cache);
+
+      // Normally, we can advance one month by adding the number of days in the
+      // current month. However, if we're at the end of the current month and
+      // the next month has fewer days, then we rolled over to the after-next
+      // month. Below we detect this condition and back up until we're back in
+      // the desired month.
+      if (months > 0) {
+        const monthsInOldYear = this.monthsInYear(oldCalendarDate, cache);
+        while (calendarDate.month - 1 !== month % monthsInOldYear) {
+          addedIso = this.addDaysIso(addedIso, -1);
+          calendarDate = this.isoToCalendarDate(addedIso, cache);
+        }
+      }
+
+      if (calendarDate.day !== day) {
+        // try to retain the original day-of-month, if possible
+        calendarDate = this.regulateDate({ ...calendarDate, day }, 'constrain', cache);
+      }
+    }
+    if (overflow === 'reject' && calendarDate.day !== day) {
+      throw new RangeError(`Day ${day} does not exist in resulting calendar month`);
+    }
+    return calendarDate;
+  }
+  addCalendar(
+    calendarDate: CalendarYMD & { monthCode: string },
+    { years = 0, months = 0, weeks = 0, days = 0 },
+    overflow: Overflow,
+    cache: OneObjectCache
+  ): FullCalendarDate {
+    const { year, day, monthCode } = calendarDate;
+    const addedYears = this.adjustCalendarDate({ year: year + years, monthCode, day }, cache);
+    const addedMonths = this.addMonthsCalendar(addedYears, months, overflow, cache);
+    const initialDays = days + weeks * 7;
+    const addedDays = this.addDaysCalendar(addedMonths, initialDays, cache);
+    return addedDays;
+  }
+  untilCalendar(
+    calendarOne: FullCalendarDate,
+    calendarTwo: FullCalendarDate,
+    largestUnit: Temporal.DateUnit,
+    cache: OneObjectCache
+  ): { years: number; months: number; weeks: number; days: number } {
+    let days = 0;
+    let weeks = 0;
+    let months = 0;
+    let years = 0;
+    switch (largestUnit) {
+      case 'day':
+        days = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
+        break;
+      case 'week': {
+        const totalDays = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
+        days = totalDays % 7;
+        weeks = (totalDays - days) / 7;
+        break;
+      }
+      case 'month':
+      case 'year': {
+        const diffYears = calendarTwo.year - calendarOne.year;
+        const diffMonths = calendarTwo.month - calendarOne.month;
+        const diffDays = calendarTwo.day - calendarOne.day;
+        const sign = this.compareCalendarDates(calendarTwo, calendarOne);
+        if (!sign) {
+          return { years: 0, months: 0, weeks: 0, days: 0 };
+        }
+        if (largestUnit === 'year' && diffYears) {
+          const isOneFurtherInYear = diffMonths * sign < 0 || (diffMonths === 0 && diffDays * sign < 0);
+          years = isOneFurtherInYear ? diffYears - sign : diffYears;
+        }
+        const yearsAdded = years ? this.addCalendar(calendarOne, { years }, 'constrain', cache) : calendarOne;
+        // Now we have less than one year remaining. Add one month at a time
+        // until we go over the target, then back up one month and calculate
+        // remaining days and weeks.
+        let current;
+        let next: CalendarYMD = yearsAdded;
+        do {
+          months += sign;
+          current = next;
+          next = this.addMonthsCalendar(current, sign, 'constrain', cache);
+          if (next.day !== calendarOne.day) {
+            // In case the day was constrained down, try to un-constrain it
+            next = this.regulateDate({ ...next, day: calendarOne.day }, 'constrain', cache);
+          }
+        } while (this.compareCalendarDates(calendarTwo, next) * sign >= 0);
+        months -= sign; // correct for loop above which overshoots by 1
+        const remainingDays = this.calendarDaysUntil(current, calendarTwo, cache);
+        days = remainingDays;
+        break;
+      }
+    }
+    return { years, months, weeks, days };
+  }
+  daysInMonth(calendarDate: CalendarYMD, cache: OneObjectCache): number {
+    // Add enough days to roll over to the next month. One we're in the next
+    // month, we can calculate the length of the current month. NOTE: This
+    // algorithm assumes that months are continuous. It would break if a
+    // calendar skipped days, like the Julian->Gregorian switchover. But the
+    // only ICU calendars that currently skip days (japanese/roc/buddhist) is a
+    // bug (https://bugs.chromium.org/p/chromium/issues/detail?id=1173158)
+    // that's currently detected by `checkIcuBugs()` which will throw. So this
+    // code should be safe for all ICU calendars.
+    const { day } = calendarDate;
+    const max = this.maximumMonthLength(calendarDate);
+    const min = this.minimumMonthLength(calendarDate);
+    // easiest case: we already know the month length if min and max are the same.
+    if (min === max) return min;
+
+    // Add enough days to get into the next month, without skipping it
+    const increment = day <= max - min ? max : min;
+    const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    const addedIsoDate = this.addDaysIso(isoDate, increment);
+    const addedCalendarDate = this.isoToCalendarDate(addedIsoDate, cache);
+
+    // Now back up to the last day of the original month
+    const endOfMonthIso = this.addDaysIso(addedIsoDate, -addedCalendarDate.day);
+    const endOfMonthCalendar = this.isoToCalendarDate(endOfMonthIso, cache);
+    return endOfMonthCalendar.day;
+  }
+  daysInPreviousMonth(calendarDate: CalendarYMD, cache: OneObjectCache): number {
+    const { day, month, year } = calendarDate;
+
+    // Check to see if we already know the month length, and return it if so
+    const previousMonthYear = month > 1 ? year : year - 1;
+    let previousMonthDate = { year: previousMonthYear, month, day: 1 };
+    const previousMonth = month > 1 ? month - 1 : this.monthsInYear(previousMonthDate, cache);
+    previousMonthDate = { ...previousMonthDate, month: previousMonth };
+    const min = this.minimumMonthLength(previousMonthDate);
+    const max = this.maximumMonthLength(previousMonthDate);
+    if (min === max) return max;
+
+    const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    const lastDayOfPreviousMonthIso = this.addDaysIso(isoDate, -day);
+    const lastDayOfPreviousMonthCalendar = this.isoToCalendarDate(lastDayOfPreviousMonthIso, cache);
+    return lastDayOfPreviousMonthCalendar.day;
+  }
+  startOfCalendarYear(calendarDate: CalendarYearOnly): CalendarYMD & { monthCode: string } {
+    return { year: calendarDate.year, month: 1, monthCode: 'M01', day: 1 };
+  }
+  startOfCalendarMonth(calendarDate: CalendarYM): CalendarYMD {
+    return { year: calendarDate.year, month: calendarDate.month, day: 1 };
+  }
+  calendarDaysUntil(calendarOne: CalendarYMD, calendarTwo: CalendarYMD, cache: OneObjectCache): number {
+    const oneIso = this.calendarToIsoDate(calendarOne, 'constrain', cache);
+    const twoIso = this.calendarToIsoDate(calendarTwo, 'constrain', cache);
+    return this.isoDaysUntil(oneIso, twoIso);
+  }
+  isoDaysUntil(oneIso: IsoYMD, twoIso: IsoYMD): number {
+    const duration = ES.DifferenceISODate(
+      oneIso.year,
+      oneIso.month,
+      oneIso.day,
+      twoIso.year,
+      twoIso.month,
+      twoIso.day,
+      'day'
+    );
+    return duration.days;
+  }
+  // The short era format works for all calendars except Japanese, which will
+  // override.
+  eraLength: Intl.DateTimeFormatOptions['era'] = 'short';
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  hasEra = true;
+  monthDayFromFields(fields: Partial<FullCalendarDate>, overflow: Overflow, cache: OneObjectCache): IsoYMD {
+    let { year, month, monthCode, day, era, eraYear } = fields;
+    if (monthCode === undefined) {
+      if (year === undefined && (era === undefined || eraYear === undefined)) {
+        throw new TypeError('`monthCode`, `year`, or `era` and `eraYear` is required');
+      }
+      ({ monthCode, year } = this.adjustCalendarDate({ year, month, monthCode, day, era, eraYear }, cache, overflow));
+    }
+
+    let isoYear, isoMonth, isoDay;
+    let closestCalendar, closestIso;
+    // Look backwards starting from the calendar year of 1972-01-01 up to 100
+    // calendar years to find a year that has this month and day. Normal months
+    // and days will match immediately, but for leap days and leap months we may
+    // have to look for a while.
+    const startDateIso = { year: 1972, month: 1, day: 1 };
+    const { year: calendarYear } = this.isoToCalendarDate(startDateIso, cache);
+    for (let i = 0; i < 100; i++) {
+      const testCalendarDate: FullCalendarDate = this.adjustCalendarDate(
+        { day, monthCode, year: calendarYear - i },
+        cache
+      );
+      const isoDate = this.calendarToIsoDate(testCalendarDate, 'constrain', cache);
+      const roundTripCalendarDate = this.isoToCalendarDate(isoDate, cache);
+      ({ year: isoYear, month: isoMonth, day: isoDay } = isoDate);
+      if (roundTripCalendarDate.monthCode === monthCode && roundTripCalendarDate.day === day) {
+        return { month: isoMonth, day: isoDay, year: isoYear };
+      } else if (overflow === 'constrain') {
+        // non-ISO constrain algorithm tries to find the closest date in a matching month
+        if (
+          closestCalendar === undefined ||
+          (roundTripCalendarDate.monthCode === closestCalendar.monthCode &&
+            roundTripCalendarDate.day > closestCalendar.day)
+        ) {
+          closestCalendar = roundTripCalendarDate;
+          closestIso = isoDate;
+        }
+      }
+    }
+    if (overflow === 'constrain' && closestIso !== undefined) return closestIso;
+    throw new RangeError(`No recent ${this.id} year with monthCode ${monthCode} and day ${day}`);
+  }
+}
+
+interface HebrewMonthInfo {
+  [m: string]: (
+    | {
+        leap: undefined;
+        regular: number;
+      }
+    | {
+        leap: number;
+        regular: undefined;
+      }
+    | {
+        leap: number;
+        regular: number;
+      }
+  ) & {
+    monthCode: string;
+    days:
+      | number
+      | {
+          min: number;
+          max: number;
+        };
+  };
+}
+
+class HebrewHelper extends HelperBase {
+  id = 'hebrew' as const;
+  calendarType = 'lunisolar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly) {
+    const { year } = calendarDate;
+    // FYI: In addition to adding a month in leap years, the Hebrew calendar
+    // also has per-year changes to the number of days of Heshvan and Kislev.
+    // Given that these can be calculated by counting the number of days in
+    // those months, I assume that these DO NOT need to be exposed as
+    // Hebrew-only prototype fields or methods.
+    return (7 * year + 1) % 19 < 7;
+  }
+  monthsInYear(calendarDate: CalendarYearOnly) {
+    return this.inLeapYear(calendarDate) ? 13 : 12;
+  }
+  minimumMonthLength(calendarDate: CalendarYM) {
+    return this.minMaxMonthLength(calendarDate, 'min');
+  }
+  maximumMonthLength(calendarDate: CalendarYM) {
+    return this.minMaxMonthLength(calendarDate, 'max');
+  }
+  minMaxMonthLength(calendarDate: CalendarYM, minOrMax: 'min' | 'max') {
+    const { month, year } = calendarDate;
+    const monthCode = this.getMonthCode(year, month);
+    const monthInfo = ObjectEntries(this.months).find((m) => m[1].monthCode === monthCode);
+    if (monthInfo === undefined) throw new RangeError(`unmatched Hebrew month: ${month}`);
+    const daysInMonth = monthInfo[1].days;
+    return typeof daysInMonth === 'number' ? daysInMonth : daysInMonth[minOrMax];
+  }
+  /** Take a guess at what ISO date a particular calendar date corresponds to */
+  estimateIsoDate(calendarDate: CalendarYMD) {
+    const { year } = calendarDate;
+    return { year: year - 3760, month: 1, day: 1 };
+  }
+  months: HebrewMonthInfo = {
+    Tishri: { leap: 1, regular: 1, monthCode: 'M01', days: 30 },
+    Heshvan: { leap: 2, regular: 2, monthCode: 'M02', days: { min: 29, max: 30 } },
+    Kislev: { leap: 3, regular: 3, monthCode: 'M03', days: { min: 29, max: 30 } },
+    Tevet: { leap: 4, regular: 4, monthCode: 'M04', days: 29 },
+    Shevat: { leap: 5, regular: 5, monthCode: 'M05', days: 30 },
+    Adar: { leap: undefined, regular: 6, monthCode: 'M06', days: 29 },
+    'Adar I': { leap: 6, regular: undefined, monthCode: 'M05L', days: 30 },
+    'Adar II': { leap: 7, regular: undefined, monthCode: 'M06', days: 29 },
+    Nisan: { leap: 8, regular: 7, monthCode: 'M07', days: 30 },
+    Iyar: { leap: 9, regular: 8, monthCode: 'M08', days: 29 },
+    Sivan: { leap: 10, regular: 9, monthCode: 'M09', days: 30 },
+    Tamuz: { leap: 11, regular: 10, monthCode: 'M10', days: 29 },
+    Av: { leap: 12, regular: 11, monthCode: 'M11', days: 30 },
+    Elul: { leap: 13, regular: 12, monthCode: 'M12', days: 29 }
+  };
+  getMonthCode(year: number, month: number) {
+    if (this.inLeapYear({ year })) {
+      return month === 6 ? buildMonthCode(5, true) : buildMonthCode(month < 6 ? month : month - 1);
+    } else {
+      return buildMonthCode(month);
+    }
+  }
+  override adjustCalendarDate(
+    calendarDate: Partial<FullCalendarDate>,
+    cache?: OneObjectCache,
+    overflow: Overflow = 'constrain',
+    fromLegacyDate = false
+  ): FullCalendarDate {
+    // The incoming type is actually CalendarDate (same as args to
+    // Calendar.dateFromParams) but TS isn't smart enough to follow all the
+    // reassignments below, so as an alternative to 10+ type casts, we'll lie
+    // here and claim that the type has `day` and `year` filled in already.
+    let { year, eraYear, month, monthCode, day, monthExtra } = calendarDate as Omit<
+      typeof calendarDate,
+      'year' | 'day'
+    > & { year: number; day: number };
+    if (year === undefined && eraYear !== undefined) year = eraYear;
+    if (eraYear === undefined && year !== undefined) eraYear = year;
+    if (fromLegacyDate) {
+      // In Pre Node-14 V8, DateTimeFormat.formatToParts `month: 'numeric'`
+      // output returns the numeric equivalent of `month` as a string, meaning
+      // that `'6'` in a leap year is Adar I, while `'6'` in a non-leap year
+      // means Adar. In this case, `month` will already be correct and no action
+      // is needed. However, in Node 14 and later formatToParts returns the name
+      // of the Hebrew month (e.g. "Tevet"), so we'll need to look up the
+      // correct `month` using the string name as a key.
+      if (monthExtra) {
+        const monthInfo = this.months[monthExtra];
+        if (!monthInfo) throw new RangeError(`Unrecognized month from formatToParts: ${monthExtra}`);
+        month = this.inLeapYear({ year }) ? monthInfo.leap : monthInfo.regular;
+      }
+      // Because we're getting data from legacy Date, then `month` will always be present
+      monthCode = this.getMonthCode(year, month as number);
+      const result = { year, month: month as number, day, era: undefined as string | undefined, eraYear, monthCode };
+      return result;
+    } else {
+      // When called without input coming from legacy Date output, simply ensure
+      // that all fields are present.
+      this.validateCalendarDate(calendarDate);
+      if (month === undefined) {
+        if ((monthCode as string).endsWith('L')) {
+          if (monthCode !== 'M05L') {
+            throw new RangeError(`Hebrew leap month must have monthCode M05L, not ${monthCode}`);
+          }
+          month = 6;
+          if (!this.inLeapYear({ year })) {
+            if (overflow === 'reject') {
+              throw new RangeError(`Hebrew monthCode M05L is invalid in year ${year} which is not a leap year`);
+            } else {
+              // constrain to last day of previous month (Av)
+              month = 5;
+              day = 30;
+              monthCode = 'M05';
+            }
+          }
+        } else {
+          month = monthCodeNumberPart(monthCode as string);
+          // if leap month is before this one, the month index is one more than the month code
+          if (this.inLeapYear({ year }) && month >= 6) month++;
+          const largestMonth = this.monthsInYear({ year });
+          if (month < 1 || month > largestMonth) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+        }
+      } else {
+        if (overflow === 'reject') {
+          ES.RejectToRange(month, 1, this.monthsInYear({ year }));
+          ES.RejectToRange(day, 1, this.maximumMonthLength({ year, month }));
+        } else {
+          month = ES.ConstrainToRange(month, 1, this.monthsInYear({ year }));
+          day = ES.ConstrainToRange(day, 1, this.maximumMonthLength({ year, month }));
+        }
+        if (monthCode === undefined) {
+          monthCode = this.getMonthCode(year, month);
+        } else {
+          const calculatedMonthCode = this.getMonthCode(year, month);
+          if (calculatedMonthCode !== monthCode) {
+            throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Hebrew year ${year}`);
+          }
+        }
+      }
+      return { ...calendarDate, day, month, monthCode: monthCode as string, year, eraYear };
+    }
+  }
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  override hasEra = false;
+}
+
+/**
+ * For Temporal purposes, the Islamic calendar is simple because it's always the
+ * same 12 months in the same order.
+ */
+abstract class IslamicBaseHelper extends HelperBase {
+  abstract override id: BuiltinCalendarId;
+  calendarType = 'lunar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly, cache: OneObjectCache) {
+    // In leap years, the 12th month has 30 days. In non-leap years: 29.
+    const days = this.daysInMonth({ year: calendarDate.year, month: 12, day: 1 }, cache);
+    return days === 30;
+  }
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  }
+  minimumMonthLength(/* calendarDate */) {
+    return 29;
+  }
+  maximumMonthLength(/* calendarDate */) {
+    return 30;
+  }
+  DAYS_PER_ISLAMIC_YEAR = 354 + 11 / 30;
+  DAYS_PER_ISO_YEAR = 365.2425;
+  override constantEra = 'ah';
+  estimateIsoDate(calendarDate: CalendarYMD) {
+    const { year } = this.adjustCalendarDate(calendarDate);
+    return { year: MathFloor((year * this.DAYS_PER_ISLAMIC_YEAR) / this.DAYS_PER_ISO_YEAR) + 622, month: 1, day: 1 };
+  }
+}
+
+// There are 6 Islamic calendars with the same implementation in this polyfill.
+// They vary only in their ID. They do emit different output from the underlying
+// Intl implementation, but our code for each of them is identical.
+class IslamicHelper extends IslamicBaseHelper {
+  id = 'islamic' as const;
+}
+class IslamicUmalquraHelper extends IslamicBaseHelper {
+  id = 'islamic-umalqura' as const;
+}
+class IslamicTblaHelper extends IslamicBaseHelper {
+  id = 'islamic-tbla' as const;
+}
+class IslamicCivilHelper extends IslamicBaseHelper {
+  id = 'islamic-civil' as const;
+}
+class IslamicRgsaHelper extends IslamicBaseHelper {
+  id = 'islamic-rgsa' as const;
+}
+class IslamicCcHelper extends IslamicBaseHelper {
+  id = 'islamicc' as const;
+}
+
+class PersianHelper extends HelperBase {
+  id = 'persian' as const;
+  calendarType = 'solar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly, cache: OneObjectCache) {
+    // Same logic (count days in the last month) for Persian as for Islamic,
+    // even though Persian is solar and Islamic is lunar.
+    return IslamicHelper.prototype.inLeapYear.call(this, calendarDate, cache);
+  }
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  }
+  minimumMonthLength(calendarDate: CalendarYM) {
+    const { month } = calendarDate;
+    if (month === 12) return 29;
+    return month <= 6 ? 31 : 30;
+  }
+  maximumMonthLength(calendarDate: CalendarYM) {
+    const { month } = calendarDate;
+    if (month === 12) return 30;
+    return month <= 6 ? 31 : 30;
+  }
+  override constantEra = 'ap';
+  estimateIsoDate(calendarDate: CalendarYMD) {
+    const { year } = this.adjustCalendarDate(calendarDate);
+    return { year: year + 621, month: 1, day: 1 };
+  }
+}
+
+interface IndianMonthInfo {
+  [month: number]: {
+    length: number;
+    month: number;
+    day: number;
+    leap?: {
+      length: number;
+      month: number;
+      day: number;
+    };
+    nextYear?: true | undefined;
+  };
+}
+
+class IndianHelper extends HelperBase {
+  id = 'indian' as const;
+  calendarType = 'solar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly) {
+    // From https://en.wikipedia.org/wiki/Indian_national_calendar:
+    // Years are counted in the Saka era, which starts its year 0 in the year 78
+    // of the Common Era. To determine leap years, add 78 to the Saka year – if
+    // the result is a leap year in the Gregorian calendar, then the Saka year
+    // is a leap year as well.
+    return isGregorianLeapYear(calendarDate.year + 78);
+  }
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  }
+  minimumMonthLength(calendarDate: CalendarYM) {
+    return this.getMonthInfo(calendarDate).length;
+  }
+  maximumMonthLength(calendarDate: CalendarYM) {
+    return this.getMonthInfo(calendarDate).length;
+  }
+  override constantEra = 'saka';
+  // Indian months always start at the same well-known Gregorian month and
+  // day. So this conversion is easy and fast. See
+  // https://en.wikipedia.org/wiki/Indian_national_calendar
+  months: IndianMonthInfo = {
+    1: { length: 30, month: 3, day: 22, leap: { length: 31, month: 3, day: 21 } },
+    2: { length: 31, month: 4, day: 21 },
+    3: { length: 31, month: 5, day: 22 },
+    4: { length: 31, month: 6, day: 22 },
+    5: { length: 31, month: 7, day: 23 },
+    6: { length: 31, month: 8, day: 23 },
+    7: { length: 30, month: 9, day: 23 },
+    8: { length: 30, month: 10, day: 23 },
+    9: { length: 30, month: 11, day: 22 },
+    10: { length: 30, month: 12, day: 22 },
+    11: { length: 30, month: 1, nextYear: true, day: 21 },
+    12: { length: 30, month: 2, nextYear: true, day: 20 }
+  };
+  getMonthInfo(calendarDate: CalendarYM) {
+    const { month } = calendarDate;
+    let monthInfo = this.months[month];
+    if (monthInfo === undefined) throw new RangeError(`Invalid month: ${month}`);
+    if (this.inLeapYear(calendarDate) && monthInfo.leap) monthInfo = monthInfo.leap;
+    return monthInfo;
+  }
+  estimateIsoDate(calendarDateParam: CalendarYMD) {
+    // FYI, this "estimate" is always the exact ISO date, which makes the Indian
+    // calendar fast!
+    const calendarDate = this.adjustCalendarDate(calendarDateParam);
+    const monthInfo = this.getMonthInfo(calendarDate);
+    const isoYear = calendarDate.year + 78 + (monthInfo.nextYear ? 1 : 0);
+    const isoMonth = monthInfo.month;
+    const isoDay = monthInfo.day;
+    const isoDate = ES.AddISODate(isoYear, isoMonth, isoDay, 0, 0, 0, calendarDate.day - 1, 'constrain');
+    return isoDate;
+  }
+  // https://bugs.chromium.org/p/v8/issues/detail?id=10529 causes Intl's Indian
+  // calendar output to fail for all dates before 0001-01-01 ISO.  For example,
+  // in Node 12 0000-01-01 is calculated as 6146/12/-583 instead of 10/11/-79 as
+  // expected.
+  vulnerableToBceBug =
+    new Date('0000-01-01T00:00Z').toLocaleDateString('en-US-u-ca-indian', { timeZone: 'UTC' }) !== '10/11/-79 Saka';
+  override checkIcuBugs(isoDate: IsoYMD) {
+    if (this.vulnerableToBceBug && isoDate.year < 1) {
+      throw new RangeError(
+        `calendar '${this.id}' is broken for ISO dates before 0001-01-01` +
+          ' (see https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
+      );
+    }
+  }
+}
+
+/**
+ * Era metadata defined for each calendar.
+ * TODO: instead of optional properties, this should really have rules
+ * encoded in the type, e.g. isoEpoch is required unless reverseOf is present.
+ *  */
+interface InputEra {
+  /** name of the era */
+  name: string;
+
+  /**
+   * Signed calendar year where this era begins.Will be
+   * 1 (or 0 for zero-based eras) for the anchor era assuming that `year`
+   * numbering starts at the beginning of the anchor era, which is true
+   * for all ICU calendars except Japanese. If an era starts mid-year
+   * then a calendar month and day are included. Otherwise
+   * `{ month: 1, day: 1 }` is assumed.
+   */
+  anchorEpoch?: CalendarYearOnly | CalendarYMD;
+
+  /** ISO date of the first day of this era */
+  isoEpoch?: { year: number; month: number; day: number };
+
+  /**
+   * If present, then this era counts years backwards like BC
+   * and this property points to the forward era. This must be
+   * the last (oldest) era in the array.
+   * */
+  reverseOf?: string;
+
+  /**
+   * If true, the era's years are 0-based. If omitted or false,
+   * then the era's years are 1-based.
+   * */
+  hasYearZero?: boolean;
+
+  /**
+   * Override if this era is the anchor. Not normally used because
+   * anchor eras are inferred.
+   * */
+  isAnchor?: boolean;
+}
+/**
+ * Transformation of the `InputEra` type with all fields filled in by
+ * `adjustEras()`
+ * */
+interface Era {
+  /** name of the era */
+  name: string;
+
+  /**
+   * alternate name of the era used in old versions of ICU data
+   * format is `era{n}` where n is the zero-based index of the era
+   * with the oldest era being 0.
+   * */
+  genericName: string;
+
+  /**
+   * Signed calendar year where this era begins. Will be 1 (or 0 for zero-based
+   * eras) for the anchor era assuming that `year` numbering starts at the
+   * beginning of the anchor era, which is true for all ICU calendars except
+   * Japanese. For input, the month and day are optional. If an era starts
+   * mid-year then a calendar month and day are included.
+   * Otherwise `{ month: 1, day: 1 }` is assumed.
+   */
+  anchorEpoch: CalendarYMD;
+
+  /** ISO date of the first day of this era */
+  isoEpoch: IsoYMD;
+
+  /**
+   * If present, then this era counts years backwards like BC
+   * and this property points to the forward era. This must be
+   * the last (oldest) era in the array.
+   * */
+  reverseOf?: Era;
+
+  /**
+   * If true, the era's years are 0-based. If omitted or false,
+   * then the era's years are 1-based.
+   * */
+  hasYearZero?: boolean;
+
+  /**
+   * Override if this era is the anchor. Not normally used because
+   * anchor eras are inferred.
+   * */
+  isAnchor?: boolean;
+}
+
+/**
+ * This function adds additional metadata that makes it easier to work with
+ * eras. Note that it mutates and normalizes the original era objects, which is
+ * OK because this is non-observable, internal-only metadata.
+ *
+ * The result is an array of eras with the shape defined above.
+ * */
+function adjustEras(erasParam: InputEra[]): { eras: Era[]; anchorEra: Era } {
+  let eras: (InputEra | Era)[] = erasParam;
+  if (eras.length === 0) {
+    throw new RangeError('Invalid era data: eras are required');
+  }
+  if (eras.length === 1 && eras[0].reverseOf) {
+    throw new RangeError('Invalid era data: anchor era cannot count years backwards');
+  }
+  if (eras.length === 1 && !eras[0].name) {
+    throw new RangeError('Invalid era data: at least one named era is required');
+  }
+  if (eras.filter((e) => e.reverseOf != null).length > 1) {
+    throw new RangeError('Invalid era data: only one era can count years backwards');
+  }
+
+  // Find the "anchor era" which is the era used for (era-less) `year`. Reversed
+  // eras can never be anchors. The era without an `anchorEpoch` property is the
+  // anchor.
+  let anchorEra: Era | InputEra | undefined;
+  eras.forEach((e) => {
+    if (e.isAnchor || (!e.anchorEpoch && !e.reverseOf)) {
+      if (anchorEra) throw new RangeError('Invalid era data: cannot have multiple anchor eras');
+      anchorEra = e;
+      e.anchorEpoch = { year: e.hasYearZero ? 0 : 1 };
+    } else if (!e.name) {
+      throw new RangeError('If era name is blank, it must be the anchor era');
+    }
+  });
+
+  // If the era name is undefined, then it's an anchor that doesn't interact
+  // with eras at all. For example, Japanese `year` is always the same as ISO
+  // `year`.  So this "era" is the anchor era but isn't used for era matching.
+  // Strip it from the list that's returned.
+  eras = eras.filter((e) => e.name);
+
+  eras.forEach((e) => {
+    // Some eras are mirror images of another era e.g. B.C. is the reverse of A.D.
+    // Replace the string-valued "reverseOf" property with the actual era object
+    // that's reversed.
+    const { reverseOf } = e;
+    if (reverseOf) {
+      const reversedEra = eras.find((era) => era.name === reverseOf);
+      if (reversedEra === undefined) throw new RangeError(`Invalid era data: unmatched reverseOf era: ${reverseOf}`);
+      e.reverseOf = reversedEra as Era;
+      e.anchorEpoch = reversedEra.anchorEpoch;
+      e.isoEpoch = reversedEra.isoEpoch;
+    }
+    type YMD = {
+      year: number;
+      month: number;
+      day: number;
+    };
+    if ((e.anchorEpoch as YMD).month === undefined) (e.anchorEpoch as YMD).month = 1;
+    if ((e.anchorEpoch as YMD).day === undefined) (e.anchorEpoch as YMD).day = 1;
+  });
+
+  // Ensure that the latest epoch is first in the array. This lets us try to
+  // match eras in index order, with the last era getting the remaining older
+  // years. Any reverse-signed era must be at the end.
+  ArraySort.call(eras, (e1, e2) => {
+    if (e1.reverseOf) return 1;
+    if (e2.reverseOf) return -1;
+    if (!e1.isoEpoch || !e2.isoEpoch) throw new RangeError('Invalid era data: missing ISO epoch');
+    return e2.isoEpoch.year - e1.isoEpoch.year;
+  });
+
+  // If there's a reversed era, then the one before it must be the era that's
+  // being reversed.
+  const lastEraReversed = eras[eras.length - 1].reverseOf;
+  if (lastEraReversed) {
+    if (lastEraReversed !== eras[eras.length - 2]) throw new RangeError('Invalid era data: invalid reverse-sign era');
+  }
+
+  // Finally, add a "genericName" property in the format "era{n} where `n` is
+  // zero-based index, with the oldest era being zero. This format is used by
+  // older versions of ICU data.
+  eras.forEach((e, i) => {
+    (e as Era).genericName = `era${eras.length - 1 - i}`;
+  });
+
+  return { eras: eras as Era[], anchorEra: (anchorEra || eras[0]) as Era };
+}
+
+function isGregorianLeapYear(year: number) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+/** Base for all Gregorian-like calendars. */
+abstract class GregorianBaseHelper extends HelperBase {
+  id: BuiltinCalendarId;
+  eras: Era[];
+  anchorEra: Era;
+
+  constructor(id: BuiltinCalendarId, originalEras: InputEra[]) {
+    super();
+    this.id = id;
+    const { eras, anchorEra } = adjustEras(originalEras);
+    this.anchorEra = anchorEra;
+    this.eras = eras;
+  }
+  calendarType = 'solar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly) {
+    // Calendars that don't override this method use the same months and leap
+    // years as Gregorian. Once we know the ISO year corresponding to the
+    // calendar year, we'll know if it's a leap year or not.
+    const { year } = this.estimateIsoDate({ month: 1, day: 1, year: calendarDate.year });
+    return isGregorianLeapYear(year);
+  }
+  monthsInYear(/* calendarDate */) {
+    return 12;
+  }
+  minimumMonthLength(calendarDate: CalendarYM): number {
+    const { month } = calendarDate;
+    if (month === 2) return this.inLeapYear(calendarDate) ? 29 : 28;
+    return [4, 6, 9, 11].indexOf(month) >= 0 ? 30 : 31;
+  }
+  maximumMonthLength(calendarDate: CalendarYM): number {
+    return this.minimumMonthLength(calendarDate);
+  }
+  /** Fill in missing parts of the (year, era, eraYear) tuple */
+  completeEraYear(calendarDate: Partial<FullCalendarDate>) {
+    const checkField = (name: keyof FullCalendarDate, value: string | number | undefined) => {
+      const currentValue = calendarDate[name];
+      if (currentValue != null && currentValue != value) {
+        throw new RangeError(`Input ${name} ${currentValue} doesn't match calculated value ${value}`);
+      }
+    };
+    const eraFromYear = (year: number) => {
+      let eraYear;
+      const adjustedCalendarDate = { ...calendarDate, year };
+      const matchingEra = this.eras.find((e, i) => {
+        if (i === this.eras.length - 1) {
+          if (e.reverseOf) {
+            // This is a reverse-sign era (like BCE) which must be the oldest
+            // era. Count years backwards.
+            if (year > 0) throw new RangeError(`Signed year ${year} is invalid for era ${e.name}`);
+            eraYear = e.anchorEpoch.year - year;
+            return true;
+          }
+          // last era always gets all "leftover" (older than epoch) years,
+          // so no need for a comparison like below.
+          eraYear = year - e.anchorEpoch.year + (e.hasYearZero ? 0 : 1);
+          return true;
+        }
+        const comparison = this.compareCalendarDates(adjustedCalendarDate, e.anchorEpoch);
+        if (comparison >= 0) {
+          eraYear = year - e.anchorEpoch.year + (e.hasYearZero ? 0 : 1);
+          return true;
+        }
+        return false;
+      });
+      if (!matchingEra) throw new RangeError(`Year ${year} was not matched by any era`);
+      return { eraYear: eraYear as unknown as number, era: matchingEra.name };
+    };
+
+    let { year, eraYear, era } = calendarDate;
+    if (year != null) {
+      ({ eraYear, era } = eraFromYear(year));
+      checkField('era', era);
+      checkField('eraYear', eraYear);
+    } else if (eraYear != null) {
+      const matchingEra =
+        era === undefined ? undefined : this.eras.find((e) => e.name === era || e.genericName === era);
+      if (!matchingEra) throw new RangeError(`Era ${era} (ISO year ${eraYear}) was not matched by any era`);
+      if (eraYear < 1 && matchingEra.reverseOf) {
+        throw new RangeError(`Years in ${era} era must be positive, not ${year}`);
+      }
+      if (matchingEra.reverseOf) {
+        year = matchingEra.anchorEpoch.year - eraYear;
+      } else {
+        year = eraYear + matchingEra.anchorEpoch.year - (matchingEra.hasYearZero ? 0 : 1);
+      }
+      checkField('year', year);
+      // We'll accept dates where the month/day is earlier than the start of
+      // the era or after its end as long as it's in the same year. If that
+      // happens, we'll adjust the era/eraYear pair to be the correct era for
+      // the `year`.
+      ({ eraYear, era } = eraFromYear(year));
+    } else {
+      throw new RangeError('Either `year` or `eraYear` and `era` are required');
+    }
+    return { ...calendarDate, year, eraYear, era };
+  }
+  override adjustCalendarDate(
+    calendarDateParam: Partial<FullCalendarDate>,
+    cache?: OneObjectCache,
+    overflow: Overflow = 'constrain'
+  ): FullCalendarDate {
+    let calendarDate = calendarDateParam;
+    // Because this is not a lunisolar calendar, it's safe to convert monthCode to a number
+    const { month, monthCode } = calendarDate;
+    if (month === undefined) calendarDate = { ...calendarDate, month: monthCodeNumberPart(monthCode as string) };
+    this.validateCalendarDate(calendarDate);
+    calendarDate = this.completeEraYear(calendarDate);
+    return super.adjustCalendarDate(calendarDate, cache, overflow);
+  }
+  estimateIsoDate(calendarDateParam: CalendarYMD) {
+    const calendarDate = this.adjustCalendarDate(calendarDateParam);
+    const { year, month, day } = calendarDate;
+    const { anchorEra } = this;
+    const isoYearEstimate = year + anchorEra.isoEpoch.year - (anchorEra.hasYearZero ? 0 : 1);
+    return ES.RegulateISODate(isoYearEstimate, month, day, 'constrain');
+  }
+  // Several calendars based on the Gregorian calendar use Julian dates (not
+  // proleptic Gregorian dates) before the Julian switchover in Oct 1582. See
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1173158.
+  v8IsVulnerableToJulianBug = new Date('+001001-01-01T00:00Z')
+    .toLocaleDateString('en-US-u-ca-japanese', { timeZone: 'UTC' })
+    .startsWith('12');
+  calendarIsVulnerableToJulianBug = false;
+  override checkIcuBugs(isoDate: IsoYMD) {
+    if (this.calendarIsVulnerableToJulianBug && this.v8IsVulnerableToJulianBug) {
+      const beforeJulianSwitch = ES.CompareISODate(isoDate.year, isoDate.month, isoDate.day, 1582, 10, 15) < 0;
+      if (beforeJulianSwitch) {
+        throw new RangeError(
+          `calendar '${this.id}' is broken for ISO dates before 1582-10-15` +
+            ' (see https://bugs.chromium.org/p/chromium/issues/detail?id=1173158)'
+        );
+      }
+    }
+  }
+}
+
+abstract class OrthodoxBaseHelper extends GregorianBaseHelper {
+  constructor(id: BuiltinCalendarId, originalEras: InputEra[]) {
+    super(id, originalEras);
+  }
+  override inLeapYear(calendarDate: CalendarYearOnly) {
+    // Leap years happen one year before the Julian leap year. Note that this
+    // calendar is based on the Julian calendar which has a leap year every 4
+    // years, unlike the Gregorian calendar which doesn't have leap years on
+    // years divisible by 100 except years divisible by 400.
+    //
+    // Note that we're assuming that leap years in before-epoch times match
+    // how leap years are defined now. This is probably not accurate but I'm
+    // not sure how better to do it.
+    const { year } = calendarDate;
+    return (year + 1) % 4 === 0;
+  }
+  override monthsInYear(/* calendarDate */) {
+    return 13;
+  }
+  override minimumMonthLength(calendarDate: CalendarYM) {
+    const { month } = calendarDate;
+    // Ethiopian/Coptic calendars have 12 30-day months and an extra 5-6 day 13th month.
+    if (month === 13) return this.inLeapYear(calendarDate) ? 6 : 5;
+    return 30;
+  }
+  override maximumMonthLength(calendarDate: CalendarYM) {
+    return this.minimumMonthLength(calendarDate);
+  }
+}
+
+// `coptic` and `ethiopic` calendars are very similar to `ethioaa` calendar,
+// with the following differences:
+// - Coptic uses BCE-like positive numbers for years before its epoch (the other
+//   two use negative year numbers before epoch)
+// - Coptic has a different epoch date
+// - Ethiopic has an additional second era that starts at the same date as the
+//   zero era of ethioaa.
+class EthioaaHelper extends OrthodoxBaseHelper {
+  constructor() {
+    super('ethioaa', [{ name: 'era0', isoEpoch: { year: -5492, month: 7, day: 17 } }]);
+  }
+}
+class CopticHelper extends OrthodoxBaseHelper {
+  constructor() {
+    super('coptic', [
+      { name: 'era1', isoEpoch: { year: 284, month: 8, day: 29 } },
+      { name: 'era0', reverseOf: 'era1' }
+    ]);
+  }
+}
+
+// Anchor is currently the older era to match ethioaa, but should it be the newer era?
+// See https://github.com/tc39/ecma402/issues/534 for discussion.
+class EthiopicHelper extends OrthodoxBaseHelper {
+  constructor() {
+    super('ethiopic', [
+      { name: 'era0', isoEpoch: { year: -5492, month: 7, day: 17 } },
+      { name: 'era1', isoEpoch: { year: 8, month: 8, day: 27 }, anchorEpoch: { year: 5501 } }
+    ]);
+  }
+  // CLDR 48 / ICU 76 renamed the Ethiopic era codes from 'era0'/'era1' to
+  // 'aa' (Amete Alem) and 'am' (Amete Mihret). Map them back so the polyfill
+  // can match them against the known era list above.
+  // See https://github.com/js-temporal/temporal-polyfill/pull/357
+  override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T): T {
+    let { era, eraYear } = calendarDate;
+    if (era === 'aa') era = 'era0';
+    if (era === 'am') era = 'era1';
+    return { era, eraYear } as T;
+  }
+}
+
+class RocHelper extends GregorianBaseHelper {
+  constructor() {
+    super('roc', [
+      { name: 'minguo', isoEpoch: { year: 1912, month: 1, day: 1 } },
+      { name: 'before-roc', reverseOf: 'minguo' }
+    ]);
+  }
+  override calendarIsVulnerableToJulianBug = true;
+}
+
+class BuddhistHelper extends GregorianBaseHelper {
+  constructor() {
+    super('buddhist', [{ name: 'be', hasYearZero: true, isoEpoch: { year: -543, month: 1, day: 1 } }]);
+  }
+  override calendarIsVulnerableToJulianBug = true;
+}
+
+class GregoryHelper extends GregorianBaseHelper {
+  constructor() {
+    super('gregory', [
+      { name: 'ce', isoEpoch: { year: 1, month: 1, day: 1 } },
+      { name: 'bce', reverseOf: 'ce' }
+    ]);
+  }
+  override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T /*, isoDate: IsoDate*/): T {
+    let { era, eraYear } = calendarDate;
+    // Firefox 96 introduced a bug where the `'short'` format of the era
+    // option mistakenly returns the one-letter (narrow) format instead. The
+    // code below handles either the correct or Firefox-buggy format. See
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1752253
+    if (era === 'bc' || era === 'b') era = 'bce';
+    if (era === 'ad' || era === 'a') era = 'ce';
+    return { era, eraYear } as T;
+  }
+}
+
+// NOTE: Only the 5 modern eras (Meiji and later) are included. For dates
+// before Meiji 1, the `ce` and `bce` eras are used. Challenges with pre-Meiji
+// eras include:
+// - Start/end dates of older eras are not precisely defined, which is
+//   challenging given Temporal's need for precision
+// - Some era dates and/or names are disputed by historians
+// - As historical research proceeds, new eras are discovered and existing era
+//   dates are modified, leading to considerable churn which is not good for
+//   Temporal use.
+//  - The earliest era (in 645 CE) may not end up being the earliest depending
+//    on future historical scholarship
+//  - Before Meiji, Japan used a lunar (or lunisolar?) calendar but AFAIK
+//    that's not reflected in the ICU implementation.
+//
+// For more discussion: https://github.com/tc39/proposal-temporal/issues/526.
+//
+// Here's a full list of CLDR/ICU eras:
+// https://github.com/unicode-org/icu/blob/master/icu4c/source/data/locales/root.txt#L1582-L1818
+// https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalData.xml#L4310-L4546
+//
+// NOTE: Japan started using the Gregorian calendar in 6 Meiji, replacing a
+// lunisolar calendar. So the day before January 1 of 6 Meiji (1873) was not
+// December 31, but December 2, of 5 Meiji (1872). The existing Ecma-402
+// Japanese calendar doesn't seem to take this into account, so neither do we:
+// > args = ['en-ca-u-ca-japanese', { era: 'short' }]
+// > new Date('1873-01-01T12:00').toLocaleString(...args)
+// '1 1, 6 Meiji, 12:00:00 PM'
+// > new Date('1872-12-31T12:00').toLocaleString(...args)
+// '12 31, 5 Meiji, 12:00:00 PM'
+class JapaneseHelper extends GregorianBaseHelper {
+  constructor() {
+    super('japanese', [
+      // The Japanese calendar `year` is just the ISO year, because (unlike other
+      // ICU calendars) there's no obvious "default era", we use the ISO year.
+      { name: 'reiwa', isoEpoch: { year: 2019, month: 5, day: 1 }, anchorEpoch: { year: 2019, month: 5, day: 1 } },
+      { name: 'heisei', isoEpoch: { year: 1989, month: 1, day: 8 }, anchorEpoch: { year: 1989, month: 1, day: 8 } },
+      { name: 'showa', isoEpoch: { year: 1926, month: 12, day: 25 }, anchorEpoch: { year: 1926, month: 12, day: 25 } },
+      { name: 'taisho', isoEpoch: { year: 1912, month: 7, day: 30 }, anchorEpoch: { year: 1912, month: 7, day: 30 } },
+      { name: 'meiji', isoEpoch: { year: 1868, month: 9, day: 8 }, anchorEpoch: { year: 1868, month: 9, day: 8 } },
+      { name: 'ce', isoEpoch: { year: 1, month: 1, day: 1 } },
+      { name: 'bce', reverseOf: 'ce' }
+    ]);
+  }
+  override calendarIsVulnerableToJulianBug = true;
+
+  // The last 3 Japanese eras confusingly return only one character in the
+  // default "short" era, so need to use the long format.
+  override eraLength = 'long' as const;
+
+  override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T, isoDate: IsoYMD): T {
+    const { era, eraYear } = calendarDate;
+    const { year: isoYear } = isoDate;
+    if (this.eras.find((e) => e.name === era)) return { era, eraYear } as T;
+    return (isoYear < 1 ? { era: 'bce', eraYear: 1 - isoYear } : { era: 'ce', eraYear: isoYear }) as T;
+  }
+}
+
+interface ChineseMonthInfo {
+  [key: string]: { monthIndex: number; daysInMonth: number };
+}
+interface ChineseDraftMonthInfo {
+  [key: string]: { monthIndex: number; daysInMonth?: number };
+}
+
+abstract class ChineseBaseHelper extends HelperBase {
+  abstract override id: BuiltinCalendarId;
+  calendarType = 'lunisolar' as const;
+  inLeapYear(calendarDate: CalendarYearOnly, cache: OneObjectCache) {
+    const months = this.getMonthList(calendarDate.year, cache as OneObjectCache);
+    return ObjectEntries(months).length === 13;
+  }
+  monthsInYear(calendarDate: CalendarYearOnly, cache: OneObjectCache) {
+    return this.inLeapYear(calendarDate, cache) ? 13 : 12;
+  }
+  minimumMonthLength(/* calendarDate */) {
+    return 29;
+  }
+  maximumMonthLength(/* calendarDate */) {
+    return 30;
+  }
+  getMonthList(calendarYear: number, cache: OneObjectCache): ChineseMonthInfo {
+    if (calendarYear === undefined) {
+      throw new TypeError('Missing year');
+    }
+    const key = JSON.stringify({ func: 'getMonthList', calendarYear, id: this.id });
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const dateTimeFormat = this.getFormatter();
+    const getCalendarDate = (isoYear: number, daysPastFeb1: number) => {
+      const isoStringFeb1 = toUtcIsoDateString({ isoYear, isoMonth: 2, isoDay: 1 });
+      const legacyDate = new Date(isoStringFeb1);
+      // Now add the requested number of days, which may wrap to the next month.
+      legacyDate.setUTCDate(daysPastFeb1 + 1);
+      const newYearGuess = dateTimeFormat.formatToParts(legacyDate);
+      const calendarMonthString = (newYearGuess.find((tv) => tv.type === 'month') as Intl.DateTimeFormatPart).value;
+      const calendarDay = +(newYearGuess.find((tv) => tv.type === 'day') as Intl.DateTimeFormatPart).value;
+      let calendarYearToVerify: globalThis.Intl.DateTimeFormatPart | number | undefined = newYearGuess.find(
+        (tv) => (tv.type as string) === 'relatedYear'
+      );
+      if (calendarYearToVerify !== undefined) {
+        calendarYearToVerify = +calendarYearToVerify.value;
+      } else {
+        // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
+        // output of Intl.DateTimeFormat.formatToParts.
+        throw new RangeError(
+          `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
+        );
+      }
+      return { calendarMonthString, calendarDay, calendarYearToVerify };
+    };
+
+    // First, find a date close to Chinese New Year. Feb 17 will either be in
+    // the first month or near the end of the last month of the previous year.
+    let isoDaysDelta = 17;
+    let { calendarMonthString, calendarDay, calendarYearToVerify } = getCalendarDate(calendarYear, isoDaysDelta);
+
+    // If we didn't guess the first month correctly, add (almost in some months)
+    // a lunar month
+    if (calendarMonthString !== '1') {
+      isoDaysDelta += 29;
+      ({ calendarMonthString, calendarDay } = getCalendarDate(calendarYear, isoDaysDelta));
+    }
+
+    // Now back up to near the start of the first month, but not too near that
+    // off-by-one issues matter.
+    isoDaysDelta -= calendarDay - 5;
+    const result = {} as ChineseDraftMonthInfo;
+    let monthIndex = 1;
+    let oldCalendarDay: number | undefined;
+    let oldMonthString: string | undefined;
+    let done = false;
+    do {
+      ({ calendarMonthString, calendarDay, calendarYearToVerify } = getCalendarDate(calendarYear, isoDaysDelta));
+      if (oldCalendarDay) {
+        result[oldMonthString as string].daysInMonth = oldCalendarDay + 30 - calendarDay;
+      }
+      if (calendarYearToVerify !== calendarYear) {
+        done = true;
+      } else {
+        result[calendarMonthString] = { monthIndex: monthIndex++ };
+        // Move to the next month. Because months are sometimes 29 days, the day of the
+        // calendar month will move forward slowly but not enough to flip over to a new
+        // month before the loop ends at 12-13 months.
+        isoDaysDelta += 30;
+      }
+      oldCalendarDay = calendarDay;
+      oldMonthString = calendarMonthString;
+    } while (!done);
+    result[oldMonthString].daysInMonth = oldCalendarDay + 30 - calendarDay;
+
+    cache.set(key, result);
+    return result as ChineseMonthInfo;
+  }
+  estimateIsoDate(calendarDate: CalendarYMD) {
+    const { year, month } = calendarDate;
+    return { year, month: month >= 12 ? 12 : month + 1, day: 1 };
+  }
+  override adjustCalendarDate(
+    calendarDate: Partial<FullCalendarDate>,
+    cache: OneObjectCache,
+    overflow: Overflow = 'constrain',
+    fromLegacyDate = false
+  ): FullCalendarDate {
+    let { year, month, monthExtra, day, monthCode, eraYear } = calendarDate;
+    if (fromLegacyDate) {
+      // Legacy Date output returns a string that's an integer with an optional
+      // "bis" suffix used only by the Chinese/Dangi calendar to indicate a leap
+      // month. Below we'll normalize the output.
+      year = eraYear;
+      if (monthExtra && monthExtra !== 'bis') throw new RangeError(`Unexpected leap month suffix: ${monthExtra}`);
+      const monthCode = buildMonthCode(month as number, monthExtra !== undefined);
+      const monthString = `${month}${monthExtra || ''}`;
+      const months = this.getMonthList(year as number, cache);
+      const monthInfo = months[monthString];
+      if (monthInfo === undefined) throw new RangeError(`Unmatched month ${monthString} in Chinese year ${year}`);
+      month = monthInfo.monthIndex;
+      return { year: year as number, month, day: day as number, era: undefined, eraYear, monthCode };
+    } else {
+      // When called without input coming from legacy Date output,
+      // simply ensure that all fields are present.
+      this.validateCalendarDate(calendarDate);
+      if (year === undefined) year = eraYear;
+      if (eraYear === undefined) eraYear = year;
+      if (month === undefined) {
+        const months = this.getMonthList(year as number, cache);
+        let numberPart = (monthCode as string).replace('L', 'bis').slice(1);
+        if (numberPart[0] === '0') numberPart = numberPart.slice(1);
+        let monthInfo = months[numberPart];
+        month = monthInfo && monthInfo.monthIndex;
+        // If this leap month isn't present in this year, constrain down to the last day of the previous month.
+        if (
+          month === undefined &&
+          (monthCode as string).endsWith('L') &&
+          !ArrayIncludes.call(['M01L', 'M12L', 'M13L'], monthCode as string) &&
+          overflow === 'constrain'
+        ) {
+          let withoutML = (monthCode as string).slice(1, -1);
+          if (withoutML[0] === '0') withoutML = withoutML.slice(1);
+          monthInfo = months[withoutML];
+          if (monthInfo) {
+            ({ daysInMonth: day, monthIndex: month } = monthInfo);
+            monthCode = buildMonthCode(withoutML);
+          }
+        }
+        if (month === undefined) {
+          throw new RangeError(`Unmatched month ${monthCode} in Chinese year ${year}`);
+        }
+      } else if (monthCode === undefined) {
+        const months = this.getMonthList(year as number, cache);
+        const monthEntries = ObjectEntries(months);
+        const largestMonth = monthEntries.length;
+        if (overflow === 'reject') {
+          ES.RejectToRange(month, 1, largestMonth);
+          ES.RejectToRange(day as number, 1, this.maximumMonthLength());
+        } else {
+          month = ES.ConstrainToRange(month, 1, largestMonth);
+          day = ES.ConstrainToRange(day, 1, this.maximumMonthLength());
+        }
+        const matchingMonthEntry = monthEntries.find(([, v]) => v.monthIndex === month);
+        if (matchingMonthEntry === undefined) {
+          throw new RangeError(`Invalid month ${month} in Chinese year ${year}`);
+        }
+        monthCode = buildMonthCode(
+          matchingMonthEntry[0].replace('bis', ''),
+          matchingMonthEntry[0].indexOf('bis') !== -1
+        );
+      } else {
+        // Both month and monthCode are present. Make sure they don't conflict.
+        const months = this.getMonthList(year as number, cache);
+        let numberPart = monthCode.replace('L', 'bis').slice(1);
+        if (numberPart[0] === '0') numberPart = numberPart.slice(1);
+        const monthInfo = months[numberPart];
+        if (!monthInfo) throw new RangeError(`Unmatched monthCode ${monthCode} in Chinese year ${year}`);
+        if (month !== monthInfo.monthIndex) {
+          throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Chinese year ${year}`);
+        }
+      }
+      return {
+        ...calendarDate,
+        year: year as number,
+        eraYear,
+        month,
+        monthCode: monthCode as string,
+        day: day as number
+      };
+    }
+  }
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  override hasEra = false;
+}
+
+class ChineseHelper extends ChineseBaseHelper {
+  id = 'chinese' as const;
+}
+
+// Dangi (Korean) calendar has same implementation as Chinese
+class DangiHelper extends ChineseBaseHelper {
+  id = 'dangi' as const;
+}
+
+/**
+ * Common implementation of all non-ISO calendars.
+ * Per-calendar id and logic live in `id` and `helper` properties attached later.
+ * This split allowed an easy separation between code that was similar between
+ * ISO and non-ISO implementations vs. code that was very different.
+ */
+const nonIsoImpl: NonIsoImpl = {
+  // `helper` is added when this object is spread into each calendar's
+  // implementation
+  helper: undefined as unknown as HelperBase,
+  dateFromFields(fieldsParam, options, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
+    const cache = new OneObjectCache();
+    // Intentionally alphabetical
+    const fields = ES.PrepareTemporalFields(
+      fieldsParam,
+      ['day', 'era', 'eraYear', 'month', 'monthCode', 'year'],
+      ['day']
+    );
+    const { year, month, day } = this.helper.calendarToIsoDate(fields, overflow, cache);
+    const result = ES.CreateTemporalDate(year, month, day, calendar);
+    cache.setObject(result);
+    return result;
+  },
+  yearMonthFromFields(fieldsParam, options, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
+    const cache = new OneObjectCache();
+    // Intentionally alphabetical
+    const fields = ES.PrepareTemporalFields(fieldsParam, ['era', 'eraYear', 'month', 'monthCode', 'year'], []);
+    const { year, month, day } = this.helper.calendarToIsoDate({ ...fields, day: 1 }, overflow, cache);
+    const result = ES.CreateTemporalYearMonth(year, month, calendar, /* referenceISODay = */ day);
+    cache.setObject(result);
+    return result;
+  },
+  monthDayFromFields(
+    fieldsParam: Params['monthDayFromFields'][0],
+    options: NonNullable<Params['monthDayFromFields'][1]>,
+    calendar: Temporal.CalendarProtocol
+  ) {
+    const overflow = ES.ToTemporalOverflow(options);
+    // All built-in calendars require `day`, but some allow other fields to be
+    // substituted for `month`. And for lunisolar calendars, either `monthCode`
+    // or `year` must be provided because `month` is ambiguous without a year or
+    // a code.
+    const cache = new OneObjectCache();
+    const fields = ES.PrepareTemporalFields(
+      fieldsParam,
+      ['day', 'era', 'eraYear', 'month', 'monthCode', 'year'],
+      ['day']
+    );
+    const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);
+    // `year` is a reference year where this month/day exists in this calendar
+    const result = ES.CreateTemporalMonthDay(month, day, calendar, /* referenceISOYear = */ year);
+    cache.setObject(result);
+    return result;
+  },
+  fields(fieldsParam) {
+    let fields = fieldsParam;
+    if (ArrayIncludes.call(fields, 'year')) fields = [...fields, 'era', 'eraYear'];
+    return fields;
+  },
+  mergeFields(fields, additionalFields) {
+    const fieldsCopy = { ...fields };
+    const additionalFieldsCopy = { ...additionalFields };
+    // era and eraYear are intentionally unused
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { month, monthCode, year, era, eraYear, ...original } = fieldsCopy;
+    const {
+      month: newMonth,
+      monthCode: newMonthCode,
+      year: newYear,
+      era: newEra,
+      eraYear: newEraYear
+    } = additionalFieldsCopy;
+    if (newMonth === undefined && newMonthCode === undefined) {
+      original.month = month;
+      original.monthCode = monthCode;
+    }
+    if (newYear === undefined && newEra === undefined && newEraYear === undefined) {
+      // Only `year` is needed. We don't set era and eraYear because it's
+      // possible to create a conflict for eras that start or end mid-year. See
+      // https://github.com/tc39/proposal-temporal/issues/1784.
+      original.year = year;
+    }
+    return { ...original, ...additionalFieldsCopy };
+  },
+  dateAdd(
+    date: Temporal.PlainDate,
+    years: number,
+    months: number,
+    weeks: number,
+    days: number,
+    overflow: Overflow,
+    calendar: Temporal.Calendar
+  ) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const added = this.helper.addCalendar(calendarDate, { years, months, weeks, days }, overflow, cache);
+    const isoAdded = this.helper.calendarToIsoDate(added, 'constrain', cache);
+    const { year, month, day } = isoAdded;
+    const newTemporalObject = ES.CreateTemporalDate(year, month, day, calendar);
+    // The new object's cache starts with the cache of the old object
+    const newCache = new OneObjectCache(cache);
+    newCache.setObject(newTemporalObject);
+    return newTemporalObject;
+  },
+  dateUntil(one: Temporal.PlainDate, two: Temporal.PlainDate, largestUnit: Temporal.DateUnit) {
+    const cacheOne = OneObjectCache.getCacheForObject(one);
+    const cacheTwo = OneObjectCache.getCacheForObject(two);
+    const calendarOne = this.helper.temporalToCalendarDate(one, cacheOne);
+    const calendarTwo = this.helper.temporalToCalendarDate(two, cacheTwo);
+    const result = this.helper.untilCalendar(calendarOne, calendarTwo, largestUnit, cacheOne);
+    return result;
+  },
+  year(date: Temporal.PlainDate) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.year;
+  },
+  month(date: Temporal.PlainDate) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.month;
+  },
+  day(date: Temporal.PlainDate) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.day;
+  },
+  era(date: Temporal.PlainDate) {
+    if (!this.helper.hasEra) return undefined;
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.era;
+  },
+  eraYear(date: Temporal.PlainDate) {
+    if (!this.helper.hasEra) return undefined;
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.eraYear;
+  },
+  monthCode(date: Temporal.PlainDate) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.monthCode;
+  },
+  dayOfWeek(date: Temporal.PlainDate) {
+    return impl['iso8601'].dayOfWeek(date);
+  },
+  dayOfYear(date: Temporal.PlainDate) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.isoToCalendarDate(date, cache);
+    const startOfYear = this.helper.startOfCalendarYear(calendarDate);
+    const diffDays = this.helper.calendarDaysUntil(startOfYear, calendarDate, cache);
+    return diffDays + 1;
+  },
+  weekOfYear(date: Temporal.PlainDate) {
+    return impl['iso8601'].weekOfYear(date);
+  },
+  daysInWeek(date: Temporal.PlainDate) {
+    return impl['iso8601'].daysInWeek(date);
+  },
+  daysInMonth(date) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+
+    // Easy case: if the helper knows the length without any heavy calculation.
+    const max = this.helper.maximumMonthLength(calendarDate);
+    const min = this.helper.minimumMonthLength(calendarDate);
+    if (max === min) return max;
+
+    // The harder case is where months vary every year, e.g. islamic calendars.
+    // Find the answer by calculating the difference in days between the first
+    // day of the current month and the first day of the next month.
+    const startOfMonthCalendar = this.helper.startOfCalendarMonth(calendarDate);
+    const startOfNextMonthCalendar = this.helper.addMonthsCalendar(startOfMonthCalendar, 1, 'constrain', cache);
+    const result = this.helper.calendarDaysUntil(startOfMonthCalendar, startOfNextMonthCalendar, cache);
+    return result;
+  },
+  daysInYear(dateParam) {
+    let date = dateParam;
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date);
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const startOfYearCalendar = this.helper.startOfCalendarYear(calendarDate);
+    const startOfNextYearCalendar = this.helper.addCalendar(startOfYearCalendar, { years: 1 }, 'constrain', cache);
+    const result = this.helper.calendarDaysUntil(startOfYearCalendar, startOfNextYearCalendar, cache);
+    return result;
+  },
+  monthsInYear(date) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const result = this.helper.monthsInYear(calendarDate, cache);
+    return result;
+  },
+  inLeapYear(dateParam) {
+    let date = dateParam;
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date);
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const result = this.helper.inLeapYear(calendarDate, cache);
+    return result;
+  }
+};
+
+for (const Helper of [
+  HebrewHelper,
+  PersianHelper,
+  EthiopicHelper,
+  EthioaaHelper,
+  CopticHelper,
+  ChineseHelper,
+  DangiHelper,
+  RocHelper,
+  IndianHelper,
+  BuddhistHelper,
+  GregoryHelper,
+  JapaneseHelper,
+  IslamicHelper,
+  IslamicUmalquraHelper,
+  IslamicTblaHelper,
+  IslamicCivilHelper,
+  IslamicRgsaHelper,
+  IslamicCcHelper
+]) {
+  const helper = new Helper();
+  // Clone the singleton non-ISO implementation that's the same for all
+  // calendars. The `helper` property contains per-calendar logic.
+  impl[helper.id] = { ...nonIsoImpl, helper };
+}

--- a/src/vendor/temporal/debug.ts
+++ b/src/vendor/temporal/debug.ts
@@ -1,0 +1,5 @@
+interface GlobalDebugInfo {
+  __debug__?: boolean;
+}
+
+export const DEBUG = !!(globalThis as GlobalDebugInfo).__debug__;

--- a/src/vendor/temporal/duration.ts
+++ b/src/vendor/temporal/duration.ts
@@ -1,0 +1,461 @@
+import { DEBUG } from './debug';
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+import {
+  YEARS,
+  MONTHS,
+  WEEKS,
+  DAYS,
+  HOURS,
+  MINUTES,
+  SECONDS,
+  MILLISECONDS,
+  MICROSECONDS,
+  NANOSECONDS,
+  CreateSlots,
+  GetSlot,
+  SetSlot
+} from './slots';
+import type { Temporal } from '..';
+import type { DurationParams as Params, DurationReturn as Return } from './internaltypes';
+import JSBI from 'jsbi';
+
+export class Duration implements Temporal.Duration {
+  constructor(
+    yearsParam: Params['constructor'][0] = 0,
+    monthsParam: Params['constructor'][1] = 0,
+    weeksParam: Params['constructor'][2] = 0,
+    daysParam: Params['constructor'][3] = 0,
+    hoursParam: Params['constructor'][4] = 0,
+    minutesParam: Params['constructor'][5] = 0,
+    secondsParam: Params['constructor'][6] = 0,
+    millisecondsParam: Params['constructor'][7] = 0,
+    microsecondsParam: Params['constructor'][8] = 0,
+    nanosecondsParam: Params['constructor'][9] = 0
+  ) {
+    const years = ES.ToIntegerWithoutRounding(yearsParam);
+    const months = ES.ToIntegerWithoutRounding(monthsParam);
+    const weeks = ES.ToIntegerWithoutRounding(weeksParam);
+    const days = ES.ToIntegerWithoutRounding(daysParam);
+    const hours = ES.ToIntegerWithoutRounding(hoursParam);
+    const minutes = ES.ToIntegerWithoutRounding(minutesParam);
+    const seconds = ES.ToIntegerWithoutRounding(secondsParam);
+    const milliseconds = ES.ToIntegerWithoutRounding(millisecondsParam);
+    const microseconds = ES.ToIntegerWithoutRounding(microsecondsParam);
+    const nanoseconds = ES.ToIntegerWithoutRounding(nanosecondsParam);
+
+    ES.RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+
+    CreateSlots(this);
+    SetSlot(this, YEARS, years);
+    SetSlot(this, MONTHS, months);
+    SetSlot(this, WEEKS, weeks);
+    SetSlot(this, DAYS, days);
+    SetSlot(this, HOURS, hours);
+    SetSlot(this, MINUTES, minutes);
+    SetSlot(this, SECONDS, seconds);
+    SetSlot(this, MILLISECONDS, milliseconds);
+    SetSlot(this, MICROSECONDS, microseconds);
+    SetSlot(this, NANOSECONDS, nanoseconds);
+
+    if (DEBUG) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${ES.TemporalDurationToString(this)}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+  get years(): Return['years'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, YEARS);
+  }
+  get months(): Return['months'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, MONTHS);
+  }
+  get weeks(): Return['weeks'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, WEEKS);
+  }
+  get days(): Return['days'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, DAYS);
+  }
+  get hours(): Return['hours'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, HOURS);
+  }
+  get minutes(): Return['minutes'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, MINUTES);
+  }
+  get seconds(): Return['seconds'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, SECONDS);
+  }
+  get milliseconds(): Return['milliseconds'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, MILLISECONDS);
+  }
+  get microseconds(): Return['microseconds'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, MICROSECONDS);
+  }
+  get nanoseconds(): Return['nanoseconds'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, NANOSECONDS);
+  }
+  get sign(): Return['sign'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return ES.DurationSign(
+      GetSlot(this, YEARS),
+      GetSlot(this, MONTHS),
+      GetSlot(this, WEEKS),
+      GetSlot(this, DAYS),
+      GetSlot(this, HOURS),
+      GetSlot(this, MINUTES),
+      GetSlot(this, SECONDS),
+      GetSlot(this, MILLISECONDS),
+      GetSlot(this, MICROSECONDS),
+      GetSlot(this, NANOSECONDS)
+    );
+  }
+  get blank(): Return['blank'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return (
+      ES.DurationSign(
+        GetSlot(this, YEARS),
+        GetSlot(this, MONTHS),
+        GetSlot(this, WEEKS),
+        GetSlot(this, DAYS),
+        GetSlot(this, HOURS),
+        GetSlot(this, MINUTES),
+        GetSlot(this, SECONDS),
+        GetSlot(this, MILLISECONDS),
+        GetSlot(this, MICROSECONDS),
+        GetSlot(this, NANOSECONDS)
+      ) === 0
+    );
+  }
+  with(durationLike: Params['with'][0]): Return['with'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    const props = ES.PrepareTemporalFields(
+      durationLike,
+      // NOTE: Field order here is important.
+      [
+        'days',
+        'hours',
+        'microseconds',
+        'milliseconds',
+        'minutes',
+        'months',
+        'nanoseconds',
+        'seconds',
+        'weeks',
+        'years'
+      ],
+      'partial'
+    );
+    if (!props) {
+      throw new TypeError('invalid duration-like');
+    }
+    const {
+      years = GetSlot(this, YEARS),
+      months = GetSlot(this, MONTHS),
+      weeks = GetSlot(this, WEEKS),
+      days = GetSlot(this, DAYS),
+      hours = GetSlot(this, HOURS),
+      minutes = GetSlot(this, MINUTES),
+      seconds = GetSlot(this, SECONDS),
+      milliseconds = GetSlot(this, MILLISECONDS),
+      microseconds = GetSlot(this, MICROSECONDS),
+      nanoseconds = GetSlot(this, NANOSECONDS)
+    } = props;
+    return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  }
+  negated(): Return['negated'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return ES.CreateNegatedTemporalDuration(this);
+  }
+  abs(): Return['abs'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return new Duration(
+      Math.abs(GetSlot(this, YEARS)),
+      Math.abs(GetSlot(this, MONTHS)),
+      Math.abs(GetSlot(this, WEEKS)),
+      Math.abs(GetSlot(this, DAYS)),
+      Math.abs(GetSlot(this, HOURS)),
+      Math.abs(GetSlot(this, MINUTES)),
+      Math.abs(GetSlot(this, SECONDS)),
+      Math.abs(GetSlot(this, MILLISECONDS)),
+      Math.abs(GetSlot(this, MICROSECONDS)),
+      Math.abs(GetSlot(this, NANOSECONDS))
+    );
+  }
+  add(other: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromDuration('add', this, other, options);
+  }
+  subtract(other: Params['subtract'][0], options: Params['subtract'][1] = undefined): Return['subtract'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromDuration('subtract', this, other, options);
+  }
+  round(optionsParam: Params['round'][0]): Return['round'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (optionsParam === undefined) throw new TypeError('options parameter is required');
+    let years = GetSlot(this, YEARS);
+    let months = GetSlot(this, MONTHS);
+    let weeks = GetSlot(this, WEEKS);
+    let days = GetSlot(this, DAYS);
+    let hours = GetSlot(this, HOURS);
+    let minutes = GetSlot(this, MINUTES);
+    let seconds = GetSlot(this, SECONDS);
+    let milliseconds = GetSlot(this, MILLISECONDS);
+    let microseconds = GetSlot(this, MICROSECONDS);
+    let nanoseconds = GetSlot(this, NANOSECONDS);
+
+    let defaultLargestUnit = ES.DefaultTemporalLargestUnit(
+      years,
+      months,
+      weeks,
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds
+    );
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    let smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'datetime', undefined);
+    let smallestUnitPresent = true;
+    if (!smallestUnit) {
+      smallestUnitPresent = false;
+      smallestUnit = 'nanosecond';
+    }
+    defaultLargestUnit = ES.LargerOfTwoTemporalUnits(defaultLargestUnit, smallestUnit);
+    let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'datetime', undefined, ['auto']);
+    let largestUnitPresent = true;
+    if (!largestUnit) {
+      largestUnitPresent = false;
+      largestUnit = defaultLargestUnit;
+    }
+    if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
+    if (!smallestUnitPresent && !largestUnitPresent) {
+      throw new RangeError('at least one of smallestUnit or largestUnit is required');
+    }
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
+    let relativeTo = ES.ToRelativeTemporalObject(options);
+
+    ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(
+      years,
+      months,
+      weeks,
+      days,
+      largestUnit,
+      relativeTo
+    ));
+    ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+      ES.RoundDuration(
+        years,
+        months,
+        weeks,
+        days,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+        roundingIncrement,
+        smallestUnit,
+        roundingMode,
+        relativeTo
+      ));
+    ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+      ES.AdjustRoundedDurationDays(
+        years,
+        months,
+        weeks,
+        days,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+        roundingIncrement,
+        smallestUnit,
+        roundingMode,
+        relativeTo
+      ));
+    ({ years, months, weeks, days } = ES.BalanceDurationRelative(years, months, weeks, days, largestUnit, relativeTo));
+    if (ES.IsTemporalZonedDateTime(relativeTo)) {
+      relativeTo = ES.MoveRelativeZonedDateTime(relativeTo, years, months, weeks, 0);
+    }
+    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      largestUnit,
+      relativeTo
+    ));
+
+    return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  }
+  total(optionsParam: Params['total'][0]): Return['total'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    let years = GetSlot(this, YEARS);
+    let months = GetSlot(this, MONTHS);
+    let weeks = GetSlot(this, WEEKS);
+    let days = GetSlot(this, DAYS);
+    let hours = GetSlot(this, HOURS);
+    let minutes = GetSlot(this, MINUTES);
+    let seconds = GetSlot(this, SECONDS);
+    let milliseconds = GetSlot(this, MILLISECONDS);
+    let microseconds = GetSlot(this, MICROSECONDS);
+    let nanoseconds = GetSlot(this, NANOSECONDS);
+
+    if (optionsParam === undefined) throw new TypeError('options argument is required');
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('unit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    const unit = ES.GetTemporalUnit(options, 'unit', 'datetime', ES.REQUIRED);
+    const relativeTo = ES.ToRelativeTemporalObject(options);
+
+    // Convert larger units down to days
+    ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(years, months, weeks, days, unit, relativeTo));
+    // If the unit we're totalling is smaller than `days`, convert days down to that unit.
+    let intermediate;
+    if (ES.IsTemporalZonedDateTime(relativeTo)) {
+      intermediate = ES.MoveRelativeZonedDateTime(relativeTo, years, months, weeks, 0);
+    }
+    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      unit,
+      intermediate
+    ));
+    // Finally, truncate to the correct unit and calculate remainder
+    const { total } = ES.RoundDuration(
+      years,
+      months,
+      weeks,
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      1,
+      unit,
+      'trunc',
+      relativeTo
+    );
+    return total;
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    if (precision === 'minute') throw new RangeError('smallestUnit must not be "minute"');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDurationToString(this);
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (typeof Intl !== 'undefined' && typeof (Intl as any).DurationFormat !== 'undefined') {
+      return new (Intl as any).DurationFormat(locales, options).format(this);
+    }
+    console.warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
+    return ES.TemporalDurationToString(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() to compare Temporal.Duration');
+  }
+  static from(item: Params['from'][0]): Return['from'] {
+    if (ES.IsTemporalDuration(item)) {
+      return new Duration(
+        GetSlot(item, YEARS),
+        GetSlot(item, MONTHS),
+        GetSlot(item, WEEKS),
+        GetSlot(item, DAYS),
+        GetSlot(item, HOURS),
+        GetSlot(item, MINUTES),
+        GetSlot(item, SECONDS),
+        GetSlot(item, MILLISECONDS),
+        GetSlot(item, MICROSECONDS),
+        GetSlot(item, NANOSECONDS)
+      );
+    }
+    return ES.ToTemporalDuration(item);
+  }
+  static compare(
+    oneParam: Params['compare'][0],
+    twoParam: Params['compare'][1],
+    optionsParam: Params['compare'][2] = undefined
+  ) {
+    const one = ES.ToTemporalDuration(oneParam);
+    const two = ES.ToTemporalDuration(twoParam);
+    const options = ES.GetOptionsObject(optionsParam);
+    const relativeTo = ES.ToRelativeTemporalObject(options);
+    const y1 = GetSlot(one, YEARS);
+    const mon1 = GetSlot(one, MONTHS);
+    const w1 = GetSlot(one, WEEKS);
+    let d1 = GetSlot(one, DAYS);
+    const h1 = GetSlot(one, HOURS);
+    const min1 = GetSlot(one, MINUTES);
+    const s1 = GetSlot(one, SECONDS);
+    const ms1 = GetSlot(one, MILLISECONDS);
+    const µs1 = GetSlot(one, MICROSECONDS);
+    let ns1 = GetSlot(one, NANOSECONDS);
+    const y2 = GetSlot(two, YEARS);
+    const mon2 = GetSlot(two, MONTHS);
+    const w2 = GetSlot(two, WEEKS);
+    let d2 = GetSlot(two, DAYS);
+    const h2 = GetSlot(two, HOURS);
+    const min2 = GetSlot(two, MINUTES);
+    const s2 = GetSlot(two, SECONDS);
+    const ms2 = GetSlot(two, MILLISECONDS);
+    const µs2 = GetSlot(two, MICROSECONDS);
+    let ns2 = GetSlot(two, NANOSECONDS);
+    const shift1 = ES.CalculateOffsetShift(relativeTo, y1, mon1, w1, d1);
+    const shift2 = ES.CalculateOffsetShift(relativeTo, y2, mon2, w2, d2);
+    if (y1 !== 0 || y2 !== 0 || mon1 !== 0 || mon2 !== 0 || w1 !== 0 || w2 !== 0) {
+      ({ days: d1 } = ES.UnbalanceDurationRelative(y1, mon1, w1, d1, 'day', relativeTo));
+      ({ days: d2 } = ES.UnbalanceDurationRelative(y2, mon2, w2, d2, 'day', relativeTo));
+    }
+    const totalNs1 = ES.TotalDurationNanoseconds(d1, h1, min1, s1, ms1, µs1, ns1, shift1);
+    const totalNs2 = ES.TotalDurationNanoseconds(d2, h2, min2, s2, ms2, µs2, ns2, shift2);
+    return ES.ComparisonResult(JSBI.toNumber(JSBI.subtract(totalNs1, totalNs2)));
+  }
+}
+
+MakeIntrinsicClass(Duration, 'Temporal.Duration');

--- a/src/vendor/temporal/ecmascript.ts
+++ b/src/vendor/temporal/ecmascript.ts
@@ -1,0 +1,6100 @@
+const ArrayIncludes = Array.prototype.includes;
+const ArrayPrototypePush = Array.prototype.push;
+const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
+const MathMin = Math.min;
+const MathMax = Math.max;
+const MathAbs = Math.abs;
+const MathFloor = Math.floor;
+const MathSign = Math.sign;
+const MathTrunc = Math.trunc;
+const NumberIsNaN = Number.isNaN;
+const NumberIsFinite = Number.isFinite;
+const NumberCtor = Number;
+const StringCtor = String;
+const NumberMaxSafeInteger = Number.MAX_SAFE_INTEGER;
+const ObjectAssign = Object.assign;
+const ObjectCreate = Object.create;
+const ObjectDefineProperty = Object.defineProperty;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectIs = Object.is;
+const ReflectApply = Reflect.apply;
+
+import { DEBUG } from './debug';
+import JSBI from 'jsbi';
+
+import type { Temporal } from '..';
+import type {
+  AnyTemporalLikeType,
+  UnitSmallerThanOrEqualTo,
+  CalendarProtocolParams,
+  TimeZoneProtocolParams,
+  InstantParams,
+  PlainMonthDayParams,
+  ZonedDateTimeParams,
+  CalendarParams,
+  TimeZoneParams,
+  PlainDateParams,
+  PlainTimeParams,
+  DurationParams,
+  PlainDateTimeParams,
+  PlainYearMonthParams,
+  PrimitiveFieldsOf,
+  BuiltinCalendarId
+} from './internaltypes';
+import { GetIntrinsic } from './intrinsicclass';
+import {
+  CreateSlots,
+  GetSlot,
+  HasSlot,
+  SetSlot,
+  EPOCHNANOSECONDS,
+  TIMEZONE_ID,
+  CALENDAR_ID,
+  INSTANT,
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  DATE_BRAND,
+  YEAR_MONTH_BRAND,
+  MONTH_DAY_BRAND,
+  TIME_ZONE,
+  CALENDAR,
+  YEARS,
+  MONTHS,
+  WEEKS,
+  DAYS,
+  HOURS,
+  MINUTES,
+  SECONDS,
+  MILLISECONDS,
+  MICROSECONDS,
+  NANOSECONDS
+} from './slots';
+
+export const ZERO = JSBI.BigInt(0);
+const ONE = JSBI.BigInt(1);
+const SIXTY = JSBI.BigInt(60);
+export const THOUSAND = JSBI.BigInt(1e3);
+export const MILLION = JSBI.BigInt(1e6);
+export const BILLION = JSBI.BigInt(1e9);
+const NEGATIVE_ONE = JSBI.BigInt(-1);
+const DAY_SECONDS = 86400;
+const DAY_NANOS = JSBI.multiply(JSBI.BigInt(DAY_SECONDS), BILLION);
+const NS_MIN = JSBI.multiply(JSBI.BigInt(-86400), JSBI.BigInt(1e17));
+const NS_MAX = JSBI.multiply(JSBI.BigInt(86400), JSBI.BigInt(1e17));
+const YEAR_MIN = -271821;
+const YEAR_MAX = 275760;
+const BEFORE_FIRST_OFFSET_TRANSITION = JSBI.multiply(JSBI.BigInt(-388152), JSBI.BigInt(1e13)); // 1847-01-01T00:00:00Z
+const ABOUT_TEN_YEARS_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(366 * 10));
+const ABOUT_ONE_YEAR_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(366 * 1));
+const TWO_WEEKS_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(2 * 7));
+
+const BUILTIN_CALENDAR_IDS = [
+  'iso8601',
+  'hebrew',
+  'islamic',
+  'islamic-umalqura',
+  'islamic-tbla',
+  'islamic-civil',
+  'islamic-rgsa',
+  'islamicc',
+  'persian',
+  'ethiopic',
+  'ethioaa',
+  'coptic',
+  'chinese',
+  'dangi',
+  'roc',
+  'indian',
+  'buddhist',
+  'japanese',
+  'gregory'
+];
+
+function IsInteger(value: unknown): value is number {
+  if (typeof value !== 'number' || !NumberIsFinite(value)) return false;
+  const abs = MathAbs(value);
+  return MathFloor(abs) === abs;
+}
+
+// For unknown values, this narrows the result to a Record. But for union types
+// like `Temporal.DurationLike | string`, it'll strip the primitive types while
+// leaving the object type(s) unchanged.
+export function IsObject<T>(
+  value: T
+): value is Exclude<T, string | null | undefined | number | bigint | symbol | boolean>;
+export function IsObject(value: unknown): value is Record<string | number | symbol, unknown> {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+}
+
+export function ToNumber(value: unknown): number {
+  if (typeof value === 'bigint') throw new TypeError('Cannot convert BigInt to number');
+  return NumberCtor(value);
+}
+
+function ToInteger(value: unknown): number {
+  const num = ToNumber(value);
+  if (NumberIsNaN(num)) return 0;
+  const integer = MathTrunc(num);
+  if (num === 0) return 0;
+  return integer;
+}
+
+export function ToString(value: unknown): string {
+  if (typeof value === 'symbol') {
+    throw new TypeError('Cannot convert a Symbol value to a String');
+  }
+  return StringCtor(value);
+}
+
+export function ToIntegerThrowOnInfinity(value: unknown): number {
+  const integer = ToInteger(value);
+  if (!NumberIsFinite(integer)) {
+    throw new RangeError('infinity is out of range');
+  }
+  return integer;
+}
+
+function ToPositiveInteger(valueParam: unknown, property?: string): number {
+  const value = ToInteger(valueParam);
+  if (!NumberIsFinite(value)) {
+    throw new RangeError('infinity is out of range');
+  }
+  if (value < 1) {
+    if (property !== undefined) {
+      throw new RangeError(`property '${property}' cannot be a a number less than one`);
+    }
+    throw new RangeError('Cannot convert a number less than one to a positive integer');
+  }
+  return value;
+}
+
+export function ToIntegerWithoutRounding(valueParam: unknown): number {
+  const value = ToNumber(valueParam);
+  if (NumberIsNaN(value)) return 0;
+  if (!NumberIsFinite(value)) {
+    throw new RangeError('infinity is out of range');
+  }
+  if (!IsInteger(value)) {
+    throw new RangeError(`unsupported fractional value ${value}`);
+  }
+  return ToInteger(value); // ℝ(value) in spec text; converts -0 to 0
+}
+function divmod(x: JSBI, y: JSBI): { quotient: JSBI; remainder: JSBI } {
+  const quotient = JSBI.divide(x, y);
+  const remainder = JSBI.remainder(x, y);
+  return { quotient, remainder };
+}
+
+function abs(x: JSBI): JSBI {
+  if (JSBI.lessThan(x, ZERO)) return JSBI.multiply(x, NEGATIVE_ONE);
+  return x;
+}
+
+export function ArrayPush<NewValue>(
+  arr: ReadonlyArray<NewValue>,
+  ...newItem: readonly NewValue[]
+): ReadonlyArray<NewValue> {
+  ArrayPrototypePush.apply(arr, newItem as any[]);
+  return arr;
+}
+
+type BuiltinCastFunction = (v: unknown) => string | number;
+const BUILTIN_CASTS = new Map<AnyTemporalKey, BuiltinCastFunction>([
+  ['year', ToIntegerThrowOnInfinity],
+  ['month', ToPositiveInteger],
+  ['monthCode', ToString],
+  ['day', ToPositiveInteger],
+  ['hour', ToIntegerThrowOnInfinity],
+  ['minute', ToIntegerThrowOnInfinity],
+  ['second', ToIntegerThrowOnInfinity],
+  ['millisecond', ToIntegerThrowOnInfinity],
+  ['microsecond', ToIntegerThrowOnInfinity],
+  ['nanosecond', ToIntegerThrowOnInfinity],
+  ['years', ToIntegerWithoutRounding],
+  ['months', ToIntegerWithoutRounding],
+  ['weeks', ToIntegerWithoutRounding],
+  ['days', ToIntegerWithoutRounding],
+  ['hours', ToIntegerWithoutRounding],
+  ['minutes', ToIntegerWithoutRounding],
+  ['seconds', ToIntegerWithoutRounding],
+  ['milliseconds', ToIntegerWithoutRounding],
+  ['microseconds', ToIntegerWithoutRounding],
+  ['nanoseconds', ToIntegerWithoutRounding],
+  ['era', ToString],
+  ['eraYear', ToInteger],
+  ['offset', ToString]
+]);
+
+const BUILTIN_DEFAULTS = new Map([
+  ['hour', 0],
+  ['minute', 0],
+  ['second', 0],
+  ['millisecond', 0],
+  ['microsecond', 0],
+  ['nanosecond', 0]
+]);
+
+// each item is [plural, singular, category]
+const SINGULAR_PLURAL_UNITS = [
+  ['years', 'year', 'date'],
+  ['months', 'month', 'date'],
+  ['weeks', 'week', 'date'],
+  ['days', 'day', 'date'],
+  ['hours', 'hour', 'time'],
+  ['minutes', 'minute', 'time'],
+  ['seconds', 'second', 'time'],
+  ['milliseconds', 'millisecond', 'time'],
+  ['microseconds', 'microsecond', 'time'],
+  ['nanoseconds', 'nanosecond', 'time']
+] as const;
+const SINGULAR_FOR = new Map(SINGULAR_PLURAL_UNITS.map((e) => [e[0], e[1]] as const));
+const PLURAL_FOR = new Map(SINGULAR_PLURAL_UNITS.map(([p, s]) => [s, p]));
+const UNITS_DESCENDING = SINGULAR_PLURAL_UNITS.map(([, s]) => s);
+
+const DURATION_FIELDS = Array.from(SINGULAR_FOR.keys()).sort();
+
+import * as PARSE from './regex';
+
+const IntlDateTimeFormatEnUsCache = new Map<string, Intl.DateTimeFormat>();
+
+function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier: string) {
+  let instance = IntlDateTimeFormatEnUsCache.get(timeZoneIdentifier);
+  if (instance === undefined) {
+    instance = new IntlDateTimeFormat('en-us', {
+      timeZone: StringCtor(timeZoneIdentifier),
+      hour12: false,
+      era: 'short',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+    IntlDateTimeFormatEnUsCache.set(timeZoneIdentifier, instance);
+  }
+  return instance;
+}
+
+export function IsTemporalInstant(item: unknown): item is Temporal.Instant {
+  return HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR);
+}
+
+export function IsTemporalTimeZone(item: unknown): item is Temporal.TimeZone {
+  return HasSlot(item, TIMEZONE_ID);
+}
+export function IsTemporalCalendar(item: unknown): item is Temporal.Calendar {
+  return HasSlot(item, CALENDAR_ID);
+}
+export function IsTemporalDuration(item: unknown): item is Temporal.Duration {
+  return HasSlot(item, YEARS, MONTHS, DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS);
+}
+export function IsTemporalDate(item: unknown): item is Temporal.PlainDate {
+  return HasSlot(item, DATE_BRAND);
+}
+export function IsTemporalTime(item: unknown): item is Temporal.PlainTime {
+  return (
+    HasSlot(item, ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND) &&
+    !HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY)
+  );
+}
+export function IsTemporalDateTime(item: unknown): item is Temporal.PlainDateTime {
+  return HasSlot(
+    item,
+    ISO_YEAR,
+    ISO_MONTH,
+    ISO_DAY,
+    ISO_HOUR,
+    ISO_MINUTE,
+    ISO_SECOND,
+    ISO_MILLISECOND,
+    ISO_MICROSECOND,
+    ISO_NANOSECOND
+  );
+}
+export function IsTemporalYearMonth(item: unknown): item is Temporal.PlainYearMonth {
+  return HasSlot(item, YEAR_MONTH_BRAND);
+}
+export function IsTemporalMonthDay(item: unknown): item is Temporal.PlainMonthDay {
+  return HasSlot(item, MONTH_DAY_BRAND);
+}
+export function IsTemporalZonedDateTime(item: unknown): item is Temporal.ZonedDateTime {
+  return HasSlot(item, EPOCHNANOSECONDS, TIME_ZONE, CALENDAR);
+}
+export function RejectObjectWithCalendarOrTimeZone(item: AnyTemporalLikeType) {
+  if (HasSlot(item, CALENDAR) || HasSlot(item, TIME_ZONE)) {
+    throw new TypeError('with() does not support a calendar or timeZone property');
+  }
+  if ((item as { calendar: unknown }).calendar !== undefined) {
+    throw new TypeError('with() does not support a calendar property');
+  }
+  if ((item as { timeZone: unknown }).timeZone !== undefined) {
+    throw new TypeError('with() does not support a timeZone property');
+  }
+}
+function ParseTemporalTimeZone(stringIdent: string) {
+  let { ianaName, offset, z } = ParseTemporalTimeZoneString(stringIdent);
+  if (ianaName) return ianaName;
+  if (z) return 'UTC';
+  return offset as string; // if !ianaName && !z then offset must be present
+}
+
+function FormatCalendarAnnotation(id: string, showCalendar: Temporal.ShowCalendarOption['calendarName']) {
+  if (showCalendar === 'never') return '';
+  if (showCalendar === 'auto' && id === 'iso8601') return '';
+  return `[u-ca=${id}]`;
+}
+
+function ParseISODateTime(isoString: string) {
+  // ZDT is the superset of fields for every other Temporal type
+  const match = PARSE.zoneddatetime.exec(isoString);
+  if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+  let yearString = match[1];
+  if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+  if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+  const year = ToInteger(yearString);
+  const month = ToInteger(match[2] || match[4]);
+  const day = ToInteger(match[3] || match[5]);
+  const hour = ToInteger(match[6]);
+  const hasTime = match[6] !== undefined;
+  const minute = ToInteger(match[7] || match[10]);
+  let second = ToInteger(match[8] || match[11]);
+  if (second === 60) second = 59;
+  const fraction = (match[9] || match[12]) + '000000000';
+  const millisecond = ToInteger(fraction.slice(0, 3));
+  const microsecond = ToInteger(fraction.slice(3, 6));
+  const nanosecond = ToInteger(fraction.slice(6, 9));
+  let offset;
+  let z = false;
+  if (match[13]) {
+    offset = undefined;
+    z = true;
+  } else if (match[14] && match[15]) {
+    const offsetSign = match[14] === '-' || match[14] === '\u2212' ? '-' : '+';
+    const offsetHours = match[15] || '00';
+    const offsetMinutes = match[16] || '00';
+    const offsetSeconds = match[17] || '00';
+    let offsetFraction = match[18] || '0';
+    offset = `${offsetSign}${offsetHours}:${offsetMinutes}`;
+    if (+offsetFraction) {
+      while (offsetFraction.endsWith('0')) offsetFraction = offsetFraction.slice(0, -1);
+      offset += `:${offsetSeconds}.${offsetFraction}`;
+    } else if (+offsetSeconds) {
+      offset += `:${offsetSeconds}`;
+    }
+    if (offset === '-00:00') offset = '+00:00';
+  }
+  let ianaName = match[19];
+  if (ianaName) {
+    try {
+      // Canonicalize name if it is an IANA link name or is capitalized wrong
+      ianaName = GetCanonicalTimeZoneIdentifier(ianaName).toString();
+    } catch {
+      // Not an IANA name, may be a custom ID, pass through unchanged
+    }
+  }
+  const calendar = match[20];
+  RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  return {
+    year,
+    month,
+    day,
+    hasTime,
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond,
+    ianaName,
+    offset,
+    z,
+    calendar
+  };
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalInstantString(isoString: string) {
+  const result = ParseISODateTime(isoString);
+  if (!result.z && !result.offset) throw new RangeError('Temporal.Instant requires a time zone offset');
+  return result;
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalZonedDateTimeString(isoString: string) {
+  const result = ParseISODateTime(isoString);
+  if (!result.ianaName) throw new RangeError('Temporal.ZonedDateTime requires a time zone ID in brackets');
+  return result;
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalDateTimeString(isoString: string) {
+  return ParseISODateTime(isoString);
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalDateString(isoString: string) {
+  return ParseISODateTime(isoString);
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalTimeString(isoString: string) {
+  const match = PARSE.time.exec(isoString);
+  let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
+  if (match) {
+    hour = ToInteger(match[1]);
+    minute = ToInteger(match[2] || match[5]);
+    second = ToInteger(match[3] || match[6]);
+    if (second === 60) second = 59;
+    const fraction = (match[4] || match[7]) + '000000000';
+    millisecond = ToInteger(fraction.slice(0, 3));
+    microsecond = ToInteger(fraction.slice(3, 6));
+    nanosecond = ToInteger(fraction.slice(6, 9));
+    calendar = match[15];
+  } else {
+    let z, hasTime;
+    ({ hasTime, hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } =
+      ParseISODateTime(isoString));
+    if (!hasTime) throw new RangeError(`time is missing in string: ${isoString}`);
+    if (z) throw new RangeError('Z designator not supported for PlainTime');
+  }
+  // if it's a date-time string, OK
+  if (/[tT ][0-9][0-9]/.test(isoString)) {
+    return { hour, minute, second, millisecond, microsecond, nanosecond, calendar };
+  }
+  // slow but non-grammar-dependent way to ensure that time-only strings that
+  // are also valid PlainMonthDay and PlainYearMonth throw. corresponds to
+  // assertion in spec text
+  try {
+    const { month, day } = ParseTemporalMonthDayString(isoString);
+    RejectISODate(1972, month, day);
+  } catch {
+    try {
+      const { year, month } = ParseTemporalYearMonthString(isoString);
+      RejectISODate(year, month, 1);
+    } catch {
+      return { hour, minute, second, millisecond, microsecond, nanosecond, calendar };
+    }
+  }
+  throw new RangeError(`invalid ISO 8601 time-only string ${isoString}; may need a T prefix`);
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalYearMonthString(isoString: string) {
+  const match = PARSE.yearmonth.exec(isoString);
+  let year, month, calendar, referenceISODay;
+  if (match) {
+    let yearString = match[1];
+    if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+    if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+    year = ToInteger(yearString);
+    month = ToInteger(match[2]);
+    calendar = match[3];
+  } else {
+    let z;
+    ({ year, month, calendar, day: referenceISODay, z } = ParseISODateTime(isoString));
+    if (z) throw new RangeError('Z designator not supported for PlainYearMonth');
+  }
+  return { year, month, calendar, referenceISODay };
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalMonthDayString(isoString: string) {
+  const match = PARSE.monthday.exec(isoString);
+  let month, day, calendar, referenceISOYear;
+  if (match) {
+    month = ToInteger(match[1]);
+    day = ToInteger(match[2]);
+  } else {
+    let z;
+    ({ month, day, calendar, year: referenceISOYear, z } = ParseISODateTime(isoString));
+    if (z) throw new RangeError('Z designator not supported for PlainMonthDay');
+  }
+  return { month, day, calendar, referenceISOYear };
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalTimeZoneString(stringIdent: string): Partial<{
+  ianaName: string | undefined;
+  offset: string | undefined;
+  z: boolean | undefined;
+}> {
+  try {
+    let canonicalIdent = GetCanonicalTimeZoneIdentifier(stringIdent);
+    if (canonicalIdent) return { ianaName: canonicalIdent.toString() };
+  } catch {
+    // fall through
+  }
+  try {
+    // Try parsing ISO string instead
+    const result = ParseISODateTime(stringIdent);
+    if (result.z || result.offset || result.ianaName) {
+      return result;
+    }
+  } catch {
+    // fall through
+  }
+  throw new RangeError(`Invalid time zone: ${stringIdent}`);
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalDurationString(isoString: string) {
+  const match = PARSE.duration.exec(isoString);
+  if (!match) throw new RangeError(`invalid duration: ${isoString}`);
+  if (match.slice(2).every((element) => element === undefined)) {
+    throw new RangeError(`invalid duration: ${isoString}`);
+  }
+  const sign = match[1] === '-' || match[1] === '\u2212' ? -1 : 1;
+  const years = ToInteger(match[2]) * sign;
+  const months = ToInteger(match[3]) * sign;
+  const weeks = ToInteger(match[4]) * sign;
+  const days = ToInteger(match[5]) * sign;
+  const hours = ToInteger(match[6]) * sign;
+  let fHours: number | string = match[7];
+  let minutes = ToInteger(match[8]) * sign;
+  let fMinutes: number | string = match[9];
+  let seconds = ToInteger(match[10]) * sign;
+  const fSeconds = match[11] + '000000000';
+  let milliseconds = ToInteger(fSeconds.slice(0, 3)) * sign;
+  let microseconds = ToInteger(fSeconds.slice(3, 6)) * sign;
+  let nanoseconds = ToInteger(fSeconds.slice(6, 9)) * sign;
+
+  fHours = fHours ? (sign * ToInteger(fHours)) / 10 ** fHours.length : 0;
+  fMinutes = fMinutes ? (sign * ToInteger(fMinutes)) / 10 ** fMinutes.length : 0;
+
+  ({ minutes, seconds, milliseconds, microseconds, nanoseconds } = DurationHandleFractions(
+    fHours,
+    minutes,
+    fMinutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds
+  ));
+  RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+// ts-prune-ignore-next TODO: remove if test/validStrings is converted to TS.
+export function ParseTemporalInstant(isoString: string) {
+  let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, offset, z } =
+    ParseTemporalInstantString(isoString);
+
+  if (!z && !offset) throw new RangeError('Temporal.Instant requires a time zone offset');
+  // At least one of z or offset is defined, but TS doesn't seem to understand
+  // that we only use offset if z is not defined (and thus offset must be defined).
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const offsetNs = z ? 0 : ParseTimeZoneOffsetString(offset!);
+  ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceISODateTime(
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond - offsetNs
+  ));
+
+  const epochNs = GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  if (epochNs === null) throw new RangeError('DateTime outside of supported range');
+  return epochNs;
+}
+
+export function RegulateISODate(
+  yearParam: number,
+  monthParam: number,
+  dayParam: number,
+  overflow: Temporal.ArithmeticOptions['overflow']
+) {
+  let year = yearParam;
+  let month = monthParam;
+  let day = dayParam;
+  switch (overflow) {
+    case 'reject':
+      RejectISODate(year, month, day);
+      break;
+    case 'constrain':
+      ({ year, month, day } = ConstrainISODate(year, month, day));
+      break;
+  }
+  return { year, month, day };
+}
+
+export function RegulateTime(
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number,
+  overflow: Temporal.ArithmeticOptions['overflow']
+) {
+  let hour = hourParam;
+  let minute = minuteParam;
+  let second = secondParam;
+  let millisecond = millisecondParam;
+  let microsecond = microsecondParam;
+  let nanosecond = nanosecondParam;
+
+  switch (overflow) {
+    case 'reject':
+      RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
+      break;
+    case 'constrain':
+      ({ hour, minute, second, millisecond, microsecond, nanosecond } = ConstrainTime(
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond
+      ));
+      break;
+  }
+  return { hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+export function RegulateISOYearMonth(
+  yearParam: number,
+  monthParam: number,
+  overflow: Temporal.ArithmeticOptions['overflow']
+) {
+  let year = yearParam;
+  let month = monthParam;
+  const referenceISODay = 1;
+  switch (overflow) {
+    case 'reject':
+      RejectISODate(year, month, referenceISODay);
+      break;
+    case 'constrain':
+      ({ year, month } = ConstrainISODate(year, month));
+      break;
+  }
+  return { year, month };
+}
+
+function DurationHandleFractions(
+  fHoursParam: number,
+  minutesParam: number,
+  fMinutesParam: number,
+  secondsParam: number,
+  millisecondsParam: number,
+  microsecondsParam: number,
+  nanosecondsParam: number
+) {
+  let fHours = fHoursParam;
+  let minutes = minutesParam;
+  let fMinutes = fMinutesParam;
+  let seconds = secondsParam;
+  let milliseconds = millisecondsParam;
+  let microseconds = microsecondsParam;
+  let nanoseconds = nanosecondsParam;
+
+  if (fHours !== 0) {
+    [minutes, fMinutes, seconds, milliseconds, microseconds, nanoseconds].forEach((val) => {
+      if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
+    });
+    const mins = fHours * 60;
+    minutes = MathTrunc(mins);
+    fMinutes = mins % 1;
+  }
+
+  if (fMinutes !== 0) {
+    [seconds, milliseconds, microseconds, nanoseconds].forEach((val) => {
+      if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
+    });
+    const secs = fMinutes * 60;
+    seconds = MathTrunc(secs);
+    const fSeconds = secs % 1;
+
+    if (fSeconds !== 0) {
+      const mils = fSeconds * 1000;
+      milliseconds = MathTrunc(mils);
+      const fMilliseconds = mils % 1;
+
+      if (fMilliseconds !== 0) {
+        const mics = fMilliseconds * 1000;
+        microseconds = MathTrunc(mics);
+        const fMicroseconds = mics % 1;
+
+        if (fMicroseconds !== 0) {
+          const nans = fMicroseconds * 1000;
+          nanoseconds = MathTrunc(nans);
+        }
+      }
+    }
+  }
+
+  return { minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function ToTemporalDurationRecord(item: Temporal.DurationLike | string) {
+  if (!IsObject(item)) {
+    return ParseTemporalDurationString(ToString(item));
+  }
+  if (IsTemporalDuration(item)) {
+    return {
+      years: GetSlot(item, YEARS),
+      months: GetSlot(item, MONTHS),
+      weeks: GetSlot(item, WEEKS),
+      days: GetSlot(item, DAYS),
+      hours: GetSlot(item, HOURS),
+      minutes: GetSlot(item, MINUTES),
+      seconds: GetSlot(item, SECONDS),
+      milliseconds: GetSlot(item, MILLISECONDS),
+      microseconds: GetSlot(item, MICROSECONDS),
+      nanoseconds: GetSlot(item, NANOSECONDS)
+    };
+  }
+  const result = {
+    years: 0,
+    months: 0,
+    weeks: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    milliseconds: 0,
+    microseconds: 0,
+    nanoseconds: 0
+  };
+  let partial = ToTemporalPartialDurationRecord(item);
+  for (const property of DURATION_FIELDS) {
+    const value = partial[property];
+    if (value !== undefined) {
+      result[property] = value;
+    }
+  }
+  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = result;
+  RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function ToTemporalPartialDurationRecord(temporalDurationLike: Temporal.DurationLike | string) {
+  if (!IsObject(temporalDurationLike)) {
+    throw new TypeError('invalid duration-like');
+  }
+  const result: Record<typeof DURATION_FIELDS[number], number | undefined> = {
+    years: undefined,
+    months: undefined,
+    weeks: undefined,
+    days: undefined,
+    hours: undefined,
+    minutes: undefined,
+    seconds: undefined,
+    milliseconds: undefined,
+    microseconds: undefined,
+    nanoseconds: undefined
+  };
+  let any = false;
+  for (const property of DURATION_FIELDS) {
+    const value = temporalDurationLike[property];
+    if (value !== undefined) {
+      any = true;
+      result[property] = ToIntegerWithoutRounding(value);
+    }
+  }
+  if (!any) {
+    throw new TypeError('invalid duration-like');
+  }
+  return result;
+}
+
+function ToLimitedTemporalDuration(
+  item: Temporal.DurationLike | string,
+  disallowedProperties: (keyof Temporal.DurationLike)[]
+) {
+  let record = ToTemporalDurationRecord(item);
+  for (const property of disallowedProperties) {
+    if (record[property] !== 0) {
+      throw new RangeError(
+        `Duration field ${property} not supported by Temporal.Instant. Try Temporal.ZonedDateTime instead.`
+      );
+    }
+  }
+  return record;
+}
+
+export function ToTemporalOverflow(options: Temporal.AssignmentOptions | undefined) {
+  if (options === undefined) return 'constrain';
+  return GetOption(options, 'overflow', ['constrain', 'reject'], 'constrain');
+}
+
+export function ToTemporalDisambiguation(options: Temporal.ToInstantOptions | undefined) {
+  if (options === undefined) return 'compatible';
+  return GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
+}
+
+export function ToTemporalRoundingMode(
+  options: { roundingMode?: Temporal.RoundingMode },
+  fallback: Temporal.RoundingMode
+) {
+  return GetOption(options, 'roundingMode', ['ceil', 'floor', 'trunc', 'halfExpand'], fallback);
+}
+
+function NegateTemporalRoundingMode(roundingMode: Temporal.RoundingMode) {
+  switch (roundingMode) {
+    case 'ceil':
+      return 'floor';
+    case 'floor':
+      return 'ceil';
+    default:
+      return roundingMode;
+  }
+}
+
+export function ToTemporalOffset(
+  options: Temporal.OffsetDisambiguationOptions | undefined,
+  fallback: Required<Temporal.OffsetDisambiguationOptions>['offset']
+) {
+  if (options === undefined) return fallback;
+  return GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
+}
+
+export function ToShowCalendarOption(options: Temporal.ShowCalendarOption) {
+  return GetOption(options, 'calendarName', ['auto', 'always', 'never'], 'auto');
+}
+
+export function ToShowTimeZoneNameOption(options: Temporal.ZonedDateTimeToStringOptions) {
+  return GetOption(options, 'timeZoneName', ['auto', 'never'], 'auto');
+}
+
+export function ToShowOffsetOption(options: Temporal.ZonedDateTimeToStringOptions) {
+  return GetOption(options, 'offset', ['auto', 'never'], 'auto');
+}
+
+export function ToTemporalRoundingIncrement(
+  options: { roundingIncrement?: number },
+  dividend: number | undefined,
+  inclusive?: boolean
+) {
+  let maximum = Infinity;
+  if (dividend !== undefined) maximum = dividend;
+  if (!inclusive && dividend !== undefined) maximum = dividend > 1 ? dividend - 1 : 1;
+  const increment = GetNumberOption(options, 'roundingIncrement', 1, maximum, 1);
+  if (dividend !== undefined && dividend % increment !== 0) {
+    throw new RangeError(`Rounding increment must divide evenly into ${dividend}`);
+  }
+  return increment;
+}
+
+type TemporalDateTimeRoundingMaximumIncrements = {
+  year?: number;
+  month?: number;
+  week?: number;
+  day?: number;
+  hour?: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+  microsecond: number;
+  nanosecond: number;
+};
+
+export function ToTemporalDateTimeRoundingIncrement(
+  options: { roundingIncrement?: number },
+  smallestUnit: keyof TemporalDateTimeRoundingMaximumIncrements
+) {
+  const maximumIncrements: TemporalDateTimeRoundingMaximumIncrements = {
+    year: undefined,
+    month: undefined,
+    week: undefined,
+    day: undefined,
+    hour: 24,
+    minute: 60,
+    second: 60,
+    millisecond: 1000,
+    microsecond: 1000,
+    nanosecond: 1000
+  };
+  return ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+}
+
+export function ToSecondsStringPrecision(options: Temporal.ToStringPrecisionOptions): {
+  precision: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 'auto' | 'minute';
+  unit: UnitSmallerThanOrEqualTo<'minute'>;
+  increment: number;
+} {
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+  if (smallestUnit === 'hour') {
+    const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce((allowed, [p, s, c]) => {
+      // Weirdly, local type inference seems to understand the types of s and p, but tsc still complains.
+      // Maybe this is fixed in later TS versions?
+      if (c === 'time' && s !== 'hour') {
+        allowed.push(s as Temporal.TimeUnit, p as Temporal.PluralUnit<Temporal.TimeUnit>);
+      }
+      return allowed;
+    }, [] as Array<Temporal.TimeUnit | Temporal.PluralUnit<Temporal.TimeUnit>>);
+    throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);
+  }
+  switch (smallestUnit) {
+    case 'minute':
+      return { precision: 'minute', unit: 'minute', increment: 1 };
+    case 'second':
+      return { precision: 0, unit: 'second', increment: 1 };
+    case 'millisecond':
+      return { precision: 3, unit: 'millisecond', increment: 1 };
+    case 'microsecond':
+      return { precision: 6, unit: 'microsecond', increment: 1 };
+    case 'nanosecond':
+      return { precision: 9, unit: 'nanosecond', increment: 1 };
+    default: // fall through if option not given
+  }
+  let digits = options.fractionalSecondDigits;
+  if (digits === undefined) digits = 'auto';
+  if (typeof digits !== 'number') {
+    const stringDigits = ToString(digits);
+    if (stringDigits === 'auto') return { precision: 'auto', unit: 'nanosecond', increment: 1 };
+    throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${stringDigits}`);
+  }
+  if (NumberIsNaN(digits) || digits < 0 || digits > 9) {
+    throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
+  }
+  const precision = MathFloor(digits);
+  switch (precision) {
+    case 0:
+      return { precision, unit: 'second', increment: 1 };
+    case 1:
+    case 2:
+    case 3:
+      return { precision, unit: 'millisecond', increment: 10 ** (3 - precision) };
+    case 4:
+    case 5:
+    case 6:
+      return { precision, unit: 'microsecond', increment: 10 ** (6 - precision) };
+    case 7:
+    case 8:
+    case 9:
+      return { precision, unit: 'nanosecond', increment: 10 ** (9 - precision) };
+    default:
+      throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
+  }
+}
+
+export const REQUIRED = Symbol('~required~');
+
+interface TemporalUnitOptionsBag {
+  smallestUnit?: Temporal.PluralUnit<Temporal.DateTimeUnit> | Temporal.DateTimeUnit;
+  largestUnit?: Temporal.PluralUnit<Temporal.DateTimeUnit> | Temporal.DateTimeUnit | 'auto';
+  unit?: Temporal.PluralUnit<Temporal.DateTimeUnit> | Temporal.DateTimeUnit;
+}
+type UnitTypeMapping = {
+  date: Temporal.DateUnit;
+  time: Temporal.TimeUnit;
+  datetime: Temporal.DateTimeUnit;
+};
+// This type specifies the allowed defaults for each unit key type.
+type AllowedGetTemporalUnitDefaultValues = {
+  smallestUnit: undefined;
+  largestUnit: 'auto' | undefined;
+  unit: undefined;
+};
+
+export function GetTemporalUnit<
+  U extends keyof TemporalUnitOptionsBag,
+  T extends keyof UnitTypeMapping,
+  D extends typeof REQUIRED | UnitTypeMapping[T] | AllowedGetTemporalUnitDefaultValues[U],
+  R extends Exclude<D, typeof REQUIRED> | UnitTypeMapping[T]
+>(options: TemporalUnitOptionsBag, key: U, unitGroup: T, requiredOrDefault: D): R;
+export function GetTemporalUnit<
+  U extends keyof TemporalUnitOptionsBag,
+  T extends keyof UnitTypeMapping,
+  D extends typeof REQUIRED | UnitTypeMapping[T] | AllowedGetTemporalUnitDefaultValues[U],
+  E extends 'auto' | Temporal.DateTimeUnit,
+  R extends UnitTypeMapping[T] | Exclude<D, typeof REQUIRED> | E
+>(options: TemporalUnitOptionsBag, key: U, unitGroup: T, requiredOrDefault: D, extraValues: ReadonlyArray<E>): R;
+// This signature of the function is NOT used in type-checking, so restricting
+// the default value via generic binding like the other overloads isn't
+// necessary.
+export function GetTemporalUnit<
+  T extends keyof UnitTypeMapping,
+  D extends typeof REQUIRED | UnitTypeMapping[T] | 'auto' | undefined,
+  E extends 'auto' | Temporal.DateTimeUnit,
+  R extends UnitTypeMapping[T] | Exclude<D, typeof REQUIRED> | E
+>(
+  options: TemporalUnitOptionsBag,
+  key: keyof typeof options,
+  unitGroup: T,
+  requiredOrDefault: D,
+  extraValues: ReadonlyArray<E> | never[] = []
+): R {
+  const allowedSingular: Array<Temporal.DateTimeUnit | 'auto'> = [];
+  for (const [, singular, category] of SINGULAR_PLURAL_UNITS) {
+    if (unitGroup === 'datetime' || unitGroup === category) {
+      allowedSingular.push(singular);
+    }
+  }
+  allowedSingular.push(...extraValues);
+  let defaultVal: typeof REQUIRED | Temporal.DateTimeUnit | 'auto' | undefined = requiredOrDefault;
+  if (defaultVal === REQUIRED) {
+    defaultVal = undefined;
+  } else if (defaultVal !== undefined) {
+    allowedSingular.push(defaultVal);
+  }
+  const allowedValues: Array<Temporal.DateTimeUnit | Temporal.PluralUnit<Temporal.DateTimeUnit> | 'auto'> = [
+    ...allowedSingular
+  ];
+  for (const singular of allowedSingular) {
+    const plural = PLURAL_FOR.get(singular as Parameters<typeof PLURAL_FOR.get>[0]);
+    if (plural !== undefined) allowedValues.push(plural);
+  }
+  let retval = GetOption(options, key, allowedValues, defaultVal);
+  if (retval === undefined && requiredOrDefault === REQUIRED) {
+    throw new RangeError(`${key} is required`);
+  }
+  // Coerce any plural units into their singular form
+  if (SINGULAR_FOR.has(retval as Temporal.PluralUnit<Temporal.DateTimeUnit>)) {
+    // We just has-checked this, but tsc doesn't understand that.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return SINGULAR_FOR.get(retval as Temporal.PluralUnit<Temporal.DateTimeUnit>)! as R;
+  }
+  return retval as R;
+}
+
+export function ToRelativeTemporalObject(options: {
+  relativeTo?:
+    | Temporal.ZonedDateTime
+    | Temporal.PlainDateTime
+    | Temporal.ZonedDateTimeLike
+    | Temporal.PlainDateTimeLike
+    | string
+    | undefined;
+}): Temporal.ZonedDateTime | Temporal.PlainDate | undefined {
+  const relativeTo = options.relativeTo;
+  if (relativeTo === undefined) return relativeTo;
+
+  let offsetBehaviour: OffsetBehaviour = 'option';
+  let matchMinutes = false;
+  let year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, timeZone, offset;
+  if (IsObject(relativeTo)) {
+    if (IsTemporalZonedDateTime(relativeTo) || IsTemporalDate(relativeTo)) return relativeTo;
+    if (IsTemporalDateTime(relativeTo)) return TemporalDateTimeToDate(relativeTo);
+    calendar = GetTemporalCalendarWithISODefault(relativeTo);
+    const fieldNames = CalendarFields(calendar, [
+      'day',
+      'hour',
+      'microsecond',
+      'millisecond',
+      'minute',
+      'month',
+      'monthCode',
+      'nanosecond',
+      'second',
+      'year'
+    ] as const);
+    const fields = PrepareTemporalFields(relativeTo, fieldNames, []);
+    const dateOptions = ObjectCreate(null);
+    dateOptions.overflow = 'constrain';
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = InterpretTemporalDateTimeFields(
+      calendar,
+      fields,
+      dateOptions
+    ));
+    // The `offset` and `timeZone` properties only exist on ZonedDateTime (or
+    // ZonedDateTimeLike-property bags). The assertions below are used to avoid
+    // TS errors while not diverging runtime code from proposal-temporal.
+    offset = (relativeTo as Temporal.ZonedDateTimeLike).offset;
+    if (offset === undefined) offsetBehaviour = 'wall';
+    timeZone = (relativeTo as Temporal.ZonedDateTimeLike).timeZone;
+  } else {
+    let ianaName, z;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, ianaName, offset, z } =
+      ParseISODateTime(ToString(relativeTo)));
+    if (ianaName) timeZone = ianaName;
+    if (z) {
+      offsetBehaviour = 'exact';
+    } else if (!offset) {
+      offsetBehaviour = 'wall';
+    }
+    if (!calendar) calendar = GetISO8601Calendar();
+    calendar = ToTemporalCalendar(calendar);
+    matchMinutes = true;
+  }
+  if (timeZone !== undefined) {
+    timeZone = ToTemporalTimeZone(timeZone);
+    let offsetNs = 0;
+    if (offsetBehaviour === 'option') offsetNs = ParseTimeZoneOffsetString(ToString(offset));
+    const epochNanoseconds = InterpretISODateTimeOffset(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      offsetBehaviour,
+      offsetNs,
+      timeZone,
+      'compatible',
+      'reject',
+      matchMinutes
+    );
+    return CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
+  }
+  return CreateTemporalDate(year, month, day, calendar);
+}
+
+export function DefaultTemporalLargestUnit(
+  years: number,
+  months: number,
+  weeks: number,
+  days: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number,
+  microseconds: number,
+  nanoseconds: number
+): Temporal.DateTimeUnit {
+  for (const [prop, v] of [
+    ['years', years],
+    ['months', months],
+    ['weeks', weeks],
+    ['days', days],
+    ['hours', hours],
+    ['minutes', minutes],
+    ['seconds', seconds],
+    ['milliseconds', milliseconds],
+    ['microseconds', microseconds],
+    ['nanoseconds', nanoseconds]
+  ] as const) {
+    if (v !== 0) {
+      // All the above keys are definitely in SINGULAR_FOR
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return SINGULAR_FOR.get(prop)!;
+    }
+  }
+  return 'nanosecond';
+}
+
+export function LargerOfTwoTemporalUnits<T1 extends Temporal.DateTimeUnit, T2 extends Temporal.DateTimeUnit>(
+  unit1: T1,
+  unit2: T2
+) {
+  if (UNITS_DESCENDING.indexOf(unit1) > UNITS_DESCENDING.indexOf(unit2)) return unit2;
+  return unit1;
+}
+
+function MergeLargestUnitOption<T extends Temporal.DateTimeUnit>(
+  optionsParam: Temporal.DifferenceOptions<T> | undefined,
+  largestUnit: T
+): Temporal.DifferenceOptions<T> {
+  let options = optionsParam;
+  if (options === undefined) options = ObjectCreate(null);
+  return ObjectAssign(ObjectCreate(null), options, { largestUnit });
+}
+
+type FieldCompleteness = 'complete' | 'partial';
+interface FieldPrepareOptions {
+  emptySourceErrorMessage: string;
+}
+
+type AnyTemporalKey = Exclude<Keys<AnyTemporalLikeType>, symbol>;
+
+// Keys is a conditionally-mapped version of keyof
+type Keys<T> = T extends Record<string, unknown> ? keyof T : never;
+
+// Returns all potential owners from all Temporal Like-types for a given union
+// of keys in K.
+// e.g.
+// Owner<'nanosecond'> => PlainDateTimeLike | ZonedDateTimeLike | PlainDateTimeLike | ZonedDateTimeLike
+// Owner<'nanoseconds'> => Duration (the only type with plural keys)
+type Owner<K extends AnyTemporalKey> =
+  // Conditional typing maps over all of the types given in AnyTemporalLikeType
+  // union
+  K extends unknown ? OwnerOf<K, AnyTemporalLikeType> : 'ThisShouldNeverHappen';
+
+// Returns T iff T has K as all of the key(s) (even if those keys are optional
+// in T), never otherwise. This is a private type for use only in the Owner type
+// above.
+type OwnerOf<K extends AnyTemporalKey, T> =
+  // Distribute the union before passing to Required
+  // Without distributing, this is
+  // Required<ZonedDateTimeLike | DurationLike> extends Record
+  // vs (with distribution)
+  // Required<ZonedDateTimeLike> extends Record<....> | Required<DurationLike> extends Record<....>
+  T extends unknown
+    ? // All the keys in the Like-types are optional, so in order for them to
+      // 'extend Record<K,...>', where K indicates the required fields, we pass T
+      // through Required to make all the keys non-optional.
+      // Note this doesn't work the other way around: using Partial<Record<K, ..>>
+      // will always be extended by any object (as all the keys are optional).
+      Required<T> extends Record<K, unknown>
+      ? T
+      : // never is the 'identity' type for unions - nothing will be added or
+        // removed from the union.
+        never
+    : 'ThisShouldNeverHappen';
+
+type Prop<T, K> = T extends unknown ? (K extends keyof T ? T[K] : undefined) : 'ThisShouldNeverHappen';
+
+// Resolve copies the keys and values of a given object type so that TS will
+// stop using type names in error messages / autocomplete. Generally, those
+// names can be more useful, but sometimes having the primitive object shape is
+// significantly easier to reason about (e.g. deeply-nested types).
+// Resolve is an identity function for function types.
+type Resolve<T> =
+  // Re-mapping doesn't work very well for functions, so exclude them
+  T extends (...args: never[]) => unknown
+    ? T
+    : // Re-map all the keys in T to the same value. This forces TS into no longer
+      // using type aliases, etc.
+      { [K in keyof T]: T[K] };
+
+type FieldObjectFromOwners<OwnerT, FieldKeys extends AnyTemporalKey> = Resolve<
+  // The resulting object type contains:
+  // - All keys in FieldKeys, which are required properties and their values
+  //   don't include undefined.
+  // - All the other keys in OwnerT that aren't in FieldKeys, which are optional
+  //   properties and their value types explicitly include undefined.
+  {
+    -readonly [k in FieldKeys]: Exclude<Prop<OwnerT, k>, undefined>;
+  } & {
+    -readonly [k in Exclude<Keys<OwnerT>, FieldKeys>]?: Prop<OwnerT, k> | undefined;
+  }
+>;
+
+type PrepareTemporalFieldsReturn<
+  FieldKeys extends AnyTemporalKey,
+  RequiredFieldsOpt extends ReadonlyArray<FieldKeys> | FieldCompleteness,
+  OwnerT extends Owner<FieldKeys>
+> = RequiredFieldsOpt extends 'partial' ? Partial<OwnerT> : FieldObjectFromOwners<OwnerT, FieldKeys>;
+export function PrepareTemporalFields<
+  FieldKeys extends AnyTemporalKey,
+  // Constrains the Required keys to be a subset of the given field keys
+  // This could have been written directly into the parameter type, but that
+  // causes an unintended effect where the required fields are added to the list
+  // of field keys, even if that key isn't present in 'fields'.
+  // RequiredFieldKeys extends FieldKeys,
+  RequiredFields extends ReadonlyArray<FieldKeys> | FieldCompleteness
+>(
+  bag: Partial<Record<FieldKeys, unknown>>,
+  fields: ReadonlyArray<FieldKeys>,
+  requiredFields: RequiredFields,
+  { emptySourceErrorMessage }: FieldPrepareOptions = { emptySourceErrorMessage: 'no supported properties found' }
+): PrepareTemporalFieldsReturn<FieldKeys, RequiredFields, Owner<FieldKeys>> {
+  const result: Partial<Record<AnyTemporalKey, unknown>> = ObjectCreate(null);
+  let any = false;
+  for (const property of fields) {
+    let value = bag[property];
+    if (value !== undefined) {
+      any = true;
+      if (BUILTIN_CASTS.has(property)) {
+        // We just has-checked this map access, so there will definitely be a
+        // value.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        value = BUILTIN_CASTS.get(property)!(value);
+      }
+      result[property] = value;
+    } else if (requiredFields !== 'partial') {
+      // TODO: using .call in this way is not correctly type-checked by tsc.
+      // We might need a type-safe Call wrapper?
+      if (ArrayIncludes.call(requiredFields, property)) {
+        throw new TypeError(`required property '${property}' missing or undefined`);
+      }
+      value = BUILTIN_DEFAULTS.get(property);
+      result[property] = value;
+    }
+  }
+  if (requiredFields === 'partial' && !any) {
+    throw new TypeError(emptySourceErrorMessage);
+  }
+  if ((result.era === undefined) !== (result.eraYear === undefined)) {
+    throw new RangeError("properties 'era' and 'eraYear' must be provided together");
+  }
+  return result as unknown as PrepareTemporalFieldsReturn<FieldKeys, RequiredFields, Owner<FieldKeys>>;
+}
+
+interface TimeRecord {
+  hour?: number;
+  minute?: number;
+  second?: number;
+  microsecond?: number;
+  millisecond?: number;
+  nanosecond?: number;
+}
+export function ToTemporalTimeRecord(bag: Partial<Record<keyof TimeRecord, string | number>>): Required<TimeRecord>;
+export function ToTemporalTimeRecord(
+  bag: Partial<Record<keyof TimeRecord, string | number | undefined>>,
+  completeness: 'partial'
+): Partial<TimeRecord>;
+export function ToTemporalTimeRecord(
+  bag: Partial<Record<keyof TimeRecord, string | number>>,
+  completeness: 'complete'
+): Required<TimeRecord>;
+export function ToTemporalTimeRecord(
+  bag: Partial<Record<keyof TimeRecord, string | number | undefined>>,
+  completeness: FieldCompleteness = 'complete'
+): Partial<TimeRecord> {
+  // NOTE: Field order here is important.
+  const fields = ['hour', 'microsecond', 'millisecond', 'minute', 'nanosecond', 'second'] as const;
+  const partial = PrepareTemporalFields(bag, fields, 'partial', { emptySourceErrorMessage: 'invalid time-like' });
+  const result: Partial<TimeRecord> = {};
+  for (const field of fields) {
+    const valueDesc = ObjectGetOwnPropertyDescriptor(partial, field);
+    if (valueDesc !== undefined) {
+      result[field] = valueDesc.value;
+    } else if (completeness === 'complete') {
+      result[field] = 0;
+    }
+  }
+  return result;
+}
+
+export function ToTemporalDate(
+  itemParam: PlainDateParams['from'][0],
+  options?: PlainDateParams['from'][1]
+): Temporal.PlainDate {
+  let item = itemParam;
+  if (IsObject(item)) {
+    if (IsTemporalDate(item)) return item;
+    if (IsTemporalZonedDateTime(item)) {
+      ToTemporalOverflow(options); // validate and ignore
+      item = BuiltinTimeZoneGetPlainDateTimeFor(
+        GetSlot(item, TIME_ZONE),
+        GetSlot(item, INSTANT),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    if (IsTemporalDateTime(item)) {
+      ToTemporalOverflow(options); // validate and ignore
+      return CreateTemporalDate(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    const calendar = GetTemporalCalendarWithISODefault(item);
+    const fieldNames = CalendarFields(calendar, ['day', 'month', 'monthCode', 'year'] as const);
+    const fields = PrepareTemporalFields(item, fieldNames, []);
+    return CalendarDateFromFields(calendar, fields, options);
+  }
+  ToTemporalOverflow(options); // validate and ignore
+  const { year, month, day, calendar, z } = ParseTemporalDateString(ToString(item));
+  if (z) throw new RangeError('Z designator not supported for PlainDate');
+  const TemporalPlainDate = GetIntrinsic('%Temporal.PlainDate%');
+  return new TemporalPlainDate(year, month, day, calendar); // include validation
+}
+
+export function InterpretTemporalDateTimeFields(
+  calendar: Temporal.CalendarProtocol,
+  fields: PrimitiveFieldsOf<Temporal.PlainDateTimeLike> & Parameters<typeof CalendarDateFromFields>[1],
+  options?: Temporal.AssignmentOptions
+) {
+  let { hour, minute, second, millisecond, microsecond, nanosecond } = ToTemporalTimeRecord(fields);
+  const overflow = ToTemporalOverflow(options);
+  const date = CalendarDateFromFields(calendar, fields, options);
+  const year = GetSlot(date, ISO_YEAR);
+  const month = GetSlot(date, ISO_MONTH);
+  const day = GetSlot(date, ISO_DAY);
+  ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond,
+    overflow
+  ));
+  return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+export function ToTemporalDateTime(item: PlainDateTimeParams['from'][0], options?: PlainDateTimeParams['from'][1]) {
+  let year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+    millisecond: number,
+    microsecond: number,
+    nanosecond: number,
+    calendar;
+  if (IsObject(item)) {
+    if (IsTemporalDateTime(item)) return item;
+    if (IsTemporalZonedDateTime(item)) {
+      ToTemporalOverflow(options); // validate and ignore
+      return BuiltinTimeZoneGetPlainDateTimeFor(
+        GetSlot(item, TIME_ZONE),
+        GetSlot(item, INSTANT),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    if (IsTemporalDate(item)) {
+      ToTemporalOverflow(options); // validate and ignore
+      return CreateTemporalDateTime(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        GetSlot(item, CALENDAR)
+      );
+    }
+
+    calendar = GetTemporalCalendarWithISODefault(item);
+    const fieldNames = CalendarFields(calendar, [
+      'day',
+      'hour',
+      'microsecond',
+      'millisecond',
+      'minute',
+      'month',
+      'monthCode',
+      'nanosecond',
+      'second',
+      'year'
+    ] as const);
+    const fields = PrepareTemporalFields(item, fieldNames, []);
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = InterpretTemporalDateTimeFields(
+      calendar,
+      fields,
+      options
+    ));
+  } else {
+    ToTemporalOverflow(options); // validate and ignore
+    let z;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } =
+      ParseTemporalDateTimeString(ToString(item)));
+    if (z) throw new RangeError('Z designator not supported for PlainDateTime');
+    RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    if (calendar === undefined) calendar = GetISO8601Calendar();
+    calendar = ToTemporalCalendar(calendar);
+  }
+  return CreateTemporalDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+}
+
+export function ToTemporalDuration(item: DurationParams['from'][0]) {
+  if (IsTemporalDuration(item)) return item;
+  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+    ToTemporalDurationRecord(item);
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  return new TemporalDuration(
+    years,
+    months,
+    weeks,
+    days,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds
+  );
+}
+
+export function ToTemporalInstant(item: InstantParams['from'][0]) {
+  if (IsTemporalInstant(item)) return item;
+  if (IsTemporalZonedDateTime(item)) {
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    return new TemporalInstant(GetSlot(item, EPOCHNANOSECONDS));
+  }
+  const ns = ParseTemporalInstant(ToString(item));
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  return new TemporalInstant(ns);
+}
+
+export function ToTemporalMonthDay(
+  itemParam: PlainMonthDayParams['from'][0],
+  options?: PlainMonthDayParams['from'][1]
+) {
+  let item = itemParam;
+  if (IsObject(item)) {
+    if (IsTemporalMonthDay(item)) return item;
+    let calendar: Temporal.CalendarProtocol, calendarAbsent: boolean;
+    if (HasSlot(item, CALENDAR)) {
+      calendar = GetSlot(item, CALENDAR);
+      calendarAbsent = false;
+    } else {
+      let maybeStringCalendar = item.calendar;
+      calendarAbsent = maybeStringCalendar === undefined;
+      if (maybeStringCalendar === undefined) maybeStringCalendar = GetISO8601Calendar();
+      calendar = ToTemporalCalendar(maybeStringCalendar);
+    }
+    // HasSlot above adjusts the type of 'item' to include
+    // TypesWithCalendarUnits, which causes type-inference failures below.
+    // This is probably indicative of problems with HasSlot's typing.
+    item = item as Temporal.PlainMonthDayLike;
+    const fieldNames = CalendarFields(calendar, ['day', 'month', 'monthCode', 'year'] as const);
+    const fields = PrepareTemporalFields(item, fieldNames, []);
+    // Callers who omit the calendar are not writing calendar-independent
+    // code. In that case, `monthCode`/`year` can be omitted; `month` and
+    // `day` are sufficient. Add a `year` to satisfy calendar validation.
+    if (calendarAbsent && fields.month !== undefined && fields.monthCode === undefined && fields.year === undefined) {
+      fields.year = 1972;
+    }
+    return CalendarMonthDayFromFields(calendar, fields, options);
+  }
+
+  ToTemporalOverflow(options); // validate and ignore
+  let { month, day, referenceISOYear, calendar: maybeStringCalendar } = ParseTemporalMonthDayString(ToString(item));
+  let calendar: Temporal.CalendarProtocol | string | undefined = maybeStringCalendar;
+  if (calendar === undefined) calendar = GetISO8601Calendar();
+  calendar = ToTemporalCalendar(calendar);
+
+  if (referenceISOYear === undefined) {
+    RejectISODate(1972, month, day);
+    return CreateTemporalMonthDay(month, day, calendar);
+  }
+  const result = CreateTemporalMonthDay(month, day, calendar, referenceISOYear);
+  return CalendarMonthDayFromFields(calendar, result);
+}
+
+export function ToTemporalTime(
+  itemParam: PlainTimeParams['from'][0],
+  overflow: NonNullable<PlainTimeParams['from'][1]>['overflow'] = 'constrain'
+) {
+  let item = itemParam;
+  let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
+  if (IsObject(item)) {
+    if (IsTemporalTime(item)) return item;
+    if (IsTemporalZonedDateTime(item)) {
+      item = BuiltinTimeZoneGetPlainDateTimeFor(
+        GetSlot(item, TIME_ZONE),
+        GetSlot(item, INSTANT),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    if (IsTemporalDateTime(item)) {
+      const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
+      return new TemporalPlainTime(
+        GetSlot(item, ISO_HOUR),
+        GetSlot(item, ISO_MINUTE),
+        GetSlot(item, ISO_SECOND),
+        GetSlot(item, ISO_MILLISECOND),
+        GetSlot(item, ISO_MICROSECOND),
+        GetSlot(item, ISO_NANOSECOND)
+      );
+    }
+    calendar = GetTemporalCalendarWithISODefault(item);
+    if (ToString(calendar) !== 'iso8601') {
+      throw new RangeError('PlainTime can only have iso8601 calendar');
+    }
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ToTemporalTimeRecord(item));
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      overflow
+    ));
+  } else {
+    ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar } = ParseTemporalTimeString(
+      ToString(item)
+    ));
+    RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
+    if (calendar !== undefined && calendar !== 'iso8601') {
+      throw new RangeError('PlainTime can only have iso8601 calendar');
+    }
+  }
+  const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
+  return new TemporalPlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+export function ToTemporalYearMonth(
+  item: PlainYearMonthParams['from'][0],
+  options?: PlainYearMonthParams['from'][1]
+): Temporal.PlainYearMonth {
+  if (IsObject(item)) {
+    if (IsTemporalYearMonth(item)) return item;
+    const calendar = GetTemporalCalendarWithISODefault(item);
+    const fieldNames = CalendarFields(calendar, ['month', 'monthCode', 'year'] as const);
+    const fields = PrepareTemporalFields(item, fieldNames, []);
+    return CalendarYearMonthFromFields(calendar, fields, options);
+  }
+
+  ToTemporalOverflow(options); // validate and ignore
+  let { year, month, referenceISODay, calendar: maybeStringCalendar } = ParseTemporalYearMonthString(ToString(item));
+  // TODO: replace with ternary?
+  let calendar: Temporal.CalendarProtocol | string = maybeStringCalendar;
+  if (calendar === undefined) calendar = GetISO8601Calendar();
+  calendar = ToTemporalCalendar(calendar);
+
+  if (referenceISODay === undefined) {
+    RejectISODate(year, month, 1);
+    return CreateTemporalYearMonth(year, month, calendar);
+  }
+  const result = CreateTemporalYearMonth(year, month, calendar, referenceISODay);
+  return CalendarYearMonthFromFields(calendar, result);
+}
+
+type OffsetBehaviour = 'wall' | 'exact' | 'option';
+
+export function InterpretISODateTimeOffset(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number,
+  offsetBehaviour: OffsetBehaviour,
+  offsetNs: number,
+  timeZone: Temporal.TimeZoneProtocol,
+  disambiguation: NonNullable<Temporal.ToInstantOptions['disambiguation']>,
+  offsetOpt: Temporal.OffsetDisambiguationOptions['offset'],
+  matchMinute: boolean
+) {
+  const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+  const dt = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+
+  if (offsetBehaviour === 'wall' || offsetOpt === 'ignore') {
+    // Simple case: ISO string without a TZ offset (or caller wants to ignore
+    // the offset), so just convert DateTime to Instant in the given time zone
+    const instant = BuiltinTimeZoneGetInstantFor(timeZone, dt, disambiguation);
+    return GetSlot(instant, EPOCHNANOSECONDS);
+  }
+
+  // The caller wants the offset to always win ('use') OR the caller is OK
+  // with the offset winning ('prefer' or 'reject') as long as it's valid
+  // for this timezone and date/time.
+  if (offsetBehaviour === 'exact' || offsetOpt === 'use') {
+    // Calculate the instant for the input's date/time and offset
+    const epochNs = GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    if (epochNs === null) throw new RangeError('ZonedDateTime outside of supported range');
+    return JSBI.subtract(epochNs, JSBI.BigInt(offsetNs));
+  }
+
+  // "prefer" or "reject"
+  const possibleInstants = GetPossibleInstantsFor(timeZone, dt);
+  for (const candidate of possibleInstants) {
+    const candidateOffset = GetOffsetNanosecondsFor(timeZone, candidate);
+    const roundedCandidateOffset = JSBI.toNumber(
+      RoundNumberToIncrement(JSBI.BigInt(candidateOffset), 60e9, 'halfExpand')
+    );
+    if (candidateOffset === offsetNs || (matchMinute && roundedCandidateOffset === offsetNs)) {
+      return GetSlot(candidate, EPOCHNANOSECONDS);
+    }
+  }
+
+  // the user-provided offset doesn't match any instants for this time
+  // zone and date/time.
+  if (offsetOpt === 'reject') {
+    const offsetStr = FormatTimeZoneOffsetString(offsetNs);
+    const timeZoneString = IsTemporalTimeZone(timeZone) ? GetSlot(timeZone, TIMEZONE_ID) : 'time zone';
+    // The tsc emit for this line rewrites to invoke the PlainDateTime's valueOf method, NOT
+    // toString (which is invoked by Node when using template literals directly).
+    // See https://github.com/microsoft/TypeScript/issues/39744 for the proposed fix in tsc emit
+    throw new RangeError(`Offset ${offsetStr} is invalid for ${dt.toString()} in ${timeZoneString}`);
+  }
+  // fall through: offsetOpt === 'prefer', but the offset doesn't match
+  // so fall back to use the time zone instead.
+  const instant = DisambiguatePossibleInstants(possibleInstants, timeZone, dt, disambiguation);
+  return GetSlot(instant, EPOCHNANOSECONDS);
+}
+
+export function ToTemporalZonedDateTime(
+  item: ZonedDateTimeParams['from'][0],
+  options?: ZonedDateTimeParams['from'][1]
+) {
+  let year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+    millisecond: number,
+    microsecond: number,
+    nanosecond: number,
+    timeZone,
+    offset: string | undefined,
+    calendar: string | Temporal.CalendarProtocol;
+  let matchMinute = false;
+  let offsetBehaviour: OffsetBehaviour = 'option';
+  if (IsObject(item)) {
+    if (IsTemporalZonedDateTime(item)) return item;
+    calendar = GetTemporalCalendarWithISODefault(item);
+    const fieldNames = CalendarFields(calendar, [
+      'day',
+      'hour',
+      'microsecond',
+      'millisecond',
+      'minute',
+      'month',
+      'monthCode',
+      'nanosecond',
+      'second',
+      'year'
+    ] as const);
+    const fieldNamesWithTzAndOffset = ArrayPush(fieldNames, 'timeZone', 'offset');
+    const fields = PrepareTemporalFields(item, fieldNamesWithTzAndOffset, ['timeZone']);
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = InterpretTemporalDateTimeFields(
+      calendar,
+      fields,
+      options
+    ));
+    timeZone = ToTemporalTimeZone(fields.timeZone);
+    offset = fields.offset;
+    if (offset === undefined) {
+      offsetBehaviour = 'wall';
+    } else {
+      offset = ToString(offset);
+    }
+  } else {
+    ToTemporalOverflow(options); // validate and ignore
+    let ianaName, z;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, ianaName, offset, z, calendar } =
+      ParseTemporalZonedDateTimeString(ToString(item)));
+    if (!ianaName) throw new RangeError('time zone ID required in brackets');
+    if (z) {
+      offsetBehaviour = 'exact';
+    } else if (!offset) {
+      offsetBehaviour = 'wall';
+    }
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    timeZone = new TemporalTimeZone(ianaName);
+    if (!calendar) calendar = GetISO8601Calendar();
+    calendar = ToTemporalCalendar(calendar);
+    matchMinute = true; // ISO strings may specify offset with less precision
+  }
+  let offsetNs = 0;
+  // The code above guarantees that if offsetBehaviour === 'option', then
+  // `offset` is not undefined.
+  if (offsetBehaviour === 'option') offsetNs = ParseTimeZoneOffsetString(offset as string);
+  const disambiguation = ToTemporalDisambiguation(options);
+  const offsetOpt = ToTemporalOffset(options, 'reject');
+  const epochNanoseconds = InterpretISODateTimeOffset(
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond,
+    offsetBehaviour,
+    offsetNs,
+    timeZone,
+    disambiguation,
+    offsetOpt,
+    matchMinute
+  );
+  return CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
+}
+
+export function CreateTemporalDateSlots(
+  result: Temporal.PlainDate,
+  isoYear: number,
+  isoMonth: number,
+  isoDay: number,
+  calendar: Temporal.CalendarProtocol
+) {
+  RejectISODate(isoYear, isoMonth, isoDay);
+  RejectDateRange(isoYear, isoMonth, isoDay);
+
+  CreateSlots(result);
+  SetSlot(result, ISO_YEAR, isoYear);
+  SetSlot(result, ISO_MONTH, isoMonth);
+  SetSlot(result, ISO_DAY, isoDay);
+  SetSlot(result, CALENDAR, calendar);
+  SetSlot(result, DATE_BRAND, true);
+
+  if (DEBUG) {
+    ObjectDefineProperty(result, '_repr_', {
+      value: `${result[Symbol.toStringTag]} <${TemporalDateToString(result)}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalDate(
+  isoYear: number,
+  isoMonth: number,
+  isoDay: number,
+  calendar: Temporal.CalendarProtocol = GetISO8601Calendar()
+) {
+  const TemporalPlainDate = GetIntrinsic('%Temporal.PlainDate%');
+  const result = ObjectCreate(TemporalPlainDate.prototype);
+  CreateTemporalDateSlots(result, isoYear, isoMonth, isoDay, calendar);
+  return result;
+}
+
+export function CreateTemporalDateTimeSlots(
+  result: Temporal.PlainDateTime,
+  isoYear: number,
+  isoMonth: number,
+  isoDay: number,
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  µs: number,
+  ns: number,
+  calendar: Temporal.CalendarProtocol
+) {
+  RejectDateTime(isoYear, isoMonth, isoDay, h, min, s, ms, µs, ns);
+  RejectDateTimeRange(isoYear, isoMonth, isoDay, h, min, s, ms, µs, ns);
+
+  CreateSlots(result);
+  SetSlot(result, ISO_YEAR, isoYear);
+  SetSlot(result, ISO_MONTH, isoMonth);
+  SetSlot(result, ISO_DAY, isoDay);
+  SetSlot(result, ISO_HOUR, h);
+  SetSlot(result, ISO_MINUTE, min);
+  SetSlot(result, ISO_SECOND, s);
+  SetSlot(result, ISO_MILLISECOND, ms);
+  SetSlot(result, ISO_MICROSECOND, µs);
+  SetSlot(result, ISO_NANOSECOND, ns);
+  SetSlot(result, CALENDAR, calendar);
+
+  if (DEBUG) {
+    Object.defineProperty(result, '_repr_', {
+      value: `${result[Symbol.toStringTag]} <${TemporalDateTimeToString(result, 'auto')}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalDateTime(
+  isoYear: number,
+  isoMonth: number,
+  isoDay: number,
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  µs: number,
+  ns: number,
+  calendar: Temporal.CalendarProtocol = GetISO8601Calendar()
+) {
+  const TemporalPlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+  const result = ObjectCreate(TemporalPlainDateTime.prototype);
+  CreateTemporalDateTimeSlots(result, isoYear, isoMonth, isoDay, h, min, s, ms, µs, ns, calendar);
+  return result as Temporal.PlainDateTime;
+}
+
+export function CreateTemporalMonthDaySlots(
+  result: Temporal.PlainMonthDay,
+  isoMonth: number,
+  isoDay: number,
+  calendar: Temporal.CalendarProtocol,
+  referenceISOYear: number
+) {
+  RejectISODate(referenceISOYear, isoMonth, isoDay);
+  RejectDateRange(referenceISOYear, isoMonth, isoDay);
+
+  CreateSlots(result);
+  SetSlot(result, ISO_MONTH, isoMonth);
+  SetSlot(result, ISO_DAY, isoDay);
+  SetSlot(result, ISO_YEAR, referenceISOYear);
+  SetSlot(result, CALENDAR, calendar);
+  SetSlot(result, MONTH_DAY_BRAND, true);
+
+  if (DEBUG) {
+    Object.defineProperty(result, '_repr_', {
+      value: `${result[Symbol.toStringTag]} <${TemporalMonthDayToString(result)}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalMonthDay(
+  isoMonth: number,
+  isoDay: number,
+  calendar: Temporal.CalendarProtocol = GetISO8601Calendar(),
+  referenceISOYear = 1972
+) {
+  const TemporalPlainMonthDay = GetIntrinsic('%Temporal.PlainMonthDay%');
+  const result = ObjectCreate(TemporalPlainMonthDay.prototype);
+  CreateTemporalMonthDaySlots(result, isoMonth, isoDay, calendar, referenceISOYear);
+  return result;
+}
+
+export function CreateTemporalYearMonthSlots(
+  result: Temporal.PlainYearMonth,
+  isoYear: number,
+  isoMonth: number,
+  calendar: Temporal.CalendarProtocol,
+  referenceISODay: number
+) {
+  RejectISODate(isoYear, isoMonth, referenceISODay);
+  RejectYearMonthRange(isoYear, isoMonth);
+
+  CreateSlots(result);
+  SetSlot(result, ISO_YEAR, isoYear);
+  SetSlot(result, ISO_MONTH, isoMonth);
+  SetSlot(result, ISO_DAY, referenceISODay);
+  SetSlot(result, CALENDAR, calendar);
+  SetSlot(result, YEAR_MONTH_BRAND, true);
+
+  if (DEBUG) {
+    Object.defineProperty(result, '_repr_', {
+      value: `${result[Symbol.toStringTag]} <${TemporalYearMonthToString(result)}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalYearMonth(
+  isoYear: number,
+  isoMonth: number,
+  calendar: Temporal.CalendarProtocol = GetISO8601Calendar(),
+  referenceISODay = 1
+) {
+  const TemporalPlainYearMonth = GetIntrinsic('%Temporal.PlainYearMonth%');
+  const result = ObjectCreate(TemporalPlainYearMonth.prototype);
+  CreateTemporalYearMonthSlots(result, isoYear, isoMonth, calendar, referenceISODay);
+  return result;
+}
+
+export function CreateTemporalZonedDateTimeSlots(
+  result: Temporal.ZonedDateTime,
+  epochNanoseconds: JSBI,
+  timeZone: Temporal.TimeZoneProtocol,
+  calendar: Temporal.CalendarProtocol
+) {
+  ValidateEpochNanoseconds(epochNanoseconds);
+
+  CreateSlots(result);
+  SetSlot(result, EPOCHNANOSECONDS, epochNanoseconds);
+  SetSlot(result, TIME_ZONE, timeZone);
+  SetSlot(result, CALENDAR, calendar);
+
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  const instant = new TemporalInstant(GetSlot(result, EPOCHNANOSECONDS));
+  SetSlot(result, INSTANT, instant);
+
+  if (DEBUG) {
+    Object.defineProperty(result, '_repr_', {
+      value: `${result[Symbol.toStringTag]} <${TemporalZonedDateTimeToString(result, 'auto')}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalZonedDateTime(
+  epochNanoseconds: JSBI,
+  timeZone: Temporal.TimeZoneProtocol,
+  calendar: Temporal.CalendarProtocol = GetISO8601Calendar()
+) {
+  const TemporalZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+  const result = ObjectCreate(TemporalZonedDateTime.prototype);
+  CreateTemporalZonedDateTimeSlots(result, epochNanoseconds, timeZone, calendar);
+  return result;
+}
+
+export function GetISO8601Calendar() {
+  const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+  return new TemporalCalendar('iso8601');
+}
+
+// TODO: should (can?) we make this generic so the field names are checked
+// against the type that the calendar is a property of?
+export function CalendarFields<F extends Iterable<string>>(calendar: Temporal.CalendarProtocol, fieldNamesParam: F) {
+  let fieldNames = fieldNamesParam;
+  if (calendar.fields) {
+    fieldNames = calendar.fields(fieldNames) as F;
+  }
+  const result: string[] = [];
+  for (const name of fieldNames) {
+    if (typeof name !== 'string') throw new TypeError('bad return from calendar.fields()');
+    ArrayPrototypePush.call(result, name);
+  }
+  return result as unknown as F;
+}
+
+export function CalendarMergeFields(
+  calendar: Temporal.CalendarProtocol,
+  fields: Record<string, unknown>,
+  additionalFields: Record<string, unknown>
+) {
+  const calMergeFields = calendar.mergeFields;
+  if (!calMergeFields) {
+    return { ...fields, ...additionalFields };
+  }
+  const result = Reflect.apply(calMergeFields, calendar, [fields, additionalFields]);
+  if (!IsObject(result)) throw new TypeError('bad return from calendar.mergeFields()');
+  return result;
+}
+
+export function CalendarDateAdd(
+  calendar: Temporal.CalendarProtocol,
+  date: CalendarProtocolParams['dateAdd'][0],
+  duration: CalendarProtocolParams['dateAdd'][1],
+  options: CalendarProtocolParams['dateAdd'][2],
+  dateAddParam?: Temporal.CalendarProtocol['dateAdd']
+) {
+  let dateAdd = dateAddParam;
+  if (dateAdd === undefined) {
+    dateAdd = calendar.dateAdd;
+  }
+  const result = ReflectApply(dateAdd, calendar, [date, duration, options]);
+  if (!IsTemporalDate(result)) throw new TypeError('invalid result');
+  return result;
+}
+
+function CalendarDateUntil(
+  calendar: Temporal.CalendarProtocol,
+  date: CalendarProtocolParams['dateUntil'][0],
+  otherDate: CalendarProtocolParams['dateUntil'][1],
+  options: CalendarProtocolParams['dateUntil'][2],
+  dateUntilParam?: Temporal.CalendarProtocol['dateUntil']
+) {
+  let dateUntil = dateUntilParam;
+  if (dateUntil === undefined) {
+    dateUntil = calendar.dateUntil;
+  }
+  const result = ReflectApply(dateUntil, calendar, [date, otherDate, options]);
+  if (!IsTemporalDuration(result)) throw new TypeError('invalid result');
+  return result;
+}
+
+export function CalendarYear(calendar: Temporal.CalendarProtocol, dateLike: CalendarProtocolParams['year'][0]) {
+  const result = calendar.year(dateLike);
+  if (result === undefined) {
+    throw new RangeError('calendar year result must be an integer');
+  }
+  return ToIntegerThrowOnInfinity(result);
+}
+
+export function CalendarMonth(calendar: Temporal.CalendarProtocol, dateLike: CalendarProtocolParams['month'][0]) {
+  const result = calendar.month(dateLike);
+  if (result === undefined) {
+    throw new RangeError('calendar month result must be a positive integer');
+  }
+  return ToPositiveInteger(result);
+}
+
+export function CalendarMonthCode(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['monthCode'][0]
+) {
+  const result = calendar.monthCode(dateLike);
+  if (result === undefined) {
+    throw new RangeError('calendar monthCode result must be a string');
+  }
+  return ToString(result);
+}
+
+export function CalendarDay(calendar: Temporal.CalendarProtocol, dateLike: CalendarProtocolParams['day'][0]) {
+  const result = calendar.day(dateLike);
+  if (result === undefined) {
+    throw new RangeError('calendar day result must be a positive integer');
+  }
+  return ToPositiveInteger(result);
+}
+
+export function CalendarEra(calendar: Temporal.CalendarProtocol, dateLike: CalendarProtocolParams['era'][0]) {
+  let result = calendar.era(dateLike);
+  if (result !== undefined) {
+    result = ToString(result);
+  }
+  return result;
+}
+
+export function CalendarEraYear(calendar: Temporal.CalendarProtocol, dateLike: CalendarProtocolParams['eraYear'][0]) {
+  let result = calendar.eraYear(dateLike);
+  if (result !== undefined) {
+    result = ToIntegerThrowOnInfinity(result);
+  }
+  return result;
+}
+
+export function CalendarDayOfWeek(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['dayOfWeek'][0]
+) {
+  return calendar.dayOfWeek(dateLike);
+}
+
+export function CalendarDayOfYear(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['dayOfYear'][0]
+) {
+  return calendar.dayOfYear(dateLike);
+}
+
+export function CalendarWeekOfYear(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['weekOfYear'][0]
+) {
+  return calendar.weekOfYear(dateLike);
+}
+
+export function CalendarDaysInWeek(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['daysInWeek'][0]
+) {
+  return calendar.daysInWeek(dateLike);
+}
+
+export function CalendarDaysInMonth(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['daysInMonth'][0]
+) {
+  return calendar.daysInMonth(dateLike);
+}
+
+export function CalendarDaysInYear(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['daysInYear'][0]
+) {
+  return calendar.daysInYear(dateLike);
+}
+
+export function CalendarMonthsInYear(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['monthsInYear'][0]
+) {
+  return calendar.monthsInYear(dateLike);
+}
+
+export function CalendarInLeapYear(
+  calendar: Temporal.CalendarProtocol,
+  dateLike: CalendarProtocolParams['inLeapYear'][0]
+) {
+  return calendar.inLeapYear(dateLike);
+}
+
+export function ToTemporalCalendar(calendarLikeParam: CalendarParams['from'][0]) {
+  let calendarLike = calendarLikeParam;
+  if (IsObject(calendarLike)) {
+    if (HasSlot(calendarLike, CALENDAR)) return GetSlot(calendarLike, CALENDAR);
+    if (!('calendar' in calendarLike)) return calendarLike;
+    calendarLike = (calendarLike as { calendar: Temporal.CalendarProtocol | string }).calendar;
+    if (IsObject(calendarLike) && !('calendar' in calendarLike)) return calendarLike;
+  }
+  const identifier = ToString(calendarLike);
+  const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+  if (IsBuiltinCalendar(identifier)) return new TemporalCalendar(identifier);
+  let calendar;
+  try {
+    ({ calendar } = ParseISODateTime(identifier));
+  } catch {
+    throw new RangeError(`Invalid calendar: ${identifier}`);
+  }
+  if (!calendar) calendar = 'iso8601';
+  return new TemporalCalendar(calendar);
+}
+
+function GetTemporalCalendarWithISODefault(
+  item: Temporal.CalendarProtocol | { calendar?: Temporal.PlainDateLike['calendar'] }
+): Temporal.Calendar | Temporal.CalendarProtocol {
+  if (HasSlot(item, CALENDAR)) return GetSlot(item, CALENDAR);
+  const { calendar } = item as Exclude<typeof item, Temporal.CalendarProtocol>;
+  if (calendar === undefined) return GetISO8601Calendar();
+  return ToTemporalCalendar(calendar);
+}
+
+export function CalendarEquals(one: Temporal.CalendarProtocol, two: Temporal.CalendarProtocol) {
+  if (one === two) return true;
+  const cal1 = ToString(one);
+  const cal2 = ToString(two);
+  return cal1 === cal2;
+}
+
+export function ConsolidateCalendars(one: Temporal.CalendarProtocol, two: Temporal.CalendarProtocol) {
+  if (one === two) return two;
+  const sOne = ToString(one);
+  const sTwo = ToString(two);
+  if (sOne === sTwo || sOne === 'iso8601') {
+    return two;
+  } else if (sTwo === 'iso8601') {
+    return one;
+  } else {
+    throw new RangeError('irreconcilable calendars');
+  }
+}
+
+export function CalendarDateFromFields(
+  calendar: Temporal.CalendarProtocol,
+  fields: CalendarProtocolParams['dateFromFields'][0],
+  options?: Partial<CalendarProtocolParams['dateFromFields'][1]>
+) {
+  const result = calendar.dateFromFields(fields, options);
+  if (!IsTemporalDate(result)) throw new TypeError('invalid result');
+  return result;
+}
+
+export function CalendarYearMonthFromFields(
+  calendar: Temporal.CalendarProtocol,
+  fields: CalendarProtocolParams['yearMonthFromFields'][0],
+  options?: CalendarProtocolParams['yearMonthFromFields'][1]
+) {
+  const result = calendar.yearMonthFromFields(fields, options);
+  if (!IsTemporalYearMonth(result)) throw new TypeError('invalid result');
+  return result;
+}
+
+export function CalendarMonthDayFromFields(
+  calendar: Temporal.CalendarProtocol,
+  fields: CalendarProtocolParams['monthDayFromFields'][0],
+  options?: CalendarProtocolParams['monthDayFromFields'][1]
+) {
+  const result = calendar.monthDayFromFields(fields, options);
+  if (!IsTemporalMonthDay(result)) throw new TypeError('invalid result');
+  return result;
+}
+
+export function ToTemporalTimeZone(temporalTimeZoneLikeParam: TimeZoneParams['from'][0]) {
+  let temporalTimeZoneLike = temporalTimeZoneLikeParam;
+  if (IsObject(temporalTimeZoneLike)) {
+    if (IsTemporalZonedDateTime(temporalTimeZoneLike)) return GetSlot(temporalTimeZoneLike, TIME_ZONE);
+    if (!('timeZone' in temporalTimeZoneLike)) return temporalTimeZoneLike;
+    temporalTimeZoneLike = (temporalTimeZoneLike as { timeZone: Temporal.TimeZoneProtocol | string }).timeZone;
+    if (IsObject(temporalTimeZoneLike) && !('timeZone' in temporalTimeZoneLike)) {
+      return temporalTimeZoneLike;
+    }
+  }
+  const identifier = ToString(temporalTimeZoneLike);
+  const timeZone = ParseTemporalTimeZone(identifier);
+  const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+  return new TemporalTimeZone(timeZone);
+}
+
+export function TimeZoneEquals(one: Temporal.TimeZoneProtocol, two: Temporal.TimeZoneProtocol) {
+  if (one === two) return true;
+  const tz1 = ToString(one);
+  const tz2 = ToString(two);
+  return tz1 === tz2;
+}
+
+export function TemporalDateTimeToDate(dateTime: Temporal.PlainDateTime) {
+  return CreateTemporalDate(
+    GetSlot(dateTime, ISO_YEAR),
+    GetSlot(dateTime, ISO_MONTH),
+    GetSlot(dateTime, ISO_DAY),
+    GetSlot(dateTime, CALENDAR)
+  );
+}
+
+export function TemporalDateTimeToTime(dateTime: Temporal.PlainDateTime) {
+  const Time = GetIntrinsic('%Temporal.PlainTime%');
+  return new Time(
+    GetSlot(dateTime, ISO_HOUR),
+    GetSlot(dateTime, ISO_MINUTE),
+    GetSlot(dateTime, ISO_SECOND),
+    GetSlot(dateTime, ISO_MILLISECOND),
+    GetSlot(dateTime, ISO_MICROSECOND),
+    GetSlot(dateTime, ISO_NANOSECOND)
+  );
+}
+
+export function GetOffsetNanosecondsFor(
+  timeZone: Temporal.TimeZoneProtocol,
+  instant: TimeZoneProtocolParams['getOffsetNanosecondsFor'][0]
+) {
+  let getOffsetNanosecondsFor = timeZone.getOffsetNanosecondsFor;
+  if (typeof getOffsetNanosecondsFor !== 'function') {
+    throw new TypeError('getOffsetNanosecondsFor not callable');
+  }
+  const offsetNs = Reflect.apply(getOffsetNanosecondsFor, timeZone, [instant]);
+  if (typeof offsetNs !== 'number') {
+    throw new TypeError('bad return from getOffsetNanosecondsFor');
+  }
+  if (!IsInteger(offsetNs) || MathAbs(offsetNs) > 86400e9) {
+    throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
+  }
+  return offsetNs;
+}
+
+export function BuiltinTimeZoneGetOffsetStringFor(timeZone: Temporal.TimeZoneProtocol, instant: Temporal.Instant) {
+  const offsetNs = GetOffsetNanosecondsFor(timeZone, instant);
+  return FormatTimeZoneOffsetString(offsetNs);
+}
+
+export function BuiltinTimeZoneGetPlainDateTimeFor(
+  timeZone: Temporal.TimeZoneProtocol,
+  instant: Temporal.Instant,
+  calendar: Temporal.CalendarProtocol
+) {
+  const ns = GetSlot(instant, EPOCHNANOSECONDS);
+  const offsetNs = GetOffsetNanosecondsFor(timeZone, instant);
+  let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = GetISOPartsFromEpoch(ns);
+  ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceISODateTime(
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond + offsetNs
+  ));
+  return CreateTemporalDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+}
+
+export function BuiltinTimeZoneGetInstantFor(
+  timeZone: Temporal.TimeZoneProtocol,
+  dateTime: Temporal.PlainDateTime,
+  disambiguation: NonNullable<Temporal.ToInstantOptions['disambiguation']>
+) {
+  const possibleInstants = GetPossibleInstantsFor(timeZone, dateTime);
+  return DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation);
+}
+
+function DisambiguatePossibleInstants(
+  possibleInstants: Temporal.Instant[],
+  timeZone: Temporal.TimeZoneProtocol,
+  dateTime: Temporal.PlainDateTime,
+  disambiguation: NonNullable<Temporal.ToInstantOptions['disambiguation']>
+) {
+  const Instant = GetIntrinsic('%Temporal.Instant%');
+  const numInstants = possibleInstants.length;
+
+  if (numInstants === 1) return possibleInstants[0];
+  if (numInstants) {
+    switch (disambiguation) {
+      case 'compatible':
+      // fall through because 'compatible' means 'earlier' for "fall back" transitions
+      case 'earlier':
+        return possibleInstants[0];
+      case 'later':
+        return possibleInstants[numInstants - 1];
+      case 'reject': {
+        throw new RangeError('multiple instants found');
+      }
+    }
+  }
+
+  const year = GetSlot(dateTime, ISO_YEAR);
+  const month = GetSlot(dateTime, ISO_MONTH);
+  const day = GetSlot(dateTime, ISO_DAY);
+  const hour = GetSlot(dateTime, ISO_HOUR);
+  const minute = GetSlot(dateTime, ISO_MINUTE);
+  const second = GetSlot(dateTime, ISO_SECOND);
+  const millisecond = GetSlot(dateTime, ISO_MILLISECOND);
+  const microsecond = GetSlot(dateTime, ISO_MICROSECOND);
+  const nanosecond = GetSlot(dateTime, ISO_NANOSECOND);
+  const utcns = GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  if (utcns === null) throw new RangeError('DateTime outside of supported range');
+  const dayBefore = new Instant(JSBI.subtract(utcns, DAY_NANOS));
+  const dayAfter = new Instant(JSBI.add(utcns, DAY_NANOS));
+  const offsetBefore = GetOffsetNanosecondsFor(timeZone, dayBefore);
+  const offsetAfter = GetOffsetNanosecondsFor(timeZone, dayAfter);
+  const nanoseconds = offsetAfter - offsetBefore;
+  switch (disambiguation) {
+    case 'earlier': {
+      const calendar = GetSlot(dateTime, CALENDAR);
+      const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+      const earlier = AddDateTime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond,
+        calendar,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -nanoseconds,
+        undefined
+      );
+      const earlierPlainDateTime = new PlainDateTime(
+        earlier.year,
+        earlier.month,
+        earlier.day,
+        earlier.hour,
+        earlier.minute,
+        earlier.second,
+        earlier.millisecond,
+        earlier.microsecond,
+        earlier.nanosecond,
+        calendar
+      );
+      return GetPossibleInstantsFor(timeZone, earlierPlainDateTime)[0];
+    }
+    case 'compatible':
+    // fall through because 'compatible' means 'later' for "spring forward" transitions
+    case 'later': {
+      const calendar = GetSlot(dateTime, CALENDAR);
+      const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+      const later = AddDateTime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond,
+        calendar,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        nanoseconds,
+        undefined
+      );
+      const laterPlainDateTime = new PlainDateTime(
+        later.year,
+        later.month,
+        later.day,
+        later.hour,
+        later.minute,
+        later.second,
+        later.millisecond,
+        later.microsecond,
+        later.nanosecond,
+        calendar
+      );
+      const possible = GetPossibleInstantsFor(timeZone, laterPlainDateTime);
+      return possible[possible.length - 1];
+    }
+    case 'reject': {
+      throw new RangeError('no such instant found');
+    }
+  }
+}
+
+function GetPossibleInstantsFor(
+  timeZone: Temporal.TimeZoneProtocol,
+  dateTime: TimeZoneProtocolParams['getPossibleInstantsFor'][0]
+) {
+  const possibleInstants = timeZone.getPossibleInstantsFor(dateTime);
+  const result: Temporal.Instant[] = [];
+  for (const instant of possibleInstants) {
+    if (!IsTemporalInstant(instant)) {
+      throw new TypeError('bad return from getPossibleInstantsFor');
+    }
+    ArrayPrototypePush.call(result, instant);
+  }
+  return result;
+}
+
+export function ISOYearString(year: number) {
+  let yearString;
+  if (year < 0 || year > 9999) {
+    const sign = year < 0 ? '-' : '+';
+    const yearNumber = MathAbs(year);
+    yearString = sign + `000000${yearNumber}`.slice(-6);
+  } else {
+    yearString = `0000${year}`.slice(-4);
+  }
+  return yearString;
+}
+
+export function ISODateTimePartString(part: number) {
+  return `00${part}`.slice(-2);
+}
+export function FormatSecondsStringPart(
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number,
+  precision: ReturnType<typeof ToSecondsStringPrecision>['precision']
+) {
+  if (precision === 'minute') return '';
+
+  const secs = `:${ISODateTimePartString(second)}`;
+  let fractionNumber = millisecond * 1e6 + microsecond * 1e3 + nanosecond;
+  let fraction: string;
+
+  if (precision === 'auto') {
+    if (fractionNumber === 0) return secs;
+    fraction = `${fractionNumber}`.padStart(9, '0');
+    while (fraction[fraction.length - 1] === '0') fraction = fraction.slice(0, -1);
+  } else {
+    if (precision === 0) return secs;
+    fraction = `${fractionNumber}`.padStart(9, '0').slice(0, precision);
+  }
+  return `${secs}.${fraction}`;
+}
+
+export function TemporalInstantToString(
+  instant: Temporal.Instant,
+  timeZone: Temporal.TimeZoneProtocol | undefined,
+  precision: ReturnType<typeof ToSecondsStringPrecision>['precision']
+) {
+  let outputTimeZone = timeZone;
+  if (outputTimeZone === undefined) {
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    outputTimeZone = new TemporalTimeZone('UTC');
+  }
+  const iso = GetISO8601Calendar();
+  const dateTime = BuiltinTimeZoneGetPlainDateTimeFor(outputTimeZone, instant, iso);
+  const year = ISOYearString(GetSlot(dateTime, ISO_YEAR));
+  const month = ISODateTimePartString(GetSlot(dateTime, ISO_MONTH));
+  const day = ISODateTimePartString(GetSlot(dateTime, ISO_DAY));
+  const hour = ISODateTimePartString(GetSlot(dateTime, ISO_HOUR));
+  const minute = ISODateTimePartString(GetSlot(dateTime, ISO_MINUTE));
+  const seconds = FormatSecondsStringPart(
+    GetSlot(dateTime, ISO_SECOND),
+    GetSlot(dateTime, ISO_MILLISECOND),
+    GetSlot(dateTime, ISO_MICROSECOND),
+    GetSlot(dateTime, ISO_NANOSECOND),
+    precision
+  );
+  let timeZoneString = 'Z';
+  if (timeZone !== undefined) {
+    const offsetNs = GetOffsetNanosecondsFor(outputTimeZone, instant);
+    timeZoneString = FormatISOTimeZoneOffsetString(offsetNs);
+  }
+  return `${year}-${month}-${day}T${hour}:${minute}${seconds}${timeZoneString}`;
+}
+
+interface ToStringOptions {
+  unit: ReturnType<typeof ToSecondsStringPrecision>['unit'];
+  increment: number;
+  roundingMode: ReturnType<typeof ToTemporalRoundingMode>;
+}
+
+export function TemporalDurationToString(
+  duration: Temporal.Duration,
+  precision: Temporal.ToStringPrecisionOptions['fractionalSecondDigits'] = 'auto',
+  options: ToStringOptions | undefined = undefined
+) {
+  function formatNumber(num: number) {
+    if (num <= NumberMaxSafeInteger) return num.toString(10);
+    return JSBI.BigInt(num).toString(10);
+  }
+
+  const years = GetSlot(duration, YEARS);
+  const months = GetSlot(duration, MONTHS);
+  const weeks = GetSlot(duration, WEEKS);
+  const days = GetSlot(duration, DAYS);
+  const hours = GetSlot(duration, HOURS);
+  const minutes = GetSlot(duration, MINUTES);
+  let seconds = GetSlot(duration, SECONDS);
+  let ms = GetSlot(duration, MILLISECONDS);
+  let µs = GetSlot(duration, MICROSECONDS);
+  let ns = GetSlot(duration, NANOSECONDS);
+  const sign = DurationSign(years, months, weeks, days, hours, minutes, seconds, ms, µs, ns);
+
+  if (options) {
+    const { unit, increment, roundingMode } = options;
+    ({
+      seconds,
+      milliseconds: ms,
+      microseconds: µs,
+      nanoseconds: ns
+    } = RoundDuration(0, 0, 0, 0, 0, 0, seconds, ms, µs, ns, increment, unit, roundingMode));
+  }
+
+  const dateParts = [];
+  if (years) dateParts.push(`${formatNumber(MathAbs(years))}Y`);
+  if (months) dateParts.push(`${formatNumber(MathAbs(months))}M`);
+  if (weeks) dateParts.push(`${formatNumber(MathAbs(weeks))}W`);
+  if (days) dateParts.push(`${formatNumber(MathAbs(days))}D`);
+
+  const timeParts = [];
+  if (hours) timeParts.push(`${formatNumber(MathAbs(hours))}H`);
+  if (minutes) timeParts.push(`${formatNumber(MathAbs(minutes))}M`);
+
+  const secondParts = [];
+  let total = TotalDurationNanoseconds(0, 0, 0, seconds, ms, µs, ns, 0);
+  let nsBigInt: JSBI, µsBigInt: JSBI, msBigInt: JSBI, secondsBigInt: JSBI;
+  ({ quotient: total, remainder: nsBigInt } = divmod(total, THOUSAND));
+  ({ quotient: total, remainder: µsBigInt } = divmod(total, THOUSAND));
+  ({ quotient: secondsBigInt, remainder: msBigInt } = divmod(total, THOUSAND));
+  const fraction =
+    MathAbs(JSBI.toNumber(msBigInt)) * 1e6 + MathAbs(JSBI.toNumber(µsBigInt)) * 1e3 + MathAbs(JSBI.toNumber(nsBigInt));
+  let decimalPart;
+  if (precision === 'auto') {
+    if (fraction !== 0) {
+      decimalPart = `${fraction}`.padStart(9, '0');
+      while (decimalPart[decimalPart.length - 1] === '0') {
+        decimalPart = decimalPart.slice(0, -1);
+      }
+    }
+  } else if (precision !== 0) {
+    decimalPart = `${fraction}`.padStart(9, '0').slice(0, precision);
+  }
+  if (decimalPart) secondParts.unshift('.', decimalPart);
+  if (!JSBI.equal(secondsBigInt, ZERO) || secondParts.length || precision !== 'auto') {
+    secondParts.unshift(abs(secondsBigInt).toString());
+  }
+  if (secondParts.length) timeParts.push(`${secondParts.join('')}S`);
+  if (timeParts.length) timeParts.unshift('T');
+  if (!dateParts.length && !timeParts.length) return 'PT0S';
+  return `${sign < 0 ? '-' : ''}P${dateParts.join('')}${timeParts.join('')}`;
+}
+
+export function TemporalDateToString(
+  date: Temporal.PlainDate,
+  showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
+) {
+  const year = ISOYearString(GetSlot(date, ISO_YEAR));
+  const month = ISODateTimePartString(GetSlot(date, ISO_MONTH));
+  const day = ISODateTimePartString(GetSlot(date, ISO_DAY));
+  const calendarID = ToString(GetSlot(date, CALENDAR));
+  const calendar = FormatCalendarAnnotation(calendarID, showCalendar);
+  return `${year}-${month}-${day}${calendar}`;
+}
+
+export function TemporalDateTimeToString(
+  dateTime: Temporal.PlainDateTime,
+  precision: ReturnType<typeof ToSecondsStringPrecision>['precision'],
+  showCalendar: ReturnType<typeof ToShowCalendarOption> = 'auto',
+  options: ToStringOptions | undefined = undefined
+) {
+  let year = GetSlot(dateTime, ISO_YEAR);
+  let month = GetSlot(dateTime, ISO_MONTH);
+  let day = GetSlot(dateTime, ISO_DAY);
+  let hour = GetSlot(dateTime, ISO_HOUR);
+  let minute = GetSlot(dateTime, ISO_MINUTE);
+  let second = GetSlot(dateTime, ISO_SECOND);
+  let millisecond = GetSlot(dateTime, ISO_MILLISECOND);
+  let microsecond = GetSlot(dateTime, ISO_MICROSECOND);
+  let nanosecond = GetSlot(dateTime, ISO_NANOSECOND);
+
+  if (options) {
+    const { unit, increment, roundingMode } = options;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = RoundISODateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      increment,
+      unit,
+      roundingMode
+    ));
+  }
+
+  const yearString = ISOYearString(year);
+  const monthString = ISODateTimePartString(month);
+  const dayString = ISODateTimePartString(day);
+  const hourString = ISODateTimePartString(hour);
+  const minuteString = ISODateTimePartString(minute);
+  const secondsString = FormatSecondsStringPart(second, millisecond, microsecond, nanosecond, precision);
+  const calendarID = ToString(GetSlot(dateTime, CALENDAR));
+  const calendar = FormatCalendarAnnotation(calendarID, showCalendar);
+  return `${yearString}-${monthString}-${dayString}T${hourString}:${minuteString}${secondsString}${calendar}`;
+}
+
+export function TemporalMonthDayToString(
+  monthDay: Temporal.PlainMonthDay,
+  showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
+) {
+  const month = ISODateTimePartString(GetSlot(monthDay, ISO_MONTH));
+  const day = ISODateTimePartString(GetSlot(monthDay, ISO_DAY));
+  let resultString = `${month}-${day}`;
+  const calendar = GetSlot(monthDay, CALENDAR);
+  const calendarID = ToString(calendar);
+  if (showCalendar === 'always' || calendarID !== 'iso8601') {
+    const year = ISOYearString(GetSlot(monthDay, ISO_YEAR));
+    resultString = `${year}-${resultString}`;
+  }
+  const calendarString = FormatCalendarAnnotation(calendarID, showCalendar);
+  if (calendarString) resultString += calendarString;
+  return resultString;
+}
+
+export function TemporalYearMonthToString(
+  yearMonth: Temporal.PlainYearMonth,
+  showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
+) {
+  const year = ISOYearString(GetSlot(yearMonth, ISO_YEAR));
+  const month = ISODateTimePartString(GetSlot(yearMonth, ISO_MONTH));
+  let resultString = `${year}-${month}`;
+  const calendar = GetSlot(yearMonth, CALENDAR);
+  const calendarID = ToString(calendar);
+  if (showCalendar === 'always' || calendarID !== 'iso8601') {
+    const day = ISODateTimePartString(GetSlot(yearMonth, ISO_DAY));
+    resultString += `-${day}`;
+  }
+  const calendarString = FormatCalendarAnnotation(calendarID, showCalendar);
+  if (calendarString) resultString += calendarString;
+  return resultString;
+}
+
+export function TemporalZonedDateTimeToString(
+  zdt: Temporal.ZonedDateTime,
+  precision: ReturnType<typeof ToSecondsStringPrecision>['precision'],
+  showCalendar: ReturnType<typeof ToShowCalendarOption> = 'auto',
+  showTimeZone: ReturnType<typeof ToShowTimeZoneNameOption> = 'auto',
+  showOffset: ReturnType<typeof ToShowOffsetOption> = 'auto',
+  options: ToStringOptions | undefined = undefined
+) {
+  let instant = GetSlot(zdt, INSTANT);
+
+  if (options) {
+    const { unit, increment, roundingMode } = options;
+    const ns = RoundInstant(GetSlot(zdt, EPOCHNANOSECONDS), increment, unit, roundingMode);
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    instant = new TemporalInstant(ns);
+  }
+
+  const tz = GetSlot(zdt, TIME_ZONE);
+  const iso = GetISO8601Calendar();
+  const dateTime = BuiltinTimeZoneGetPlainDateTimeFor(tz, instant, iso);
+
+  const year = ISOYearString(GetSlot(dateTime, ISO_YEAR));
+  const month = ISODateTimePartString(GetSlot(dateTime, ISO_MONTH));
+  const day = ISODateTimePartString(GetSlot(dateTime, ISO_DAY));
+  const hour = ISODateTimePartString(GetSlot(dateTime, ISO_HOUR));
+  const minute = ISODateTimePartString(GetSlot(dateTime, ISO_MINUTE));
+  const seconds = FormatSecondsStringPart(
+    GetSlot(dateTime, ISO_SECOND),
+    GetSlot(dateTime, ISO_MILLISECOND),
+    GetSlot(dateTime, ISO_MICROSECOND),
+    GetSlot(dateTime, ISO_NANOSECOND),
+    precision
+  );
+  let result = `${year}-${month}-${day}T${hour}:${minute}${seconds}`;
+  if (showOffset !== 'never') {
+    const offsetNs = GetOffsetNanosecondsFor(tz, instant);
+    result += FormatISOTimeZoneOffsetString(offsetNs);
+  }
+  if (showTimeZone !== 'never') result += `[${tz}]`;
+  const calendarID = ToString(GetSlot(zdt, CALENDAR));
+  result += FormatCalendarAnnotation(calendarID, showCalendar);
+  return result;
+}
+
+export function TestTimeZoneOffsetString(string: string) {
+  return OFFSET.test(StringCtor(string));
+}
+
+export function ParseTimeZoneOffsetString(string: string): number {
+  const match = OFFSET.exec(StringCtor(string));
+  if (!match) {
+    throw new RangeError(`invalid time zone offset: ${string}`);
+  }
+  const sign = match[1] === '-' || match[1] === '\u2212' ? -1 : +1;
+  const hours = +match[2];
+  const minutes = +(match[3] || 0);
+  const seconds = +(match[4] || 0);
+  const nanoseconds = +((match[5] || 0) + '000000000').slice(0, 9);
+  return sign * (((hours * 60 + minutes) * 60 + seconds) * 1e9 + nanoseconds);
+}
+
+export function GetCanonicalTimeZoneIdentifier(timeZoneIdentifier: string): string {
+  if (TestTimeZoneOffsetString(timeZoneIdentifier)) {
+    const offsetNs = ParseTimeZoneOffsetString(timeZoneIdentifier);
+    return FormatTimeZoneOffsetString(offsetNs);
+  }
+  const formatter = getIntlDateTimeFormatEnUsForTimeZone(StringCtor(timeZoneIdentifier));
+  return formatter.resolvedOptions().timeZone;
+}
+
+export function GetIANATimeZoneOffsetNanoseconds(epochNanoseconds: JSBI, id: string) {
+  const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = GetIANATimeZoneDateTimeParts(
+    epochNanoseconds,
+    id
+  );
+  const utc = GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  if (utc === null) throw new RangeError('Date outside of supported range');
+  return JSBI.toNumber(JSBI.subtract(utc, epochNanoseconds));
+}
+
+function FormatTimeZoneOffsetString(offsetNanosecondsParam: number): string {
+  const sign = offsetNanosecondsParam < 0 ? '-' : '+';
+  const offsetNanoseconds = MathAbs(offsetNanosecondsParam);
+  const nanoseconds = offsetNanoseconds % 1e9;
+  const seconds = MathFloor(offsetNanoseconds / 1e9) % 60;
+  const minutes = MathFloor(offsetNanoseconds / 60e9) % 60;
+  const hours = MathFloor(offsetNanoseconds / 3600e9);
+
+  const hourString = ISODateTimePartString(hours);
+  const minuteString = ISODateTimePartString(minutes);
+  const secondString = ISODateTimePartString(seconds);
+  let post = '';
+  if (nanoseconds) {
+    let fraction = `${nanoseconds}`.padStart(9, '0');
+    while (fraction[fraction.length - 1] === '0') fraction = fraction.slice(0, -1);
+    post = `:${secondString}.${fraction}`;
+  } else if (seconds) {
+    post = `:${secondString}`;
+  }
+  return `${sign}${hourString}:${minuteString}${post}`;
+}
+
+function FormatISOTimeZoneOffsetString(offsetNanosecondsParam: number): string {
+  let offsetNanoseconds = JSBI.toNumber(
+    RoundNumberToIncrement(JSBI.BigInt(offsetNanosecondsParam), 60e9, 'halfExpand')
+  );
+  const sign = offsetNanoseconds < 0 ? '-' : '+';
+  offsetNanoseconds = MathAbs(offsetNanoseconds);
+  const minutes = (offsetNanoseconds / 60e9) % 60;
+  const hours = MathFloor(offsetNanoseconds / 3600e9);
+
+  const hourString = ISODateTimePartString(hours);
+  const minuteString = ISODateTimePartString(minutes);
+  return `${sign}${hourString}:${minuteString}`;
+}
+export function GetEpochFromISOParts(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number
+) {
+  // Note: Date.UTC() interprets one and two-digit years as being in the
+  // 20th century, so don't use it
+  const legacyDate = new Date();
+  legacyDate.setUTCHours(hour, minute, second, millisecond);
+  legacyDate.setUTCFullYear(year, month - 1, day);
+  const ms = legacyDate.getTime();
+  if (NumberIsNaN(ms)) return null;
+  let ns = JSBI.multiply(JSBI.BigInt(ms), MILLION);
+  ns = JSBI.add(ns, JSBI.multiply(JSBI.BigInt(microsecond), THOUSAND));
+  ns = JSBI.add(ns, JSBI.BigInt(nanosecond));
+  if (JSBI.lessThan(ns, NS_MIN) || JSBI.greaterThan(ns, NS_MAX)) return null;
+  return ns;
+}
+
+function GetISOPartsFromEpoch(epochNanoseconds: JSBI) {
+  const { quotient, remainder } = divmod(epochNanoseconds, MILLION);
+  let epochMilliseconds = JSBI.toNumber(quotient);
+  let nanos = JSBI.toNumber(remainder);
+  if (nanos < 0) {
+    nanos += 1e6;
+    epochMilliseconds -= 1;
+  }
+  const microsecond = MathFloor(nanos / 1e3) % 1e3;
+  const nanosecond = nanos % 1e3;
+
+  const item = new Date(epochMilliseconds);
+  const year = item.getUTCFullYear();
+  const month = item.getUTCMonth() + 1;
+  const day = item.getUTCDate();
+  const hour = item.getUTCHours();
+  const minute = item.getUTCMinutes();
+  const second = item.getUTCSeconds();
+  const millisecond = item.getUTCMilliseconds();
+
+  return { epochMilliseconds, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
+export function GetIANATimeZoneDateTimeParts(epochNanoseconds: JSBI, id: string) {
+  const { epochMilliseconds, millisecond, microsecond, nanosecond } = GetISOPartsFromEpoch(epochNanoseconds);
+  const { year, month, day, hour, minute, second } = GetFormatterParts(id, epochMilliseconds);
+  return BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+function maxJSBI(one: JSBI, two: JSBI) {
+  return JSBI.lessThan(one, two) ? two : one;
+}
+
+/**
+ * Our best guess at how far in advance new rules will be put into the TZDB for
+ * future offset transitions. We'll pick 10 years but can always revise it if
+ * we find that countries are being unusually proactive in their announcing
+ * of offset changes.
+ */
+function afterLatestPossibleTzdbRuleChange() {
+  return JSBI.add(SystemUTCEpochNanoSeconds(), ABOUT_TEN_YEARS_NANOS);
+}
+
+export function GetIANATimeZoneNextTransition(epochNanoseconds: JSBI, id: string): JSBI | null {
+  // Decide how far in the future after `epochNanoseconds` we'll look for an
+  // offset change. There are two cases:
+  // 1. If it's a past date (or a date in the near future) then it's possible
+  //    that the time zone may have newly added DST in the next few years. So
+  //    we'll have to look from the provided time until a few years after the
+  //    current system time. (Changes to DST policy are usually announced a few
+  //    years in the future.) Note that the first DST anywhere started in 1847,
+  //    so we'll start checks in 1847 instead of wasting cycles on years where
+  //    there will never be transitions.
+  // 2. If it's a future date beyond the next few years, then we'll just assume
+  //    that the latest DST policy in TZDB will still be in effect.  In this
+  //    case, we only need to look one year in the future to see if there are
+  //    any DST transitions.  We actually only need to look 9-10 months because
+  //    DST has two transitions per year, but we'll use a year just to be safe.
+  const oneYearLater = JSBI.add(epochNanoseconds, ABOUT_ONE_YEAR_NANOS);
+  const uppercap = maxJSBI(afterLatestPossibleTzdbRuleChange(), oneYearLater);
+  // The first transition (in any timezone) recorded in the TZDB was in 1847, so
+  // start there if an earlier date is supplied.
+  let leftNanos = maxJSBI(BEFORE_FIRST_OFFSET_TRANSITION, epochNanoseconds);
+  const leftOffsetNs = GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
+  let rightNanos = leftNanos;
+  let rightOffsetNs = leftOffsetNs;
+  while (leftOffsetNs === rightOffsetNs && JSBI.lessThan(JSBI.BigInt(leftNanos), uppercap)) {
+    rightNanos = JSBI.add(leftNanos, TWO_WEEKS_NANOS);
+    rightOffsetNs = GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
+    if (leftOffsetNs === rightOffsetNs) {
+      leftNanos = rightNanos;
+    }
+  }
+  if (leftOffsetNs === rightOffsetNs) return null;
+  const result = bisect(
+    (epochNs: JSBI) => GetIANATimeZoneOffsetNanoseconds(epochNs, id),
+    leftNanos,
+    rightNanos,
+    leftOffsetNs,
+    rightOffsetNs
+  );
+  return result;
+}
+
+export function GetIANATimeZonePreviousTransition(epochNanoseconds: JSBI, id: string): JSBI | null {
+  // If a time zone uses DST (at the time of `epochNanoseconds`), then we only
+  // have to look back one year to find a transition. But if it doesn't use DST,
+  // then we need to look all the way back to 1847 (the earliest rule in the
+  // TZDB) to see if it had other offset transitions in the past. Looping back
+  // from a far-future date to 1847 is very slow (minutes of 100% CPU!), and is
+  // also unnecessary because DST rules aren't put into the TZDB more than a few
+  // years in the future because the political changes in time zones happen with
+  // only a few years' warning. Therefore, if a far-future date is provided,
+  // then we'll run the check in two parts:
+  // 1. First, we'll look back for up to one year to see if the latest TZDB
+  //    rules have DST.
+  // 2. If not, then we'll "fast-reverse" back to a few years later than the
+  //    current system time, and then look back to 1847. This reduces the
+  //    worst-case loop from 273K years to 175 years, for a ~1500x improvement
+  //    in worst-case perf.
+  const afterLatestRule = afterLatestPossibleTzdbRuleChange();
+  const isFarFuture = JSBI.greaterThan(epochNanoseconds, afterLatestRule);
+  const lowercap = isFarFuture ? JSBI.subtract(epochNanoseconds, ABOUT_ONE_YEAR_NANOS) : BEFORE_FIRST_OFFSET_TRANSITION;
+  let rightNanos = JSBI.subtract(epochNanoseconds, ONE);
+  const rightOffsetNs = GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
+  let leftNanos = rightNanos;
+  let leftOffsetNs = rightOffsetNs;
+  while (rightOffsetNs === leftOffsetNs && JSBI.greaterThan(rightNanos, lowercap)) {
+    leftNanos = JSBI.subtract(rightNanos, TWO_WEEKS_NANOS);
+    leftOffsetNs = GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
+    if (rightOffsetNs === leftOffsetNs) {
+      rightNanos = leftNanos;
+    }
+  }
+  if (rightOffsetNs === leftOffsetNs) {
+    if (isFarFuture) {
+      // There was no DST after looking back one year, which means that the most
+      // recent TZDB rules don't have any recurring transitions. To check for
+      // transitions in older rules, back up to a few years after the current
+      // date and then look all the way back to 1847. Note that we move back one
+      // day from the latest possible rule so that when the recursion runs it
+      // won't consider the new time to be "far future" because the system clock
+      // has advanced in the meantime.
+      const newTimeToCheck = JSBI.subtract(afterLatestRule, DAY_NANOS);
+      return GetIANATimeZonePreviousTransition(newTimeToCheck, id);
+    }
+    return null;
+  }
+  const result = bisect(
+    (epochNs: JSBI) => GetIANATimeZoneOffsetNanoseconds(epochNs, id),
+    leftNanos,
+    rightNanos,
+    leftOffsetNs,
+    rightOffsetNs
+  );
+  return result;
+}
+
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
+export function parseFromEnUsFormat(datetime: string) {
+  const parts = datetime.split(/[^\w]+/);
+
+  if (parts.length !== 7) {
+    throw new RangeError(`expected 7 parts in "${datetime}`);
+  }
+
+  const month = +parts[0];
+  const day = +parts[1];
+  let year = +parts[2];
+  const era = parts[3].toUpperCase();
+  if (era === 'B' || era === 'BC') {
+    year = -year + 1;
+  } else if (era !== 'A' && era !== 'AD') {
+    throw new RangeError(`Unknown era ${era} in "${datetime}`);
+  }
+  let hour = +parts[4];
+  if (hour === 24) {
+    // bugs.chromium.org/p/chromium/issues/detail?id=1045791
+    hour = 0;
+  }
+  const minute = +parts[5];
+  const second = +parts[6];
+
+  if (
+    !NumberIsFinite(year) ||
+    !NumberIsFinite(month) ||
+    !NumberIsFinite(day) ||
+    !NumberIsFinite(hour) ||
+    !NumberIsFinite(minute) ||
+    !NumberIsFinite(second)
+  ) {
+    throw new RangeError(`Invalid number in "${datetime}`);
+  }
+
+  return { year, month, day, hour, minute, second };
+}
+
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
+export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
+  const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
+  // Using `format` instead of `formatToParts` for compatibility with older clients
+  const datetime = formatter.format(new Date(epochMilliseconds));
+  return parseFromEnUsFormat(datetime);
+}
+
+export function GetIANATimeZoneEpochValue(
+  id: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number
+) {
+  const ns = GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  if (ns === null) throw new RangeError('DateTime outside of supported range');
+  let nsEarlier = JSBI.subtract(ns, DAY_NANOS);
+  if (JSBI.lessThan(nsEarlier, NS_MIN)) nsEarlier = ns;
+  let nsLater = JSBI.add(ns, DAY_NANOS);
+  if (JSBI.greaterThan(nsLater, NS_MAX)) nsLater = ns;
+  const earliest = GetIANATimeZoneOffsetNanoseconds(nsEarlier, id);
+  const latest = GetIANATimeZoneOffsetNanoseconds(nsLater, id);
+  const found = earliest === latest ? [earliest] : [earliest, latest];
+  return found
+    .map((offsetNanoseconds) => {
+      const epochNanoseconds = JSBI.subtract(ns, JSBI.BigInt(offsetNanoseconds));
+      const parts = GetIANATimeZoneDateTimeParts(epochNanoseconds, id);
+      if (
+        year !== parts.year ||
+        month !== parts.month ||
+        day !== parts.day ||
+        hour !== parts.hour ||
+        minute !== parts.minute ||
+        second !== parts.second ||
+        millisecond !== parts.millisecond ||
+        microsecond !== parts.microsecond ||
+        nanosecond !== parts.nanosecond
+      ) {
+        return undefined;
+      }
+      return epochNanoseconds;
+    })
+    .filter((x) => x !== undefined) as JSBI[];
+}
+
+export function LeapYear(year: number) {
+  if (undefined === year) return false;
+  const isDiv4 = year % 4 === 0;
+  const isDiv100 = year % 100 === 0;
+  const isDiv400 = year % 400 === 0;
+  return isDiv4 && (!isDiv100 || isDiv400);
+}
+
+export function ISODaysInMonth(year: number, month: number) {
+  const DoM = {
+    standard: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    leapyear: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  };
+  return DoM[LeapYear(year) ? 'leapyear' : 'standard'][month - 1];
+}
+
+export function DayOfWeek(year: number, month: number, day: number) {
+  const m = month + (month < 3 ? 10 : -2);
+  const Y = year - (month < 3 ? 1 : 0);
+
+  const c = MathFloor(Y / 100);
+  const y = Y - c * 100;
+  const d = day;
+
+  const pD = d;
+  const pM = MathFloor(2.6 * m - 0.2);
+  const pY = y + MathFloor(y / 4);
+  const pC = MathFloor(c / 4) - 2 * c;
+
+  const dow = (pD + pM + pY + pC) % 7;
+
+  return dow + (dow <= 0 ? 7 : 0);
+}
+
+export function DayOfYear(year: number, month: number, day: number) {
+  let days = day;
+  for (let m = month - 1; m > 0; m--) {
+    days += ISODaysInMonth(year, m);
+  }
+  return days;
+}
+
+export function WeekOfYear(year: number, month: number, day: number) {
+  const doy = DayOfYear(year, month, day);
+  const dow = DayOfWeek(year, month, day) || 7;
+  const doj = DayOfWeek(year, 1, 1);
+
+  const week = MathFloor((doy - dow + 10) / 7);
+
+  if (week < 1) {
+    if (doj === 5 || (doj === 6 && LeapYear(year - 1))) {
+      return 53;
+    } else {
+      return 52;
+    }
+  }
+  if (week === 53) {
+    if ((LeapYear(year) ? 366 : 365) - doy < 4 - dow) {
+      return 1;
+    }
+  }
+
+  return week;
+}
+
+export function DurationSign(
+  y: number,
+  mon: number,
+  w: number,
+  d: number,
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  µs: number,
+  ns: number
+) {
+  for (const prop of [y, mon, w, d, h, min, s, ms, µs, ns]) {
+    if (prop !== 0) return prop < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function BalanceISOYearMonth(yearParam: number, monthParam: number) {
+  let year = yearParam;
+  let month = monthParam;
+  if (!NumberIsFinite(year) || !NumberIsFinite(month)) throw new RangeError('infinity is out of range');
+  month -= 1;
+  year += MathFloor(month / 12);
+  month %= 12;
+  if (month < 0) month += 12;
+  month += 1;
+  return { year, month };
+}
+
+function BalanceISODate(yearParam: number, monthParam: number, dayParam: number) {
+  let year = yearParam;
+  let month = monthParam;
+  let day = dayParam;
+  if (!NumberIsFinite(day)) throw new RangeError('infinity is out of range');
+  ({ year, month } = BalanceISOYearMonth(year, month));
+  let daysInYear = 0;
+  let testYear = month > 2 ? year : year - 1;
+  while (((daysInYear = LeapYear(testYear) ? 366 : 365), day < -daysInYear)) {
+    year -= 1;
+    testYear -= 1;
+    day += daysInYear;
+  }
+  testYear += 1;
+  while (((daysInYear = LeapYear(testYear) ? 366 : 365), day > daysInYear)) {
+    year += 1;
+    testYear += 1;
+    day -= daysInYear;
+  }
+
+  while (day < 1) {
+    ({ year, month } = BalanceISOYearMonth(year, month - 1));
+    day += ISODaysInMonth(year, month);
+  }
+  while (day > ISODaysInMonth(year, month)) {
+    day -= ISODaysInMonth(year, month);
+    ({ year, month } = BalanceISOYearMonth(year, month + 1));
+  }
+
+  return { year, month, day };
+}
+
+function BalanceISODateTime(
+  yearParam: number,
+  monthParam: number,
+  dayParam: number,
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number
+) {
+  const { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceTime(
+    hourParam,
+    minuteParam,
+    secondParam,
+    millisecondParam,
+    microsecondParam,
+    nanosecondParam
+  );
+  const { year, month, day } = BalanceISODate(yearParam, monthParam, dayParam + deltaDays);
+  return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+function BalanceTime(
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number
+) {
+  let hour = hourParam;
+  let minute = minuteParam;
+  let second = secondParam;
+  let millisecond = millisecondParam;
+  let microsecond = microsecondParam;
+  let nanosecond = nanosecondParam;
+  if (
+    !NumberIsFinite(hour) ||
+    !NumberIsFinite(minute) ||
+    !NumberIsFinite(second) ||
+    !NumberIsFinite(millisecond) ||
+    !NumberIsFinite(microsecond) ||
+    !NumberIsFinite(nanosecond)
+  ) {
+    throw new RangeError('infinity is out of range');
+  }
+
+  microsecond += MathFloor(nanosecond / 1000);
+  nanosecond = NonNegativeModulo(nanosecond, 1000);
+
+  millisecond += MathFloor(microsecond / 1000);
+  microsecond = NonNegativeModulo(microsecond, 1000);
+
+  second += MathFloor(millisecond / 1000);
+  millisecond = NonNegativeModulo(millisecond, 1000);
+
+  minute += MathFloor(second / 60);
+  second = NonNegativeModulo(second, 60);
+
+  hour += MathFloor(minute / 60);
+  minute = NonNegativeModulo(minute, 60);
+
+  const deltaDays = MathFloor(hour / 24);
+  hour = NonNegativeModulo(hour, 24);
+
+  return { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+export function TotalDurationNanoseconds(
+  daysParam: number,
+  hoursParam: number,
+  minutesParam: number,
+  secondsParam: number,
+  millisecondsParam: number,
+  microsecondsParam: number,
+  nanosecondsParam: number,
+  offsetShift: number
+) {
+  const days: JSBI = JSBI.BigInt(daysParam);
+  let nanoseconds: JSBI = JSBI.BigInt(nanosecondsParam);
+  if (daysParam !== 0) nanoseconds = JSBI.subtract(JSBI.BigInt(nanosecondsParam), JSBI.BigInt(offsetShift));
+  const hours = JSBI.add(JSBI.BigInt(hoursParam), JSBI.multiply(days, JSBI.BigInt(24)));
+  const minutes = JSBI.add(JSBI.BigInt(minutesParam), JSBI.multiply(hours, SIXTY));
+  const seconds = JSBI.add(JSBI.BigInt(secondsParam), JSBI.multiply(minutes, SIXTY));
+  const milliseconds = JSBI.add(JSBI.BigInt(millisecondsParam), JSBI.multiply(seconds, THOUSAND));
+  const microseconds = JSBI.add(JSBI.BigInt(microsecondsParam), JSBI.multiply(milliseconds, THOUSAND));
+  return JSBI.add(JSBI.BigInt(nanoseconds), JSBI.multiply(microseconds, THOUSAND));
+}
+
+function NanosecondsToDays(nanosecondsParam: JSBI, relativeTo: ReturnType<typeof ToRelativeTemporalObject>) {
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  const sign = MathSign(JSBI.toNumber(nanosecondsParam));
+  let nanoseconds = JSBI.BigInt(nanosecondsParam);
+  let dayLengthNs = 86400e9;
+  if (sign === 0) return { days: 0, nanoseconds: ZERO, dayLengthNs };
+  if (!IsTemporalZonedDateTime(relativeTo)) {
+    let days: JSBI;
+    ({ quotient: days, remainder: nanoseconds } = divmod(nanoseconds, JSBI.BigInt(dayLengthNs)));
+    return { days: JSBI.toNumber(days), nanoseconds, dayLengthNs };
+  }
+
+  const startNs = GetSlot(relativeTo, EPOCHNANOSECONDS);
+  const start = GetSlot(relativeTo, INSTANT);
+  const endNs = JSBI.add(startNs, nanoseconds);
+  const end = new TemporalInstant(endNs);
+  const timeZone = GetSlot(relativeTo, TIME_ZONE);
+  const calendar = GetSlot(relativeTo, CALENDAR);
+
+  // Find the difference in days only.
+  const dtStart = BuiltinTimeZoneGetPlainDateTimeFor(timeZone, start, calendar);
+  const dtEnd = BuiltinTimeZoneGetPlainDateTimeFor(timeZone, end, calendar);
+  let { days } = DifferenceISODateTime(
+    GetSlot(dtStart, ISO_YEAR),
+    GetSlot(dtStart, ISO_MONTH),
+    GetSlot(dtStart, ISO_DAY),
+    GetSlot(dtStart, ISO_HOUR),
+    GetSlot(dtStart, ISO_MINUTE),
+    GetSlot(dtStart, ISO_SECOND),
+    GetSlot(dtStart, ISO_MILLISECOND),
+    GetSlot(dtStart, ISO_MICROSECOND),
+    GetSlot(dtStart, ISO_NANOSECOND),
+    GetSlot(dtEnd, ISO_YEAR),
+    GetSlot(dtEnd, ISO_MONTH),
+    GetSlot(dtEnd, ISO_DAY),
+    GetSlot(dtEnd, ISO_HOUR),
+    GetSlot(dtEnd, ISO_MINUTE),
+    GetSlot(dtEnd, ISO_SECOND),
+    GetSlot(dtEnd, ISO_MILLISECOND),
+    GetSlot(dtEnd, ISO_MICROSECOND),
+    GetSlot(dtEnd, ISO_NANOSECOND),
+    calendar,
+    'day',
+    ObjectCreate(null)
+  );
+  let intermediateNs = AddZonedDateTime(start, timeZone, calendar, 0, 0, 0, days, 0, 0, 0, 0, 0, 0);
+  // may disambiguate
+
+  // If clock time after addition was in the middle of a skipped period, the
+  // endpoint was disambiguated to a later clock time. So it's possible that
+  // the resulting disambiguated result is later than endNs. If so, then back
+  // up one day and try again. Repeat if necessary (some transitions are
+  // > 24 hours) until either there's zero days left or the date duration is
+  // back inside the period where it belongs. Note that this case only can
+  // happen for positive durations because the only direction that
+  // `disambiguation: 'compatible'` can change clock time is forwards.
+  if (sign === 1) {
+    while (days > 0 && JSBI.greaterThan(intermediateNs, endNs)) {
+      --days;
+      intermediateNs = AddZonedDateTime(start, timeZone, calendar, 0, 0, 0, days, 0, 0, 0, 0, 0, 0);
+      // may do disambiguation
+    }
+  }
+  nanoseconds = JSBI.subtract(endNs, intermediateNs);
+
+  let isOverflow = false;
+  let relativeInstant = new TemporalInstant(intermediateNs);
+  do {
+    // calculate length of the next day (day that contains the time remainder)
+    const oneDayFartherNs = AddZonedDateTime(relativeInstant, timeZone, calendar, 0, 0, 0, sign, 0, 0, 0, 0, 0, 0);
+    const relativeNs = GetSlot(relativeInstant, EPOCHNANOSECONDS);
+    dayLengthNs = JSBI.toNumber(JSBI.subtract(oneDayFartherNs, relativeNs));
+    isOverflow = JSBI.greaterThan(
+      JSBI.multiply(JSBI.subtract(nanoseconds, JSBI.BigInt(dayLengthNs)), JSBI.BigInt(sign)),
+      ZERO
+    );
+    if (isOverflow) {
+      nanoseconds = JSBI.subtract(nanoseconds, JSBI.BigInt(dayLengthNs));
+      relativeInstant = new TemporalInstant(oneDayFartherNs);
+      days += sign;
+    }
+  } while (isOverflow);
+  return { days, nanoseconds, dayLengthNs: MathAbs(dayLengthNs) };
+}
+
+export function BalanceDuration(
+  daysParam: number,
+  hoursParam: number,
+  minutesParam: number,
+  secondsParam: number,
+  millisecondsParam: number,
+  microsecondsParam: number,
+  nanosecondsParam: number,
+  largestUnit: Temporal.DateTimeUnit,
+  relativeTo: ReturnType<typeof ToRelativeTemporalObject> = undefined
+) {
+  let days = daysParam;
+  let nanosecondsBigInt: JSBI,
+    microsecondsBigInt: JSBI,
+    millisecondsBigInt: JSBI,
+    secondsBigInt: JSBI,
+    minutesBigInt: JSBI,
+    hoursBigInt: JSBI;
+  if (IsTemporalZonedDateTime(relativeTo)) {
+    const endNs = AddZonedDateTime(
+      GetSlot(relativeTo, INSTANT),
+      GetSlot(relativeTo, TIME_ZONE),
+      GetSlot(relativeTo, CALENDAR),
+      0,
+      0,
+      0,
+      days,
+      hoursParam,
+      minutesParam,
+      secondsParam,
+      millisecondsParam,
+      microsecondsParam,
+      nanosecondsParam
+    );
+    const startNs = GetSlot(relativeTo, EPOCHNANOSECONDS);
+    nanosecondsBigInt = JSBI.subtract(endNs, startNs);
+  } else {
+    nanosecondsBigInt = TotalDurationNanoseconds(
+      days,
+      hoursParam,
+      minutesParam,
+      secondsParam,
+      millisecondsParam,
+      microsecondsParam,
+      nanosecondsParam,
+      0
+    );
+  }
+  if (largestUnit === 'year' || largestUnit === 'month' || largestUnit === 'week' || largestUnit === 'day') {
+    ({ days, nanoseconds: nanosecondsBigInt } = NanosecondsToDays(nanosecondsBigInt, relativeTo));
+  } else {
+    days = 0;
+  }
+
+  const sign = JSBI.lessThan(nanosecondsBigInt, ZERO) ? -1 : 1;
+  nanosecondsBigInt = abs(nanosecondsBigInt);
+  microsecondsBigInt = millisecondsBigInt = secondsBigInt = minutesBigInt = hoursBigInt = ZERO;
+
+  switch (largestUnit) {
+    case 'year':
+    case 'month':
+    case 'week':
+    case 'day':
+    case 'hour':
+      ({ quotient: microsecondsBigInt, remainder: nanosecondsBigInt } = divmod(nanosecondsBigInt, THOUSAND));
+      ({ quotient: millisecondsBigInt, remainder: microsecondsBigInt } = divmod(microsecondsBigInt, THOUSAND));
+      ({ quotient: secondsBigInt, remainder: millisecondsBigInt } = divmod(millisecondsBigInt, THOUSAND));
+      ({ quotient: minutesBigInt, remainder: secondsBigInt } = divmod(secondsBigInt, SIXTY));
+      ({ quotient: hoursBigInt, remainder: minutesBigInt } = divmod(minutesBigInt, SIXTY));
+      break;
+    case 'minute':
+      ({ quotient: microsecondsBigInt, remainder: nanosecondsBigInt } = divmod(nanosecondsBigInt, THOUSAND));
+      ({ quotient: millisecondsBigInt, remainder: microsecondsBigInt } = divmod(microsecondsBigInt, THOUSAND));
+      ({ quotient: secondsBigInt, remainder: millisecondsBigInt } = divmod(millisecondsBigInt, THOUSAND));
+      ({ quotient: minutesBigInt, remainder: secondsBigInt } = divmod(secondsBigInt, SIXTY));
+      break;
+    case 'second':
+      ({ quotient: microsecondsBigInt, remainder: nanosecondsBigInt } = divmod(nanosecondsBigInt, THOUSAND));
+      ({ quotient: millisecondsBigInt, remainder: microsecondsBigInt } = divmod(microsecondsBigInt, THOUSAND));
+      ({ quotient: secondsBigInt, remainder: millisecondsBigInt } = divmod(millisecondsBigInt, THOUSAND));
+      break;
+    case 'millisecond':
+      ({ quotient: microsecondsBigInt, remainder: nanosecondsBigInt } = divmod(nanosecondsBigInt, THOUSAND));
+      ({ quotient: millisecondsBigInt, remainder: microsecondsBigInt } = divmod(microsecondsBigInt, THOUSAND));
+      break;
+    case 'microsecond':
+      ({ quotient: microsecondsBigInt, remainder: nanosecondsBigInt } = divmod(nanosecondsBigInt, THOUSAND));
+      break;
+    case 'nanosecond':
+      break;
+    default:
+      throw new Error('assert not reached');
+  }
+
+  const hours = JSBI.toNumber(hoursBigInt) * sign;
+  const minutes = JSBI.toNumber(minutesBigInt) * sign;
+  const seconds = JSBI.toNumber(secondsBigInt) * sign;
+  const milliseconds = JSBI.toNumber(millisecondsBigInt) * sign;
+  const microseconds = JSBI.toNumber(microsecondsBigInt) * sign;
+  const nanoseconds = JSBI.toNumber(nanosecondsBigInt) * sign;
+
+  return { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+export function UnbalanceDurationRelative(
+  yearsParam: number,
+  monthsParam: number,
+  weeksParam: number,
+  daysParam: number,
+  largestUnit: Temporal.DateTimeUnit,
+  relativeToParam: ReturnType<typeof ToRelativeTemporalObject>
+) {
+  let years = yearsParam;
+  let months = monthsParam;
+  let weeks = weeksParam;
+  let days = daysParam;
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+
+  let calendar;
+  let relativeTo: Temporal.PlainDate | undefined;
+  if (relativeToParam) {
+    relativeTo = ToTemporalDate(relativeToParam);
+    calendar = GetSlot(relativeTo, CALENDAR);
+  }
+
+  const oneYear = new TemporalDuration(sign);
+  const oneMonth = new TemporalDuration(0, sign);
+  const oneWeek = new TemporalDuration(0, 0, sign);
+
+  switch (largestUnit) {
+    case 'year':
+      // no-op
+      break;
+    case 'month':
+      {
+        if (!calendar) throw new RangeError('a starting point is required for months balancing');
+        // balance years down to months
+        const dateAdd = calendar.dateAdd;
+        const dateUntil = calendar.dateUntil;
+        let relativeToDateOnly: Temporal.PlainDateLike = relativeTo as Temporal.PlainDateLike;
+        while (MathAbs(years) > 0) {
+          const newRelativeTo = CalendarDateAdd(calendar, relativeToDateOnly, oneYear, undefined, dateAdd);
+          const untilOptions = ObjectCreate(null);
+          untilOptions.largestUnit = 'month';
+          const untilResult = CalendarDateUntil(calendar, relativeToDateOnly, newRelativeTo, untilOptions, dateUntil);
+          const oneYearMonths = GetSlot(untilResult, MONTHS);
+          relativeToDateOnly = newRelativeTo;
+          months += oneYearMonths;
+          years -= sign;
+        }
+      }
+      break;
+    case 'week':
+      if (!calendar) throw new RangeError('a starting point is required for weeks balancing');
+      // balance years down to days
+      while (MathAbs(years) > 0) {
+        let oneYearDays;
+        ({ relativeTo, days: oneYearDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneYear));
+        days += oneYearDays;
+        years -= sign;
+      }
+
+      // balance months down to days
+      while (MathAbs(months) > 0) {
+        let oneMonthDays;
+        ({ relativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneMonth));
+        days += oneMonthDays;
+        months -= sign;
+      }
+      break;
+    default:
+      // balance years down to days
+      while (MathAbs(years) > 0) {
+        if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
+        let oneYearDays;
+        ({ relativeTo, days: oneYearDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneYear));
+        days += oneYearDays;
+        years -= sign;
+      }
+
+      // balance months down to days
+      while (MathAbs(months) > 0) {
+        if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
+        let oneMonthDays;
+        ({ relativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneMonth));
+        days += oneMonthDays;
+        months -= sign;
+      }
+
+      // balance weeks down to days
+      while (MathAbs(weeks) > 0) {
+        if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
+        let oneWeekDays;
+        ({ relativeTo, days: oneWeekDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneWeek));
+        days += oneWeekDays;
+        weeks -= sign;
+      }
+      break;
+  }
+
+  return { years, months, weeks, days };
+}
+
+export function BalanceDurationRelative(
+  yearsParam: number,
+  monthsParam: number,
+  weeksParam: number,
+  daysParam: number,
+  largestUnit: Temporal.DateTimeUnit,
+  relativeToParam: ReturnType<typeof ToRelativeTemporalObject>
+) {
+  let years = yearsParam;
+  let months = monthsParam;
+  let weeks = weeksParam;
+  let days = daysParam;
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  if (sign === 0) return { years, months, weeks, days };
+
+  let calendar;
+  let relativeTo: Temporal.PlainDate | undefined;
+  if (relativeToParam) {
+    relativeTo = ToTemporalDate(relativeToParam);
+    calendar = GetSlot(relativeTo, CALENDAR);
+  }
+
+  const oneYear = new TemporalDuration(sign);
+  const oneMonth = new TemporalDuration(0, sign);
+  const oneWeek = new TemporalDuration(0, 0, sign);
+
+  switch (largestUnit) {
+    case 'year': {
+      if (!calendar) throw new RangeError('a starting point is required for years balancing');
+      // balance days up to years
+      let newRelativeTo, oneYearDays;
+      ({ relativeTo: newRelativeTo, days: oneYearDays } = MoveRelativeDate(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        oneYear
+      ));
+      while (MathAbs(days) >= MathAbs(oneYearDays)) {
+        days -= oneYearDays;
+        years += sign;
+        relativeTo = newRelativeTo;
+        ({ relativeTo: newRelativeTo, days: oneYearDays } = MoveRelativeDate(calendar, relativeTo, oneYear));
+      }
+
+      // balance days up to months
+      let oneMonthDays;
+      ({ relativeTo: newRelativeTo, days: oneMonthDays } = MoveRelativeDate(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        oneMonth
+      ));
+      while (MathAbs(days) >= MathAbs(oneMonthDays)) {
+        days -= oneMonthDays;
+        months += sign;
+        relativeTo = newRelativeTo;
+        ({ relativeTo: newRelativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo, oneMonth));
+      }
+
+      // balance months up to years
+      const dateAdd = calendar.dateAdd;
+      newRelativeTo = CalendarDateAdd(calendar, relativeTo as Temporal.PlainDate, oneYear, undefined, dateAdd);
+      const dateUntil = calendar.dateUntil;
+      const untilOptions = ObjectCreate(null);
+      untilOptions.largestUnit = 'month';
+      let untilResult = CalendarDateUntil(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        newRelativeTo,
+        untilOptions,
+        dateUntil
+      );
+      let oneYearMonths = GetSlot(untilResult, MONTHS);
+      while (MathAbs(months) >= MathAbs(oneYearMonths)) {
+        months -= oneYearMonths;
+        years += sign;
+        relativeTo = newRelativeTo;
+        newRelativeTo = CalendarDateAdd(calendar, relativeTo, oneYear, undefined, dateAdd);
+        const untilOptions = ObjectCreate(null);
+        untilOptions.largestUnit = 'month';
+        untilResult = CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil);
+        oneYearMonths = GetSlot(untilResult, MONTHS);
+      }
+      break;
+    }
+    case 'month': {
+      if (!calendar) throw new RangeError('a starting point is required for months balancing');
+      // balance days up to months
+      let newRelativeTo, oneMonthDays;
+      ({ relativeTo: newRelativeTo, days: oneMonthDays } = MoveRelativeDate(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        oneMonth
+      ));
+      while (MathAbs(days) >= MathAbs(oneMonthDays)) {
+        days -= oneMonthDays;
+        months += sign;
+        relativeTo = newRelativeTo;
+        ({ relativeTo: newRelativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo, oneMonth));
+      }
+      break;
+    }
+    case 'week': {
+      if (!calendar) throw new RangeError('a starting point is required for weeks balancing');
+      // balance days up to weeks
+      let newRelativeTo, oneWeekDays;
+      ({ relativeTo: newRelativeTo, days: oneWeekDays } = MoveRelativeDate(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        oneWeek
+      ));
+      while (MathAbs(days) >= MathAbs(oneWeekDays)) {
+        days -= oneWeekDays;
+        weeks += sign;
+        relativeTo = newRelativeTo;
+        ({ relativeTo: newRelativeTo, days: oneWeekDays } = MoveRelativeDate(calendar, relativeTo, oneWeek));
+      }
+      break;
+    }
+    default:
+      // no-op
+      break;
+  }
+
+  return { years, months, weeks, days };
+}
+
+export function CalculateOffsetShift(
+  relativeTo: ReturnType<typeof ToRelativeTemporalObject>,
+  y: number,
+  mon: number,
+  w: number,
+  d: number
+) {
+  if (IsTemporalZonedDateTime(relativeTo)) {
+    const instant = GetSlot(relativeTo, INSTANT);
+    const timeZone = GetSlot(relativeTo, TIME_ZONE);
+    const calendar = GetSlot(relativeTo, CALENDAR);
+    const offsetBefore = GetOffsetNanosecondsFor(timeZone, instant);
+    const after = AddZonedDateTime(instant, timeZone, calendar, y, mon, w, d, 0, 0, 0, 0, 0, 0);
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    const instantAfter = new TemporalInstant(after);
+    const offsetAfter = GetOffsetNanosecondsFor(timeZone, instantAfter);
+    return offsetAfter - offsetBefore;
+  }
+  return 0;
+}
+
+export function CreateNegatedTemporalDuration(duration: Temporal.Duration) {
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  return new TemporalDuration(
+    -GetSlot(duration, YEARS),
+    -GetSlot(duration, MONTHS),
+    -GetSlot(duration, WEEKS),
+    -GetSlot(duration, DAYS),
+    -GetSlot(duration, HOURS),
+    -GetSlot(duration, MINUTES),
+    -GetSlot(duration, SECONDS),
+    -GetSlot(duration, MILLISECONDS),
+    -GetSlot(duration, MICROSECONDS),
+    -GetSlot(duration, NANOSECONDS)
+  );
+}
+
+export function ConstrainToRange(value: number | undefined, min: number, max: number) {
+  // Math.Max accepts undefined values and returns NaN. Undefined values are
+  // used for optional params in the method below.
+  return MathMin(max, MathMax(min, value as number));
+}
+function ConstrainISODate(year: number, monthParam: number, dayParam?: number) {
+  const month = ConstrainToRange(monthParam, 1, 12);
+  const day = ConstrainToRange(dayParam, 1, ISODaysInMonth(year, month));
+  return { year, month, day };
+}
+
+function ConstrainTime(
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number
+) {
+  const hour = ConstrainToRange(hourParam, 0, 23);
+  const minute = ConstrainToRange(minuteParam, 0, 59);
+  const second = ConstrainToRange(secondParam, 0, 59);
+  const millisecond = ConstrainToRange(millisecondParam, 0, 999);
+  const microsecond = ConstrainToRange(microsecondParam, 0, 999);
+  const nanosecond = ConstrainToRange(nanosecondParam, 0, 999);
+  return { hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+export function RejectToRange(value: number, min: number, max: number) {
+  if (value < min || value > max) throw new RangeError(`value out of range: ${min} <= ${value} <= ${max}`);
+}
+
+function RejectISODate(year: number, month: number, day: number) {
+  RejectToRange(month, 1, 12);
+  RejectToRange(day, 1, ISODaysInMonth(year, month));
+}
+
+function RejectDateRange(year: number, month: number, day: number) {
+  // Noon avoids trouble at edges of DateTime range (excludes midnight)
+  RejectDateTimeRange(year, month, day, 12, 0, 0, 0, 0, 0);
+}
+
+export function RejectTime(
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number
+) {
+  RejectToRange(hour, 0, 23);
+  RejectToRange(minute, 0, 59);
+  RejectToRange(second, 0, 59);
+  RejectToRange(millisecond, 0, 999);
+  RejectToRange(microsecond, 0, 999);
+  RejectToRange(nanosecond, 0, 999);
+}
+
+function RejectDateTime(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number
+) {
+  RejectISODate(year, month, day);
+  RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+function RejectDateTimeRange(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number
+) {
+  RejectToRange(year, YEAR_MIN, YEAR_MAX);
+  // Reject any DateTime 24 hours or more outside the Instant range
+  if (
+    (year === YEAR_MIN &&
+      null ==
+        GetEpochFromISOParts(year, month, day + 1, hour, minute, second, millisecond, microsecond, nanosecond - 1)) ||
+    (year === YEAR_MAX &&
+      null ==
+        GetEpochFromISOParts(year, month, day - 1, hour, minute, second, millisecond, microsecond, nanosecond + 1))
+  ) {
+    throw new RangeError('DateTime outside of supported range');
+  }
+}
+
+export function ValidateEpochNanoseconds(epochNanoseconds: JSBI) {
+  if (JSBI.lessThan(epochNanoseconds, NS_MIN) || JSBI.greaterThan(epochNanoseconds, NS_MAX)) {
+    throw new RangeError('Instant outside of supported range');
+  }
+}
+
+function RejectYearMonthRange(year: number, month: number) {
+  RejectToRange(year, YEAR_MIN, YEAR_MAX);
+  if (year === YEAR_MIN) {
+    RejectToRange(month, 4, 12);
+  } else if (year === YEAR_MAX) {
+    RejectToRange(month, 1, 9);
+  }
+}
+
+export function RejectDuration(
+  y: number,
+  mon: number,
+  w: number,
+  d: number,
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  µs: number,
+  ns: number
+) {
+  const sign = DurationSign(y, mon, w, d, h, min, s, ms, µs, ns);
+  for (const prop of [y, mon, w, d, h, min, s, ms, µs, ns]) {
+    if (!NumberIsFinite(prop)) throw new RangeError('infinite values not allowed as duration fields');
+    const propSign = MathSign(prop);
+    if (propSign !== 0 && propSign !== sign) throw new RangeError('mixed-sign values not allowed as duration fields');
+  }
+}
+
+export function DifferenceISODate<Allowed extends Temporal.DateTimeUnit>(
+  y1: number,
+  m1: number,
+  d1: number,
+  y2: number,
+  m2: number,
+  d2: number,
+  largestUnit: Allowed
+) {
+  switch (largestUnit) {
+    case 'year':
+    case 'month': {
+      const sign = -CompareISODate(y1, m1, d1, y2, m2, d2);
+      if (sign === 0) return { years: 0, months: 0, weeks: 0, days: 0 };
+
+      const start = { year: y1, month: m1, day: d1 };
+      const end = { year: y2, month: m2, day: d2 };
+
+      let years = end.year - start.year;
+      let mid = AddISODate(y1, m1, d1, years, 0, 0, 0, 'constrain');
+      let midSign = -CompareISODate(mid.year, mid.month, mid.day, y2, m2, d2);
+      if (midSign === 0) {
+        return largestUnit === 'year'
+          ? { years, months: 0, weeks: 0, days: 0 }
+          : { years: 0, months: years * 12, weeks: 0, days: 0 };
+      }
+      let months = end.month - start.month;
+      if (midSign !== sign) {
+        years -= sign;
+        months += sign * 12;
+      }
+      mid = AddISODate(y1, m1, d1, years, months, 0, 0, 'constrain');
+      midSign = -CompareISODate(mid.year, mid.month, mid.day, y2, m2, d2);
+      if (midSign === 0) {
+        return largestUnit === 'year'
+          ? { years, months, weeks: 0, days: 0 }
+          : { years: 0, months: months + years * 12, weeks: 0, days: 0 };
+      }
+      if (midSign !== sign) {
+        // The end date is later in the month than mid date (or earlier for
+        // negative durations). Back up one month.
+        months -= sign;
+        if (months === -sign) {
+          years -= sign;
+          months = 11 * sign;
+        }
+        mid = AddISODate(y1, m1, d1, years, months, 0, 0, 'constrain');
+      }
+
+      let days = 0;
+      // If we get here, months and years are correct (no overflow), and `mid`
+      // is within the range from `start` to `end`. To count the days between
+      // `mid` and `end`, there are 3 cases:
+      // 1) same month: use simple subtraction
+      // 2) end is previous month from intermediate (negative duration)
+      // 3) end is next month from intermediate (positive duration)
+      if (mid.month === end.month) {
+        // 1) same month: use simple subtraction
+        days = end.day - mid.day;
+      } else if (sign < 0) {
+        // 2) end is previous month from intermediate (negative duration)
+        // Example: intermediate: Feb 1, end: Jan 30, DaysInMonth = 31, days = -2
+        days = -mid.day - (ISODaysInMonth(end.year, end.month) - end.day);
+      } else {
+        // 3) end is next month from intermediate (positive duration)
+        // Example: intermediate: Jan 29, end: Feb 1, DaysInMonth = 31, days = 3
+        days = end.day + (ISODaysInMonth(mid.year, mid.month) - mid.day);
+      }
+
+      if (largestUnit === 'month') {
+        months += years * 12;
+        years = 0;
+      }
+      return { years, months, weeks: 0, days };
+    }
+    case 'week':
+    case 'day': {
+      let larger, smaller, sign;
+      if (CompareISODate(y1, m1, d1, y2, m2, d2) < 0) {
+        smaller = { year: y1, month: m1, day: d1 };
+        larger = { year: y2, month: m2, day: d2 };
+        sign = 1;
+      } else {
+        smaller = { year: y2, month: m2, day: d2 };
+        larger = { year: y1, month: m1, day: d1 };
+        sign = -1;
+      }
+      let days = DayOfYear(larger.year, larger.month, larger.day) - DayOfYear(smaller.year, smaller.month, smaller.day);
+      for (let year = smaller.year; year < larger.year; ++year) {
+        days += LeapYear(year) ? 366 : 365;
+      }
+      let weeks = 0;
+      if (largestUnit === 'week') {
+        weeks = MathFloor(days / 7);
+        days %= 7;
+      }
+      weeks *= sign;
+      days *= sign;
+      return { years: 0, months: 0, weeks, days };
+    }
+    default:
+      throw new Error('assert not reached');
+  }
+}
+
+function DifferenceTime(
+  h1: number,
+  min1: number,
+  s1: number,
+  ms1: number,
+  µs1: number,
+  ns1: number,
+  h2: number,
+  min2: number,
+  s2: number,
+  ms2: number,
+  µs2: number,
+  ns2: number
+) {
+  let hours = h2 - h1;
+  let minutes = min2 - min1;
+  let seconds = s2 - s1;
+  let milliseconds = ms2 - ms1;
+  let microseconds = µs2 - µs1;
+  let nanoseconds = ns2 - ns1;
+
+  const sign = DurationSign(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  hours *= sign;
+  minutes *= sign;
+  seconds *= sign;
+  milliseconds *= sign;
+  microseconds *= sign;
+  nanoseconds *= sign;
+
+  let deltaDays = 0;
+  ({
+    deltaDays,
+    hour: hours,
+    minute: minutes,
+    second: seconds,
+    millisecond: milliseconds,
+    microsecond: microseconds,
+    nanosecond: nanoseconds
+  } = BalanceTime(hours, minutes, seconds, milliseconds, microseconds, nanoseconds));
+
+  if (deltaDays != 0) throw new Error('assertion failure in DifferenceTime: _bt_.[[Days]] should be 0');
+  hours *= sign;
+  minutes *= sign;
+  seconds *= sign;
+  milliseconds *= sign;
+  microseconds *= sign;
+  nanoseconds *= sign;
+
+  return { hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function DifferenceInstant(
+  ns1: JSBI,
+  ns2: JSBI,
+  increment: number,
+  unit: keyof typeof nsPerTimeUnit,
+  roundingMode: Temporal.RoundingMode
+) {
+  const diff = JSBI.subtract(ns2, ns1);
+
+  const remainder = JSBI.remainder(diff, JSBI.BigInt(86400e9));
+  const wholeDays = JSBI.subtract(diff, remainder);
+  const roundedRemainder = RoundNumberToIncrement(remainder, nsPerTimeUnit[unit] * increment, roundingMode);
+  const roundedDiff = JSBI.add(wholeDays, roundedRemainder);
+
+  const nanoseconds = JSBI.toNumber(JSBI.remainder(roundedDiff, THOUSAND));
+  const microseconds = JSBI.toNumber(JSBI.remainder(JSBI.divide(roundedDiff, THOUSAND), THOUSAND));
+  const milliseconds = JSBI.toNumber(JSBI.remainder(JSBI.divide(roundedDiff, MILLION), THOUSAND));
+  const seconds = JSBI.toNumber(JSBI.divide(roundedDiff, BILLION));
+  return { seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function DifferenceISODateTime(
+  y1Param: number,
+  mon1Param: number,
+  d1Param: number,
+  h1: number,
+  min1: number,
+  s1: number,
+  ms1: number,
+  µs1: number,
+  ns1: number,
+  y2: number,
+  mon2: number,
+  d2: number,
+  h2: number,
+  min2: number,
+  s2: number,
+  ms2: number,
+  µs2: number,
+  ns2: number,
+  calendar: Temporal.CalendarProtocol,
+  largestUnit: Temporal.DateTimeUnit,
+  options: Temporal.DifferenceOptions<Temporal.DateTimeUnit>
+) {
+  let y1 = y1Param;
+  let mon1 = mon1Param;
+  let d1 = d1Param;
+
+  let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = DifferenceTime(
+    h1,
+    min1,
+    s1,
+    ms1,
+    µs1,
+    ns1,
+    h2,
+    min2,
+    s2,
+    ms2,
+    µs2,
+    ns2
+  );
+
+  const timeSign = DurationSign(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  const dateSign = CompareISODate(y2, mon2, d2, y1, mon1, d1);
+  if (dateSign === -timeSign) {
+    ({ year: y1, month: mon1, day: d1 } = BalanceISODate(y1, mon1, d1 - timeSign));
+    ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+      -timeSign,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      largestUnit
+    ));
+  }
+
+  const date1 = CreateTemporalDate(y1, mon1, d1, calendar);
+  const date2 = CreateTemporalDate(y2, mon2, d2, calendar);
+  const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit);
+  const untilOptions = MergeLargestUnitOption(options, dateLargestUnit);
+  // TODO untilOptions doesn't want to compile as it seems that smallestUnit is not clamped?
+  // Type 'SmallestUnit<DateTimeUnit> | undefined' is not assignable to type
+  //      'SmallestUnit<"year" | "month" | "day" | "week"> | undefined'.
+  // Type '"hour"' is not assignable to type
+  //      'SmallestUnit<"year" | "month" | "day" | "week"> | undefined'.ts(2345)
+  let { years, months, weeks, days } = CalendarDateUntil(calendar, date1, date2, untilOptions as any);
+  // Signs of date part and time part may not agree; balance them together
+  ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+    days,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    largestUnit
+  ));
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function DifferenceZonedDateTime(
+  ns1: JSBI,
+  ns2: JSBI,
+  timeZone: Temporal.TimeZoneProtocol,
+  calendar: Temporal.CalendarProtocol,
+  largestUnit: Temporal.DateTimeUnit,
+  options: Temporal.DifferenceOptions<Temporal.DateTimeUnit>
+) {
+  const nsDiff = JSBI.subtract(ns2, ns1);
+  if (JSBI.equal(nsDiff, ZERO)) {
+    return {
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+      microseconds: 0,
+      nanoseconds: 0
+    };
+  }
+
+  // Find the difference in dates only.
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  const start = new TemporalInstant(ns1);
+  const end = new TemporalInstant(ns2);
+  const dtStart = BuiltinTimeZoneGetPlainDateTimeFor(timeZone, start, calendar);
+  const dtEnd = BuiltinTimeZoneGetPlainDateTimeFor(timeZone, end, calendar);
+  let { years, months, weeks, days } = DifferenceISODateTime(
+    GetSlot(dtStart, ISO_YEAR),
+    GetSlot(dtStart, ISO_MONTH),
+    GetSlot(dtStart, ISO_DAY),
+    GetSlot(dtStart, ISO_HOUR),
+    GetSlot(dtStart, ISO_MINUTE),
+    GetSlot(dtStart, ISO_SECOND),
+    GetSlot(dtStart, ISO_MILLISECOND),
+    GetSlot(dtStart, ISO_MICROSECOND),
+    GetSlot(dtStart, ISO_NANOSECOND),
+    GetSlot(dtEnd, ISO_YEAR),
+    GetSlot(dtEnd, ISO_MONTH),
+    GetSlot(dtEnd, ISO_DAY),
+    GetSlot(dtEnd, ISO_HOUR),
+    GetSlot(dtEnd, ISO_MINUTE),
+    GetSlot(dtEnd, ISO_SECOND),
+    GetSlot(dtEnd, ISO_MILLISECOND),
+    GetSlot(dtEnd, ISO_MICROSECOND),
+    GetSlot(dtEnd, ISO_NANOSECOND),
+    calendar,
+    largestUnit,
+    options
+  );
+  const intermediateNs = AddZonedDateTime(start, timeZone, calendar, years, months, weeks, 0, 0, 0, 0, 0, 0, 0);
+  // may disambiguate
+  let timeRemainderNs = JSBI.subtract(ns2, intermediateNs);
+  const intermediate = CreateTemporalZonedDateTime(intermediateNs, timeZone, calendar);
+  ({ nanoseconds: timeRemainderNs, days } = NanosecondsToDays(timeRemainderNs, intermediate));
+
+  // Finally, merge the date and time durations and return the merged result.
+  const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    JSBI.toNumber(timeRemainderNs),
+    'hour'
+  );
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+type DifferenceOperation = 'since' | 'until';
+
+// TODO: does it make sense to explicitly union the other and options types for each operation?
+export function DifferenceTemporalInstant(
+  operation: DifferenceOperation,
+  instant: Temporal.Instant,
+  otherParam: InstantParams['until'][0],
+  optionsParam: InstantParams['until'][1] | undefined
+): Temporal.Duration {
+  const other = ToTemporalInstant(otherParam);
+  let first, second;
+  if (operation === 'until') {
+    [first, second] = [instant, other];
+  } else {
+    [first, second] = [other, instant];
+  }
+  const options = GetOptionsObject(optionsParam);
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
+  const defaultLargestUnit = LargerOfTwoTemporalUnits('second', smallestUnit);
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
+  if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  const roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  const MAX_DIFFERENCE_INCREMENTS = {
+    hour: 24,
+    minute: 60,
+    second: 60,
+    millisecond: 1000,
+    microsecond: 1000,
+    nanosecond: 1000
+  };
+  const roundingIncrement = ToTemporalRoundingIncrement(options, MAX_DIFFERENCE_INCREMENTS[smallestUnit], false);
+  const onens = GetSlot(first, EPOCHNANOSECONDS);
+  const twons = GetSlot(second, EPOCHNANOSECONDS);
+  let { seconds, milliseconds, microseconds, nanoseconds } = DifferenceInstant(
+    onens,
+    twons,
+    roundingIncrement,
+    smallestUnit,
+    roundingMode
+  );
+  let hours, minutes;
+  ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+    0,
+    0,
+    0,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    largestUnit
+  ));
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+}
+
+export function DifferenceTemporalPlainDate(
+  operation: DifferenceOperation,
+  plainDate: Temporal.PlainDate,
+  otherParam: PlainDateParams['until'][0],
+  optionsParam: PlainDateParams['until'][1]
+): Temporal.Duration {
+  const sign = operation === 'since' ? -1 : 1;
+  const other = ToTemporalDate(otherParam);
+  const calendar = GetSlot(plainDate, CALENDAR);
+  const otherCalendar = GetSlot(other, CALENDAR);
+  const calendarId = ToString(calendar);
+  const otherCalendarId = ToString(otherCalendar);
+  if (calendarId !== otherCalendarId) {
+    throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
+  }
+
+  const options = GetOptionsObject(optionsParam);
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'date', 'day');
+  const defaultLargestUnit = LargerOfTwoTemporalUnits('day', smallestUnit);
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
+  if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  let roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  if (operation === 'since') roundingMode = NegateTemporalRoundingMode(roundingMode);
+  const roundingIncrement = ToTemporalRoundingIncrement(options, undefined, false);
+
+  const untilOptions = MergeLargestUnitOption(options, largestUnit);
+  let { years, months, weeks, days } = CalendarDateUntil(calendar, plainDate, other, untilOptions);
+
+  if (smallestUnit !== 'day' || roundingIncrement !== 1) {
+    ({ years, months, weeks, days } = RoundDuration(
+      years,
+      months,
+      weeks,
+      days,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode,
+      plainDate
+    ));
+  }
+
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(sign * years, sign * months, sign * weeks, sign * days, 0, 0, 0, 0, 0, 0);
+}
+
+export function DifferenceTemporalPlainDateTime(
+  operation: DifferenceOperation,
+  plainDateTime: Temporal.PlainDateTime,
+  otherParam: PlainDateTimeParams['until'][0],
+  optionsParam: PlainDateTimeParams['until'][1]
+): Temporal.Duration {
+  const sign = operation === 'since' ? -1 : 1;
+  const other = ToTemporalDateTime(otherParam);
+  const calendar = GetSlot(plainDateTime, CALENDAR);
+  const otherCalendar = GetSlot(other, CALENDAR);
+  const calendarId = ToString(calendar);
+  const otherCalendarId = ToString(otherCalendar);
+  if (calendarId !== otherCalendarId) {
+    throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
+  }
+  const options = GetOptionsObject(optionsParam);
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'datetime', 'nanosecond');
+  const defaultLargestUnit = LargerOfTwoTemporalUnits('day', smallestUnit);
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
+  if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  let roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  if (operation === 'since') roundingMode = NegateTemporalRoundingMode(roundingMode);
+  const roundingIncrement = ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
+
+  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+    DifferenceISODateTime(
+      GetSlot(plainDateTime, ISO_YEAR),
+      GetSlot(plainDateTime, ISO_MONTH),
+      GetSlot(plainDateTime, ISO_DAY),
+      GetSlot(plainDateTime, ISO_HOUR),
+      GetSlot(plainDateTime, ISO_MINUTE),
+      GetSlot(plainDateTime, ISO_SECOND),
+      GetSlot(plainDateTime, ISO_MILLISECOND),
+      GetSlot(plainDateTime, ISO_MICROSECOND),
+      GetSlot(plainDateTime, ISO_NANOSECOND),
+      GetSlot(other, ISO_YEAR),
+      GetSlot(other, ISO_MONTH),
+      GetSlot(other, ISO_DAY),
+      GetSlot(other, ISO_HOUR),
+      GetSlot(other, ISO_MINUTE),
+      GetSlot(other, ISO_SECOND),
+      GetSlot(other, ISO_MILLISECOND),
+      GetSlot(other, ISO_MICROSECOND),
+      GetSlot(other, ISO_NANOSECOND),
+      calendar,
+      largestUnit,
+      options
+    );
+
+  const relativeTo = TemporalDateTimeToDate(plainDateTime);
+  ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = RoundDuration(
+    years,
+    months,
+    weeks,
+    days,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    roundingIncrement,
+    smallestUnit,
+    roundingMode,
+    relativeTo
+  ));
+  ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+    days,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    largestUnit
+  ));
+
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(
+    sign * years,
+    sign * months,
+    sign * weeks,
+    sign * days,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds
+  );
+}
+
+export function DifferenceTemporalPlainTime(
+  operation: DifferenceOperation,
+  plainTime: Temporal.PlainTime,
+  otherParam: PlainTimeParams['until'][0],
+  optionsParam: PlainTimeParams['until'][1]
+): Temporal.Duration {
+  const sign = operation === 'since' ? -1 : 1;
+  const other = ToTemporalTime(otherParam);
+  const options = GetOptionsObject(optionsParam);
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
+  if (largestUnit === 'auto') largestUnit = 'hour';
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  let roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  if (operation === 'since') roundingMode = NegateTemporalRoundingMode(roundingMode);
+  const MAX_INCREMENTS = {
+    hour: 24,
+    minute: 60,
+    second: 60,
+    millisecond: 1000,
+    microsecond: 1000,
+    nanosecond: 1000
+  };
+  const roundingIncrement = ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
+  let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = DifferenceTime(
+    GetSlot(plainTime, ISO_HOUR),
+    GetSlot(plainTime, ISO_MINUTE),
+    GetSlot(plainTime, ISO_SECOND),
+    GetSlot(plainTime, ISO_MILLISECOND),
+    GetSlot(plainTime, ISO_MICROSECOND),
+    GetSlot(plainTime, ISO_NANOSECOND),
+    GetSlot(other, ISO_HOUR),
+    GetSlot(other, ISO_MINUTE),
+    GetSlot(other, ISO_SECOND),
+    GetSlot(other, ISO_MILLISECOND),
+    GetSlot(other, ISO_MICROSECOND),
+    GetSlot(other, ISO_NANOSECOND)
+  );
+  ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = RoundDuration(
+    0,
+    0,
+    0,
+    0,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    roundingIncrement,
+    smallestUnit,
+    roundingMode
+  ));
+  ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+    0,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    largestUnit
+  ));
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(
+    0,
+    0,
+    0,
+    0,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds
+  );
+}
+
+export function DifferenceTemporalPlainYearMonth(
+  operation: DifferenceOperation,
+  yearMonth: Temporal.PlainYearMonth,
+  otherParam: PlainYearMonthParams['until'][0],
+  optionsParam: PlainYearMonthParams['until'][1]
+): Temporal.Duration {
+  const sign = operation === 'since' ? -1 : 1;
+  const other = ToTemporalYearMonth(otherParam);
+  const calendar = GetSlot(yearMonth, CALENDAR);
+  const otherCalendar = GetSlot(other, CALENDAR);
+  const calendarID = ToString(calendar);
+  const otherCalendarID = ToString(otherCalendar);
+  if (calendarID !== otherCalendarID) {
+    throw new RangeError(`cannot compute difference between months of ${calendarID} and ${otherCalendarID} calendars`);
+  }
+  const options = GetOptionsObject(optionsParam);
+  const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce((allowed, [p, s, c]) => {
+    if (c === 'date' && s !== 'week' && s !== 'day') allowed.push(s, p);
+    return allowed;
+  }, [] as Array<Temporal.DateTimeUnit | Temporal.PluralUnit<Temporal.DateTimeUnit>>);
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'date', 'month');
+  if (smallestUnit === 'week' || smallestUnit === 'day') {
+    throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);
+  }
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
+  if (largestUnit === 'week' || largestUnit === 'day') {
+    throw new RangeError(`largestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${largestUnit}`);
+  }
+  if (largestUnit === 'auto') largestUnit = 'year';
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  let roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  if (operation === 'since') roundingMode = NegateTemporalRoundingMode(roundingMode);
+  const roundingIncrement = ToTemporalRoundingIncrement(options, undefined, false);
+
+  const fieldNames = CalendarFields(calendar, ['monthCode', 'year'] as const);
+  const otherFields = PrepareTemporalFields(other, fieldNames, []);
+  otherFields.day = 1;
+  const thisFields = PrepareTemporalFields(yearMonth, fieldNames, []);
+  thisFields.day = 1;
+  // The calls to PrepareTemporalFields don't mark day as a required property,
+  // and TS doesn't automatically narrow the type of the object because of the
+  // assignments above, so we must "cast" the inputs.
+  const otherDate = CalendarDateFromFields(calendar, otherFields as typeof otherFields & { day: number });
+  const thisDate = CalendarDateFromFields(calendar, thisFields as typeof thisFields & { day: number });
+
+  const untilOptions = MergeLargestUnitOption(options, largestUnit);
+  let { years, months } = CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
+
+  if (smallestUnit !== 'month' || roundingIncrement !== 1) {
+    ({ years, months } = RoundDuration(
+      years,
+      months,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode,
+      thisDate
+    ));
+  }
+
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(sign * years, sign * months, 0, 0, 0, 0, 0, 0, 0, 0);
+}
+
+export function DifferenceTemporalZonedDateTime(
+  operation: DifferenceOperation,
+  zonedDateTime: Temporal.ZonedDateTime,
+  otherParam: ZonedDateTimeParams['until'][0],
+  optionsParam: ZonedDateTimeParams['until'][1]
+): Temporal.Duration {
+  const sign = operation === 'since' ? -1 : 1;
+  const other = ToTemporalZonedDateTime(otherParam);
+  const calendar = GetSlot(zonedDateTime, CALENDAR);
+  const otherCalendar = GetSlot(other, CALENDAR);
+  const calendarId = ToString(calendar);
+  const otherCalendarId = ToString(otherCalendar);
+  if (calendarId !== otherCalendarId) {
+    throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
+  }
+  const options = GetOptionsObject(optionsParam);
+  const smallestUnit = GetTemporalUnit(options, 'smallestUnit', 'datetime', 'nanosecond');
+  const defaultLargestUnit = LargerOfTwoTemporalUnits('hour', smallestUnit);
+  let largestUnit = GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
+  if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
+  if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+  }
+  let roundingMode = ToTemporalRoundingMode(options, 'trunc');
+  if (operation === 'since') roundingMode = NegateTemporalRoundingMode(roundingMode);
+  const roundingIncrement = ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
+
+  const ns1 = GetSlot(zonedDateTime, EPOCHNANOSECONDS);
+  const ns2 = GetSlot(other, EPOCHNANOSECONDS);
+  let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
+  if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
+    // The user is only asking for a time difference, so return difference of instants.
+    years = 0;
+    months = 0;
+    weeks = 0;
+    days = 0;
+    ({ seconds, milliseconds, microseconds, nanoseconds } = DifferenceInstant(
+      ns1,
+      ns2,
+      roundingIncrement,
+      // TODO this doesn't type-check as it includes >= day-size units
+      // This is probably safe as the typing for ToSmallestTemporalUnit isn't
+      // very good.
+      smallestUnit as any,
+      roundingMode
+    ));
+    ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+      0,
+      0,
+      0,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      largestUnit
+    ));
+  } else {
+    const timeZone = GetSlot(zonedDateTime, TIME_ZONE);
+    if (!TimeZoneEquals(timeZone, GetSlot(other, TIME_ZONE))) {
+      throw new RangeError(
+        "When calculating difference between time zones, largestUnit must be 'hours' " +
+          'or smaller because day lengths can vary between time zones due to DST or time zone offset changes.'
+      );
+    }
+    const untilOptions = MergeLargestUnitOption(options, largestUnit);
+    ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+      DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUnit, untilOptions));
+    ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = RoundDuration(
+      years,
+      months,
+      weeks,
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode,
+      zonedDateTime
+    ));
+    ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+      AdjustRoundedDurationDays(
+        years,
+        months,
+        weeks,
+        days,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+        roundingIncrement,
+        smallestUnit,
+        roundingMode,
+        zonedDateTime
+      ));
+  }
+
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(
+    sign * years,
+    sign * months,
+    sign * weeks,
+    sign * days,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds
+  );
+}
+
+export function AddISODate(
+  yearParam: number,
+  monthParam: number,
+  dayParam: number,
+  yearsParam: number,
+  monthsParam: number,
+  weeksParam: number,
+  daysParam: number,
+  overflow: Temporal.ArithmeticOptions['overflow']
+) {
+  let year = yearParam;
+  let month = monthParam;
+  let day = dayParam;
+  let years = yearsParam;
+  let months = monthsParam;
+  let weeks = weeksParam;
+  let days = daysParam;
+
+  year += years;
+  month += months;
+  ({ year, month } = BalanceISOYearMonth(year, month));
+  ({ year, month, day } = RegulateISODate(year, month, day, overflow));
+  days += 7 * weeks;
+  day += days;
+  ({ year, month, day } = BalanceISODate(year, month, day));
+  return { year, month, day };
+}
+
+function AddTime(
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number,
+  microseconds: number,
+  nanoseconds: number
+) {
+  let hour = hourParam;
+  let minute = minuteParam;
+  let second = secondParam;
+  let millisecond = millisecondParam;
+  let microsecond = microsecondParam;
+  let nanosecond = nanosecondParam;
+
+  hour += hours;
+  minute += minutes;
+  second += seconds;
+  millisecond += milliseconds;
+  microsecond += microseconds;
+  nanosecond += nanoseconds;
+  let deltaDays = 0;
+  ({ deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceTime(
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond
+  ));
+  return { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+function AddDuration(
+  y1: number,
+  mon1: number,
+  w1: number,
+  d1: number,
+  h1: number,
+  min1: number,
+  s1: number,
+  ms1: number,
+  µs1: number,
+  ns1: number,
+  y2: number,
+  mon2: number,
+  w2: number,
+  d2: number,
+  h2: number,
+  min2: number,
+  s2: number,
+  ms2: number,
+  µs2: number,
+  ns2: number,
+  relativeTo: ReturnType<typeof ToRelativeTemporalObject>
+) {
+  const largestUnit1 = DefaultTemporalLargestUnit(y1, mon1, w1, d1, h1, min1, s1, ms1, µs1, ns1);
+  const largestUnit2 = DefaultTemporalLargestUnit(y2, mon2, w2, d2, h2, min2, s2, ms2, µs2, ns2);
+  const largestUnit = LargerOfTwoTemporalUnits(largestUnit1, largestUnit2);
+
+  let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
+  if (!relativeTo) {
+    if (largestUnit === 'year' || largestUnit === 'month' || largestUnit === 'week') {
+      throw new RangeError('relativeTo is required for years, months, or weeks arithmetic');
+    }
+    years = months = weeks = 0;
+    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+      d1 + d2,
+      h1 + h2,
+      min1 + min2,
+      s1 + s2,
+      ms1 + ms2,
+      µs1 + µs2,
+      ns1 + ns2,
+      largestUnit
+    ));
+  } else if (IsTemporalDate(relativeTo)) {
+    const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+    const calendar = GetSlot(relativeTo, CALENDAR);
+
+    const dateDuration1 = new TemporalDuration(y1, mon1, w1, d1, 0, 0, 0, 0, 0, 0);
+    const dateDuration2 = new TemporalDuration(y2, mon2, w2, d2, 0, 0, 0, 0, 0, 0);
+    const dateAdd = calendar.dateAdd;
+    const intermediate = CalendarDateAdd(calendar, relativeTo, dateDuration1, undefined, dateAdd);
+    const end = CalendarDateAdd(calendar, intermediate, dateDuration2, undefined, dateAdd);
+
+    const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit);
+    const differenceOptions = ObjectCreate(null);
+    differenceOptions.largestUnit = dateLargestUnit;
+    ({ years, months, weeks, days } = CalendarDateUntil(calendar, relativeTo, end, differenceOptions));
+    // Signs of date part and time part may not agree; balance them together
+    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+      days,
+      h1 + h2,
+      min1 + min2,
+      s1 + s2,
+      ms1 + ms2,
+      µs1 + µs2,
+      ns1 + ns2,
+      largestUnit
+    ));
+  } else {
+    // relativeTo is a ZonedDateTime
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    const timeZone = GetSlot(relativeTo, TIME_ZONE);
+    const calendar = GetSlot(relativeTo, CALENDAR);
+    const intermediateNs = AddZonedDateTime(
+      GetSlot(relativeTo, INSTANT),
+      timeZone,
+      calendar,
+      y1,
+      mon1,
+      w1,
+      d1,
+      h1,
+      min1,
+      s1,
+      ms1,
+      µs1,
+      ns1
+    );
+    const endNs = AddZonedDateTime(
+      new TemporalInstant(intermediateNs),
+      timeZone,
+      calendar,
+      y2,
+      mon2,
+      w2,
+      d2,
+      h2,
+      min2,
+      s2,
+      ms2,
+      µs2,
+      ns2
+    );
+    if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
+      // The user is only asking for a time difference, so return difference of instants.
+      years = 0;
+      months = 0;
+      weeks = 0;
+      days = 0;
+      ({ seconds, milliseconds, microseconds, nanoseconds } = DifferenceInstant(
+        GetSlot(relativeTo, EPOCHNANOSECONDS),
+        endNs,
+        1,
+        'nanosecond',
+        'halfExpand'
+      ));
+      ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+        0,
+        0,
+        0,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+        largestUnit
+      ));
+    } else {
+      ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+        DifferenceZonedDateTime(
+          GetSlot(relativeTo, EPOCHNANOSECONDS),
+          endNs,
+          timeZone,
+          calendar,
+          largestUnit,
+          ObjectCreate(null)
+        ));
+    }
+  }
+
+  RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+function AddInstant(epochNanoseconds: JSBI, h: number, min: number, s: number, ms: number, µs: number, ns: number) {
+  let sum = ZERO;
+  sum = JSBI.add(sum, JSBI.BigInt(ns));
+  sum = JSBI.add(sum, JSBI.multiply(JSBI.BigInt(µs), THOUSAND));
+  sum = JSBI.add(sum, JSBI.multiply(JSBI.BigInt(ms), MILLION));
+  sum = JSBI.add(sum, JSBI.multiply(JSBI.BigInt(s), BILLION));
+  sum = JSBI.add(sum, JSBI.multiply(JSBI.BigInt(min), JSBI.BigInt(60 * 1e9)));
+  sum = JSBI.add(sum, JSBI.multiply(JSBI.BigInt(h), JSBI.BigInt(60 * 60 * 1e9)));
+
+  const result = JSBI.add(epochNanoseconds, sum);
+  ValidateEpochNanoseconds(result);
+  return result;
+}
+
+function AddDateTime(
+  year: number,
+  month: number,
+  day: number,
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number,
+  calendar: Temporal.CalendarProtocol,
+  years: number,
+  months: number,
+  weeks: number,
+  daysParam: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number,
+  microseconds: number,
+  nanoseconds: number,
+  options?: Temporal.ArithmeticOptions
+) {
+  let days = daysParam;
+  // Add the time part
+  let { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = AddTime(
+    hourParam,
+    minuteParam,
+    secondParam,
+    millisecondParam,
+    microsecondParam,
+    nanosecondParam,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds
+  );
+  days += deltaDays;
+
+  // Delegate the date part addition to the calendar
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  const datePart = CreateTemporalDate(year, month, day, calendar);
+  const dateDuration = new TemporalDuration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  const addedDate = CalendarDateAdd(calendar, datePart, dateDuration, options);
+
+  return {
+    year: GetSlot(addedDate, ISO_YEAR),
+    month: GetSlot(addedDate, ISO_MONTH),
+    day: GetSlot(addedDate, ISO_DAY),
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond
+  };
+}
+
+export function AddZonedDateTime(
+  instant: Temporal.Instant,
+  timeZone: Temporal.TimeZoneProtocol,
+  calendar: Temporal.CalendarProtocol,
+  years: number,
+  months: number,
+  weeks: number,
+  days: number,
+  h: number,
+  min: number,
+  s: number,
+  ms: number,
+  µs: number,
+  ns: number,
+  options?: Temporal.ArithmeticOptions
+) {
+  // If only time is to be added, then use Instant math. It's not OK to fall
+  // through to the date/time code below because compatible disambiguation in
+  // the PlainDateTime=>Instant conversion will change the offset of any
+  // ZonedDateTime in the repeated clock time after a backwards transition.
+  // When adding/subtracting time units and not dates, this disambiguation is
+  // not expected and so is avoided below via a fast path for time-only
+  // arithmetic.
+  // BTW, this behavior is similar in spirit to offset: 'prefer' in `with`.
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  if (DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0) === 0) {
+    return AddInstant(GetSlot(instant, EPOCHNANOSECONDS), h, min, s, ms, µs, ns);
+  }
+
+  // RFC 5545 requires the date portion to be added in calendar days and the
+  // time portion to be added in exact time.
+  const dt = BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar);
+  const datePart = CreateTemporalDate(GetSlot(dt, ISO_YEAR), GetSlot(dt, ISO_MONTH), GetSlot(dt, ISO_DAY), calendar);
+  const dateDuration = new TemporalDuration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  const addedDate = CalendarDateAdd(calendar, datePart, dateDuration, options);
+  const dtIntermediate = CreateTemporalDateTime(
+    GetSlot(addedDate, ISO_YEAR),
+    GetSlot(addedDate, ISO_MONTH),
+    GetSlot(addedDate, ISO_DAY),
+    GetSlot(dt, ISO_HOUR),
+    GetSlot(dt, ISO_MINUTE),
+    GetSlot(dt, ISO_SECOND),
+    GetSlot(dt, ISO_MILLISECOND),
+    GetSlot(dt, ISO_MICROSECOND),
+    GetSlot(dt, ISO_NANOSECOND),
+    calendar
+  );
+
+  // Note that 'compatible' is used below because this disambiguation behavior
+  // is required by RFC 5545.
+  const instantIntermediate = BuiltinTimeZoneGetInstantFor(timeZone, dtIntermediate, 'compatible');
+  return AddInstant(GetSlot(instantIntermediate, EPOCHNANOSECONDS), h, min, s, ms, µs, ns);
+}
+
+type AddSubtractOperation = 'add' | 'subtract';
+
+export function AddDurationToOrSubtractDurationFromDuration(
+  operation: AddSubtractOperation,
+  duration: Temporal.Duration,
+  other: DurationParams['add'][0],
+  optionsParam: DurationParams['add'][1]
+): Temporal.Duration {
+  const sign = operation === 'subtract' ? -1 : 1;
+  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+    ToTemporalDurationRecord(other);
+  const options = GetOptionsObject(optionsParam);
+  const relativeTo = ToRelativeTemporalObject(options);
+  ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = AddDuration(
+    GetSlot(duration, YEARS),
+    GetSlot(duration, MONTHS),
+    GetSlot(duration, WEEKS),
+    GetSlot(duration, DAYS),
+    GetSlot(duration, HOURS),
+    GetSlot(duration, MINUTES),
+    GetSlot(duration, SECONDS),
+    GetSlot(duration, MILLISECONDS),
+    GetSlot(duration, MICROSECONDS),
+    GetSlot(duration, NANOSECONDS),
+    sign * years,
+    sign * months,
+    sign * weeks,
+    sign * days,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds,
+    relativeTo
+  ));
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+}
+
+export function AddDurationToOrSubtractDurationFromInstant(
+  operation: AddSubtractOperation,
+  instant: Temporal.Instant,
+  durationLike: InstantParams['add'][0]
+): Temporal.Instant {
+  const sign = operation === 'subtract' ? -1 : 1;
+  const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ToLimitedTemporalDuration(durationLike, [
+    'years',
+    'months',
+    'weeks',
+    'days'
+  ]);
+  const ns = AddInstant(
+    GetSlot(instant, EPOCHNANOSECONDS),
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds
+  );
+  const Instant = GetIntrinsic('%Temporal.Instant%');
+  return new Instant(ns);
+}
+
+export function AddDurationToOrSubtractDurationFromPlainDateTime(
+  operation: AddSubtractOperation,
+  dateTime: Temporal.PlainDateTime,
+  durationLike: PlainDateTimeParams['add'][0],
+  optionsParam: PlainDateTimeParams['add'][1]
+): Temporal.PlainDateTime {
+  const sign = operation === 'subtract' ? -1 : 1;
+  const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+    ToTemporalDurationRecord(durationLike);
+  const options = GetOptionsObject(optionsParam);
+  const calendar = GetSlot(dateTime, CALENDAR);
+  const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = AddDateTime(
+    GetSlot(dateTime, ISO_YEAR),
+    GetSlot(dateTime, ISO_MONTH),
+    GetSlot(dateTime, ISO_DAY),
+    GetSlot(dateTime, ISO_HOUR),
+    GetSlot(dateTime, ISO_MINUTE),
+    GetSlot(dateTime, ISO_SECOND),
+    GetSlot(dateTime, ISO_MILLISECOND),
+    GetSlot(dateTime, ISO_MICROSECOND),
+    GetSlot(dateTime, ISO_NANOSECOND),
+    calendar,
+    sign * years,
+    sign * months,
+    sign * weeks,
+    sign * days,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds,
+    options
+  );
+  return CreateTemporalDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+}
+
+export function AddDurationToOrSubtractDurationFromPlainTime(
+  operation: AddSubtractOperation,
+  temporalTime: Temporal.PlainTime,
+  durationLike: PlainTimeParams['add'][0]
+): Temporal.PlainTime {
+  const sign = operation === 'subtract' ? -1 : 1;
+  const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ToTemporalDurationRecord(durationLike);
+  let { hour, minute, second, millisecond, microsecond, nanosecond } = AddTime(
+    GetSlot(temporalTime, ISO_HOUR),
+    GetSlot(temporalTime, ISO_MINUTE),
+    GetSlot(temporalTime, ISO_SECOND),
+    GetSlot(temporalTime, ISO_MILLISECOND),
+    GetSlot(temporalTime, ISO_MICROSECOND),
+    GetSlot(temporalTime, ISO_NANOSECOND),
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds
+  );
+  ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(
+    hour,
+    minute,
+    second,
+    millisecond,
+    microsecond,
+    nanosecond,
+    'reject'
+  ));
+  const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
+  return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+export function AddDurationToOrSubtractDurationFromPlainYearMonth(
+  operation: AddSubtractOperation,
+  yearMonth: Temporal.PlainYearMonth,
+  durationLike: PlainYearMonthParams['add'][0],
+  optionsParam: PlainYearMonthParams['add'][1]
+): Temporal.PlainYearMonth {
+  let duration = ToTemporalDurationRecord(durationLike);
+  if (operation === 'subtract') {
+    duration = {
+      years: -duration.years,
+      months: -duration.months,
+      weeks: -duration.weeks,
+      days: -duration.days,
+      hours: -duration.hours,
+      minutes: -duration.minutes,
+      seconds: -duration.seconds,
+      milliseconds: -duration.milliseconds,
+      microseconds: -duration.microseconds,
+      nanoseconds: -duration.nanoseconds
+    };
+  }
+  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+  ({ days } = BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
+
+  const options = GetOptionsObject(optionsParam);
+
+  const calendar = GetSlot(yearMonth, CALENDAR);
+  const fieldNames = CalendarFields(calendar, ['monthCode', 'year'] as const);
+  const fields = PrepareTemporalFields(yearMonth, fieldNames, []);
+  const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  fields.day = sign < 0 ? ToPositiveInteger(CalendarDaysInMonth(calendar, yearMonth)) : 1;
+  // PrepareTemporalFields returns a type where 'day' is potentially undefined,
+  // and TS doesn't narrow the type as a result of the assignment above, so we
+  // cast the fields input to the new type.
+  const startDate = CalendarDateFromFields(calendar, fields as typeof fields & { day: number });
+  const Duration = GetIntrinsic('%Temporal.Duration%');
+  const durationToAdd = new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  const optionsCopy = ObjectAssign(ObjectCreate(null), options);
+  const addedDate = CalendarDateAdd(calendar, startDate, durationToAdd, options);
+  const addedDateFields = PrepareTemporalFields(addedDate, fieldNames, []);
+
+  return CalendarYearMonthFromFields(calendar, addedDateFields, optionsCopy);
+}
+
+export function AddDurationToOrSubtractDurationFromZonedDateTime(
+  operation: AddSubtractOperation,
+  zonedDateTime: Temporal.ZonedDateTime,
+  durationLike: ZonedDateTimeParams['add'][0],
+  optionsParam: ZonedDateTimeParams['add'][1]
+): Temporal.ZonedDateTime {
+  const sign = operation === 'subtract' ? -1 : 1;
+  const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
+    ToTemporalDurationRecord(durationLike);
+  const options = GetOptionsObject(optionsParam);
+  const timeZone = GetSlot(zonedDateTime, TIME_ZONE);
+  const calendar = GetSlot(zonedDateTime, CALENDAR);
+  const epochNanoseconds = AddZonedDateTime(
+    GetSlot(zonedDateTime, INSTANT),
+    timeZone,
+    calendar,
+    sign * years,
+    sign * months,
+    sign * weeks,
+    sign * days,
+    sign * hours,
+    sign * minutes,
+    sign * seconds,
+    sign * milliseconds,
+    sign * microseconds,
+    sign * nanoseconds,
+    options
+  );
+  return CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
+}
+
+function RoundNumberToIncrement(quantity: JSBI, increment: number, mode: Temporal.RoundingMode) {
+  if (increment === 1) return quantity;
+  let { quotient, remainder } = divmod(quantity, JSBI.BigInt(increment));
+  if (JSBI.equal(remainder, ZERO)) return quantity;
+  const sign = JSBI.lessThan(remainder, ZERO) ? -1 : 1;
+  switch (mode) {
+    case 'ceil':
+      if (sign > 0) quotient = JSBI.add(quotient, JSBI.BigInt(sign));
+      break;
+    case 'floor':
+      if (sign < 0) quotient = JSBI.add(quotient, JSBI.BigInt(sign));
+      break;
+    case 'trunc':
+      // no change needed, because divmod is a truncation
+      break;
+    case 'halfExpand':
+      // "half up away from zero"
+      if (JSBI.toNumber(abs(JSBI.multiply(remainder, JSBI.BigInt(2)))) >= increment) {
+        quotient = JSBI.add(quotient, JSBI.BigInt(sign));
+      }
+      break;
+  }
+  return JSBI.multiply(quotient, JSBI.BigInt(increment));
+}
+
+export function RoundInstant(
+  epochNs: JSBI,
+  increment: number,
+  unit: keyof typeof nsPerTimeUnit,
+  roundingMode: Temporal.RoundingMode
+) {
+  // Note: NonNegativeModulo, but with BigInt
+  let remainder = JSBI.remainder(epochNs, JSBI.BigInt(86400e9));
+  if (JSBI.lessThan(remainder, ZERO)) remainder = JSBI.add(remainder, JSBI.BigInt(86400e9));
+  const wholeDays = JSBI.subtract(epochNs, remainder);
+  const roundedRemainder = RoundNumberToIncrement(remainder, nsPerTimeUnit[unit] * increment, roundingMode);
+  return JSBI.add(wholeDays, roundedRemainder);
+}
+
+export function RoundISODateTime(
+  yearParam: number,
+  monthParam: number,
+  dayParam: number,
+  hourParam: number,
+  minuteParam: number,
+  secondParam: number,
+  millisecondParam: number,
+  microsecondParam: number,
+  nanosecondParam: number,
+  increment: number,
+  unit: UnitSmallerThanOrEqualTo<'day'>,
+  roundingMode: Temporal.RoundingMode,
+  dayLengthNs = 86400e9
+) {
+  const { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = RoundTime(
+    hourParam,
+    minuteParam,
+    secondParam,
+    millisecondParam,
+    microsecondParam,
+    nanosecondParam,
+    increment,
+    unit,
+    roundingMode,
+    dayLengthNs
+  );
+  const { year, month, day } = BalanceISODate(yearParam, monthParam, dayParam + deltaDays);
+  return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
+}
+
+export function RoundTime(
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+  microsecond: number,
+  nanosecond: number,
+  increment: number,
+  unit: keyof typeof nsPerTimeUnit | 'day',
+  roundingMode: Temporal.RoundingMode,
+  dayLengthNs = 86400e9
+) {
+  let quantity = ZERO;
+  switch (unit) {
+    case 'day':
+    case 'hour':
+      quantity = JSBI.BigInt(hour);
+    // fall through
+    case 'minute':
+      quantity = JSBI.add(JSBI.multiply(quantity, SIXTY), JSBI.BigInt(minute));
+    // fall through
+    case 'second':
+      quantity = JSBI.add(JSBI.multiply(quantity, SIXTY), JSBI.BigInt(second));
+    // fall through
+    case 'millisecond':
+      quantity = JSBI.add(JSBI.multiply(quantity, THOUSAND), JSBI.BigInt(millisecond));
+    // fall through
+    case 'microsecond':
+      quantity = JSBI.add(JSBI.multiply(quantity, THOUSAND), JSBI.BigInt(microsecond));
+    // fall through
+    case 'nanosecond':
+      quantity = JSBI.add(JSBI.multiply(quantity, THOUSAND), JSBI.BigInt(nanosecond));
+  }
+  const nsPerUnit = unit === 'day' ? dayLengthNs : nsPerTimeUnit[unit];
+  const rounded = RoundNumberToIncrement(quantity, nsPerUnit * increment, roundingMode);
+  const result = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(nsPerUnit)));
+  switch (unit) {
+    case 'day':
+      return { deltaDays: result, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+    case 'hour':
+      return BalanceTime(result, 0, 0, 0, 0, 0);
+    case 'minute':
+      return BalanceTime(hour, result, 0, 0, 0, 0);
+    case 'second':
+      return BalanceTime(hour, minute, result, 0, 0, 0);
+    case 'millisecond':
+      return BalanceTime(hour, minute, second, result, 0, 0);
+    case 'microsecond':
+      return BalanceTime(hour, minute, second, millisecond, result, 0);
+    case 'nanosecond':
+      return BalanceTime(hour, minute, second, millisecond, microsecond, result);
+    default:
+      throw new Error(`Invalid unit ${unit}`);
+  }
+}
+
+function DaysUntil(
+  earlier: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  later: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime
+) {
+  return DifferenceISODate(
+    GetSlot(earlier, ISO_YEAR),
+    GetSlot(earlier, ISO_MONTH),
+    GetSlot(earlier, ISO_DAY),
+    GetSlot(later, ISO_YEAR),
+    GetSlot(later, ISO_MONTH),
+    GetSlot(later, ISO_DAY),
+    'day'
+  ).days;
+}
+
+function MoveRelativeDate(
+  calendar: Temporal.CalendarProtocol,
+  relativeToParam: NonNullable<ReturnType<typeof ToRelativeTemporalObject>>,
+  duration: Temporal.Duration
+) {
+  const later = CalendarDateAdd(calendar, relativeToParam, duration, undefined);
+  const days = DaysUntil(relativeToParam, later);
+  return { relativeTo: later, days };
+}
+
+export function MoveRelativeZonedDateTime(
+  relativeTo: Temporal.ZonedDateTime,
+  years: number,
+  months: number,
+  weeks: number,
+  days: number
+) {
+  const timeZone = GetSlot(relativeTo, TIME_ZONE);
+  const calendar = GetSlot(relativeTo, CALENDAR);
+  const intermediateNs = AddZonedDateTime(
+    GetSlot(relativeTo, INSTANT),
+    timeZone,
+    calendar,
+    years,
+    months,
+    weeks,
+    days,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
+  return CreateTemporalZonedDateTime(intermediateNs, timeZone, calendar);
+}
+
+export function AdjustRoundedDurationDays(
+  yearsParam: number,
+  monthsParam: number,
+  weeksParam: number,
+  daysParam: number,
+  hoursParam: number,
+  minutesParam: number,
+  secondsParam: number,
+  millisecondsParam: number,
+  microsecondsParam: number,
+  nanosecondsParam: number,
+  increment: number,
+  unit: Temporal.DateTimeUnit,
+  roundingMode: Temporal.RoundingMode,
+  relativeTo: ReturnType<typeof ToRelativeTemporalObject>
+) {
+  let years = yearsParam;
+  let months = monthsParam;
+  let weeks = weeksParam;
+  let days = daysParam;
+  let hours = hoursParam;
+  let minutes = minutesParam;
+  let seconds = secondsParam;
+  let milliseconds = millisecondsParam;
+  let microseconds = microsecondsParam;
+  let nanoseconds = nanosecondsParam;
+  if (
+    !IsTemporalZonedDateTime(relativeTo) ||
+    unit === 'year' ||
+    unit === 'month' ||
+    unit === 'week' ||
+    unit === 'day' ||
+    (unit === 'nanosecond' && increment === 1)
+  ) {
+    return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+  }
+
+  // There's one more round of rounding possible: if relativeTo is a
+  // ZonedDateTime, the time units could have rounded up into enough hours
+  // to exceed the day length. If this happens, grow the date part by a
+  // single day and re-run exact time rounding on the smaller remainder. DO
+  // NOT RECURSE, because once the extra hours are sucked up into the date
+  // duration, there's no way for another full day to come from the next
+  // round of rounding. And if it were possible (e.g. contrived calendar
+  // with 30-minute-long "days") then it'd risk an infinite loop.
+  let timeRemainderNs = TotalDurationNanoseconds(
+    0,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds,
+    0
+  );
+  const direction = MathSign(JSBI.toNumber(timeRemainderNs));
+
+  const timeZone = GetSlot(relativeTo, TIME_ZONE);
+  const calendar = GetSlot(relativeTo, CALENDAR);
+  const dayStart = AddZonedDateTime(
+    GetSlot(relativeTo, INSTANT),
+    timeZone,
+    calendar,
+    years,
+    months,
+    weeks,
+    days,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  const dayEnd = AddZonedDateTime(
+    new TemporalInstant(dayStart),
+    timeZone,
+    calendar,
+    0,
+    0,
+    0,
+    direction,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  );
+  const dayLengthNs = JSBI.subtract(dayEnd, dayStart);
+
+  if (
+    JSBI.greaterThanOrEqual(JSBI.multiply(JSBI.subtract(timeRemainderNs, dayLengthNs), JSBI.BigInt(direction)), ZERO)
+  ) {
+    ({ years, months, weeks, days } = AddDuration(
+      years,
+      months,
+      weeks,
+      days,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      direction,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      relativeTo
+    ));
+    timeRemainderNs = RoundInstant(JSBI.subtract(timeRemainderNs, dayLengthNs), increment, unit, roundingMode);
+    ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceDuration(
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      JSBI.toNumber(timeRemainderNs),
+      'hour'
+    ));
+  }
+  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+}
+
+export function RoundDuration(
+  yearsParam: number,
+  monthsParam: number,
+  weeksParam: number,
+  daysParam: number,
+  hoursParam: number,
+  minutesParam: number,
+  secondsParam: number,
+  millisecondsParam: number,
+  microsecondsParam: number,
+  nanosecondsParam: number,
+  increment: number,
+  unit: Temporal.DateTimeUnit,
+  roundingMode: Temporal.RoundingMode,
+  relativeToParam: ReturnType<typeof ToRelativeTemporalObject> = undefined
+) {
+  let years = yearsParam;
+  let months = monthsParam;
+  let weeks = weeksParam;
+  let days = daysParam;
+  let hours = hoursParam;
+  let minutes = minutesParam;
+  let seconds = secondsParam;
+  let milliseconds = millisecondsParam;
+  let microseconds = microsecondsParam;
+  let nanoseconds = JSBI.BigInt(nanosecondsParam);
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  let calendar, zdtRelative;
+  // A cast is used below because relativeTo will be either PlainDate or
+  // undefined for the rest of this long method (after any ZDT=>PlainDate
+  // conversion below), and TS isn't smart enough to know that the type has
+  // changed. See https://github.com/microsoft/TypeScript/issues/27706.
+  let relativeTo = relativeToParam as Temporal.PlainDate | undefined;
+  if (relativeTo) {
+    if (IsTemporalZonedDateTime(relativeTo)) {
+      zdtRelative = relativeTo;
+      relativeTo = ToTemporalDate(relativeTo);
+    } else if (!IsTemporalDate(relativeTo)) {
+      throw new TypeError('starting point must be PlainDate or ZonedDateTime');
+    }
+    calendar = GetSlot(relativeTo, CALENDAR);
+  }
+
+  // First convert time units up to days, if rounding to days or higher units.
+  // If rounding relative to a ZonedDateTime, then some days may not be 24h.
+  // TS doesn't know that `dayLengthNs` is only used if the unit is day or
+  // larger. We'll cast away `undefined` when it's used lower down below.
+  let dayLengthNs: JSBI | undefined;
+  if (unit === 'year' || unit === 'month' || unit === 'week' || unit === 'day') {
+    nanoseconds = TotalDurationNanoseconds(0, hours, minutes, seconds, milliseconds, microseconds, nanosecondsParam, 0);
+    let intermediate;
+    if (zdtRelative) {
+      intermediate = MoveRelativeZonedDateTime(zdtRelative, years, months, weeks, days);
+    }
+    let deltaDays;
+    let dayLength: number;
+    ({ days: deltaDays, nanoseconds, dayLengthNs: dayLength } = NanosecondsToDays(nanoseconds, intermediate));
+    dayLengthNs = JSBI.BigInt(dayLength);
+    days += deltaDays;
+    hours = minutes = seconds = milliseconds = microseconds = 0;
+  }
+
+  let total: number;
+  switch (unit) {
+    case 'year': {
+      if (!calendar) throw new RangeError('A starting point is required for years rounding');
+
+      // convert months and weeks to days by calculating difference(
+      // relativeTo + years, relativeTo + { years, months, weeks })
+      const yearsDuration = new TemporalDuration(years);
+      const dateAdd = calendar.dateAdd;
+      const yearsLater = CalendarDateAdd(calendar, relativeTo as Temporal.PlainDate, yearsDuration, undefined, dateAdd);
+      const yearsMonthsWeeks = new TemporalDuration(years, months, weeks);
+      const yearsMonthsWeeksLater = CalendarDateAdd(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        yearsMonthsWeeks,
+        undefined,
+        dateAdd
+      );
+      const monthsWeeksInDays = DaysUntil(yearsLater, yearsMonthsWeeksLater);
+      relativeTo = yearsLater;
+      days += monthsWeeksInDays;
+
+      const daysLater = CalendarDateAdd(calendar, relativeTo, { days }, undefined, dateAdd);
+      const untilOptions = ObjectCreate(null);
+      untilOptions.largestUnit = 'year';
+      const yearsPassed = CalendarDateUntil(calendar, relativeTo, daysLater, untilOptions).years;
+      years += yearsPassed;
+      const oldRelativeTo = relativeTo;
+      relativeTo = CalendarDateAdd(calendar, relativeTo, { years: yearsPassed }, undefined, dateAdd);
+      const daysPassed = DaysUntil(oldRelativeTo, relativeTo);
+      days -= daysPassed;
+      const oneYear = new TemporalDuration(days < 0 ? -1 : 1);
+      let { days: oneYearDays } = MoveRelativeDate(calendar, relativeTo, oneYear);
+
+      // Note that `nanoseconds` below (here and in similar code for months,
+      // weeks, and days further below) isn't actually nanoseconds for the
+      // full date range.  Instead, it's a BigInt representation of total
+      // days multiplied by the number of nanoseconds in the last day of
+      // the duration. This lets us do days-or-larger rounding using BigInt
+      // math which reduces precision loss.
+      oneYearDays = MathAbs(oneYearDays);
+      // dayLengthNs is never undefined if unit is `day` or larger.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const divisor = JSBI.multiply(JSBI.BigInt(oneYearDays), dayLengthNs!);
+      nanoseconds = JSBI.add(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        JSBI.add(JSBI.multiply(divisor, JSBI.BigInt(years)), JSBI.multiply(JSBI.BigInt(days), dayLengthNs!)),
+        nanoseconds
+      );
+      const rounded = RoundNumberToIncrement(
+        nanoseconds,
+        JSBI.toNumber(JSBI.multiply(divisor, JSBI.BigInt(increment))),
+        roundingMode
+      );
+      total = JSBI.toNumber(nanoseconds) / JSBI.toNumber(divisor);
+      years = JSBI.toNumber(JSBI.divide(rounded, divisor));
+      nanoseconds = ZERO;
+      months = weeks = days = 0;
+      break;
+    }
+    case 'month': {
+      if (!calendar) throw new RangeError('A starting point is required for months rounding');
+
+      // convert weeks to days by calculating difference(relativeTo +
+      //   { years, months }, relativeTo + { years, months, weeks })
+      const yearsMonths = new TemporalDuration(years, months);
+      const dateAdd = calendar.dateAdd;
+      const yearsMonthsLater = CalendarDateAdd(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        yearsMonths,
+        undefined,
+        dateAdd
+      );
+      const yearsMonthsWeeks = new TemporalDuration(years, months, weeks);
+      const yearsMonthsWeeksLater = CalendarDateAdd(
+        calendar,
+        relativeTo as Temporal.PlainDate,
+        yearsMonthsWeeks,
+        undefined,
+        dateAdd
+      );
+      const weeksInDays = DaysUntil(yearsMonthsLater, yearsMonthsWeeksLater);
+      relativeTo = yearsMonthsLater;
+      days += weeksInDays;
+
+      // Months may be different lengths of days depending on the calendar,
+      // convert days to months in a loop as described above under 'years'.
+      const sign = MathSign(days);
+      const oneMonth = new TemporalDuration(0, days < 0 ? -1 : 1);
+      let oneMonthDays: number;
+      ({ relativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo, oneMonth));
+      while (MathAbs(days) >= MathAbs(oneMonthDays)) {
+        months += sign;
+        days -= oneMonthDays;
+        ({ relativeTo, days: oneMonthDays } = MoveRelativeDate(calendar, relativeTo, oneMonth));
+      }
+      oneMonthDays = MathAbs(oneMonthDays);
+      // dayLengthNs is never undefined if unit is `day` or larger.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const divisor = JSBI.multiply(JSBI.BigInt(oneMonthDays), dayLengthNs!);
+      nanoseconds = JSBI.add(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        JSBI.add(JSBI.multiply(divisor, JSBI.BigInt(months)), JSBI.multiply(JSBI.BigInt(days), dayLengthNs!)),
+        nanoseconds
+      );
+      const rounded = RoundNumberToIncrement(
+        nanoseconds,
+        JSBI.toNumber(JSBI.multiply(divisor, JSBI.BigInt(increment))),
+        roundingMode
+      );
+      total = JSBI.toNumber(nanoseconds) / JSBI.toNumber(divisor);
+      months = JSBI.toNumber(JSBI.divide(rounded, divisor));
+      nanoseconds = ZERO;
+      weeks = days = 0;
+      break;
+    }
+    case 'week': {
+      if (!calendar) throw new RangeError('A starting point is required for weeks rounding');
+      // Weeks may be different lengths of days depending on the calendar,
+      // convert days to weeks in a loop as described above under 'years'.
+      const sign = MathSign(days);
+      const oneWeek = new TemporalDuration(0, 0, days < 0 ? -1 : 1);
+      let oneWeekDays;
+      ({ relativeTo, days: oneWeekDays } = MoveRelativeDate(calendar, relativeTo as Temporal.PlainDate, oneWeek));
+      while (MathAbs(days) >= MathAbs(oneWeekDays)) {
+        weeks += sign;
+        days -= oneWeekDays;
+        ({ relativeTo, days: oneWeekDays } = MoveRelativeDate(calendar, relativeTo, oneWeek));
+      }
+      oneWeekDays = MathAbs(oneWeekDays);
+      // dayLengthNs is never undefined if unit is `day` or larger.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const divisor = JSBI.multiply(JSBI.BigInt(oneWeekDays), dayLengthNs!);
+      nanoseconds = JSBI.add(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        JSBI.add(JSBI.multiply(divisor, JSBI.BigInt(weeks)), JSBI.multiply(JSBI.BigInt(days), dayLengthNs!)),
+        nanoseconds
+      );
+      const rounded = RoundNumberToIncrement(
+        nanoseconds,
+        JSBI.toNumber(JSBI.multiply(divisor, JSBI.BigInt(increment))),
+        roundingMode
+      );
+      total = JSBI.toNumber(nanoseconds) / JSBI.toNumber(divisor);
+      weeks = JSBI.toNumber(JSBI.divide(rounded, divisor));
+      nanoseconds = ZERO;
+      days = 0;
+      break;
+    }
+    case 'day': {
+      // dayLengthNs is never undefined if unit is `day` or larger.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const divisor = dayLengthNs!;
+      nanoseconds = JSBI.add(JSBI.multiply(divisor, JSBI.BigInt(days)), nanoseconds);
+      const rounded = RoundNumberToIncrement(
+        nanoseconds,
+        JSBI.toNumber(JSBI.multiply(divisor, JSBI.BigInt(increment))),
+        roundingMode
+      );
+      total = JSBI.toNumber(nanoseconds) / JSBI.toNumber(divisor);
+      days = JSBI.toNumber(JSBI.divide(rounded, divisor));
+      nanoseconds = ZERO;
+      break;
+    }
+    case 'hour': {
+      const divisor = 3600e9;
+      let allNanoseconds = JSBI.multiply(JSBI.BigInt(hours), JSBI.BigInt(3600e9));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(minutes), JSBI.BigInt(60e9)));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(seconds), BILLION));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(milliseconds), MILLION));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(microseconds), THOUSAND));
+      allNanoseconds = JSBI.add(allNanoseconds, nanoseconds);
+      total = JSBI.toNumber(allNanoseconds) / divisor;
+      const rounded = RoundNumberToIncrement(allNanoseconds, divisor * increment, roundingMode);
+      hours = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(divisor)));
+      nanoseconds = ZERO;
+      minutes = seconds = milliseconds = microseconds = 0;
+      break;
+    }
+    case 'minute': {
+      const divisor = 60e9;
+      let allNanoseconds = JSBI.multiply(JSBI.BigInt(minutes), JSBI.BigInt(60e9));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(seconds), BILLION));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(milliseconds), MILLION));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(microseconds), THOUSAND));
+      allNanoseconds = JSBI.add(allNanoseconds, nanoseconds);
+      total = JSBI.toNumber(allNanoseconds) / divisor;
+      const rounded = RoundNumberToIncrement(allNanoseconds, divisor * increment, roundingMode);
+      minutes = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(divisor)));
+      nanoseconds = ZERO;
+      seconds = milliseconds = microseconds = 0;
+      break;
+    }
+    case 'second': {
+      const divisor = 1e9;
+      let allNanoseconds = JSBI.multiply(JSBI.BigInt(seconds), BILLION);
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(milliseconds), MILLION));
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(microseconds), THOUSAND));
+      allNanoseconds = JSBI.add(allNanoseconds, nanoseconds);
+      total = JSBI.toNumber(allNanoseconds) / divisor;
+      const rounded = RoundNumberToIncrement(allNanoseconds, divisor * increment, roundingMode);
+      seconds = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(divisor)));
+      nanoseconds = ZERO;
+      milliseconds = microseconds = 0;
+      break;
+    }
+    case 'millisecond': {
+      const divisor = 1e6;
+      let allNanoseconds = JSBI.multiply(JSBI.BigInt(milliseconds), MILLION);
+      allNanoseconds = JSBI.add(allNanoseconds, JSBI.multiply(JSBI.BigInt(microseconds), THOUSAND));
+      allNanoseconds = JSBI.add(allNanoseconds, nanoseconds);
+      total = JSBI.toNumber(allNanoseconds) / divisor;
+      const rounded = RoundNumberToIncrement(allNanoseconds, divisor * increment, roundingMode);
+      milliseconds = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(divisor)));
+      nanoseconds = ZERO;
+      microseconds = 0;
+      break;
+    }
+    case 'microsecond': {
+      const divisor = 1e3;
+      let allNanoseconds = JSBI.multiply(JSBI.BigInt(microseconds), THOUSAND);
+      allNanoseconds = JSBI.add(allNanoseconds, nanoseconds);
+      total = JSBI.toNumber(allNanoseconds) / divisor;
+      const rounded = RoundNumberToIncrement(allNanoseconds, divisor * increment, roundingMode);
+      microseconds = JSBI.toNumber(JSBI.divide(rounded, JSBI.BigInt(divisor)));
+      nanoseconds = ZERO;
+      break;
+    }
+    case 'nanosecond': {
+      total = JSBI.toNumber(nanoseconds);
+      nanoseconds = RoundNumberToIncrement(nanoseconds, increment, roundingMode);
+      break;
+    }
+  }
+  return {
+    years,
+    months,
+    weeks,
+    days,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+    microseconds,
+    nanoseconds: JSBI.toNumber(nanoseconds),
+    total
+  };
+}
+
+export function CompareISODate(y1: number, m1: number, d1: number, y2: number, m2: number, d2: number) {
+  for (const [x, y] of [
+    [y1, y2],
+    [m1, m2],
+    [d1, d2]
+  ]) {
+    if (x !== y) return ComparisonResult(x - y);
+  }
+  return 0;
+}
+
+function NonNegativeModulo(x: number, y: number) {
+  let result = x % y;
+  if (ObjectIs(result, -0)) return 0;
+  if (result < 0) result += y;
+  return result;
+}
+
+// Defaults to native bigint, or something "native bigint-like".
+// For users of Temporal that are running in environments without native BigInt,
+// the only guarantee we should give is that the returned object's toString will
+// return a string containing an accurate base 10 value of this bigint. This
+// form factor should correctly interop with other bigint compat libraries
+// easily.
+type ExternalBigInt = bigint;
+
+export function ToBigIntExternal(arg: unknown): ExternalBigInt {
+  const jsbiBI = ToBigInt(arg);
+  if (typeof (globalThis as any).BigInt !== 'undefined') return (globalThis as any).BigInt(jsbiBI.toString(10));
+  return jsbiBI as unknown as ExternalBigInt;
+}
+
+export function ToBigInt(arg: unknown): JSBI {
+  if (arg instanceof JSBI) {
+    return arg;
+  }
+
+  let prim = arg;
+  if (typeof arg === 'object') {
+    const toPrimFn = (arg as { [Symbol.toPrimitive]: unknown })[Symbol.toPrimitive];
+    if (toPrimFn && typeof toPrimFn === 'function') {
+      prim = ReflectApply(toPrimFn, arg, ['number']);
+    }
+  }
+  switch (typeof prim) {
+    case 'undefined':
+    case 'object':
+    case 'number':
+    case 'symbol':
+    default:
+      throw new TypeError(`cannot convert ${typeof arg} to bigint`);
+    case 'string':
+      if (!prim.match(/^\s*(?:[+-]?\d+\s*)?$/)) {
+        throw new SyntaxError('invalid BigInt syntax');
+      }
+    // eslint: no-fallthrough: false
+    case 'bigint':
+      try {
+        return JSBI.BigInt(prim.toString());
+      } catch (e: unknown) {
+        if (e instanceof Error && e.message.startsWith('Invalid integer')) throw new SyntaxError(e.message);
+        throw e;
+      }
+    case 'boolean':
+      if (prim) {
+        return ONE;
+      } else {
+        return ZERO;
+      }
+  }
+}
+
+// Note: This method returns values with bogus nanoseconds based on the previous iteration's
+// milliseconds. That way there is a guarantee that the full nanoseconds are always going to be
+// increasing at least and that the microsecond and nanosecond fields are likely to be non-zero.
+export const SystemUTCEpochNanoSeconds: () => JSBI = (() => {
+  let ns = JSBI.BigInt(Date.now() % 1e6);
+  return () => {
+    const ms = JSBI.BigInt(Date.now());
+    const result = JSBI.add(JSBI.multiply(ms, MILLION), ns);
+    ns = JSBI.remainder(ms, MILLION);
+    if (JSBI.greaterThan(result, NS_MAX)) return NS_MAX;
+    if (JSBI.lessThan(result, NS_MIN)) return NS_MIN;
+    return result;
+  };
+})();
+
+export function SystemTimeZone() {
+  const fmt = new IntlDateTimeFormat('en-us');
+  const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+  return new TemporalTimeZone(ParseTemporalTimeZone(fmt.resolvedOptions().timeZone));
+}
+
+export function ComparisonResult(value: number) {
+  return value < 0 ? -1 : value > 0 ? 1 : (value as 0);
+}
+
+export function GetOptionsObject<T>(options: T) {
+  if (options === undefined) return ObjectCreate(null) as NonNullable<T>;
+  if (IsObject(options) && options !== null) return options;
+  throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `${typeof options}`}`);
+}
+
+export function CreateOnePropObject<K extends string, V>(propName: K, propValue: V): { [k in K]: V } {
+  const o = ObjectCreate(null);
+  o[propName] = propValue;
+  return o;
+}
+
+type StringlyTypedKeys<T> = Exclude<keyof T, symbol | number>;
+function GetOption<P extends StringlyTypedKeys<O>, O extends Partial<Record<P, unknown>>>(
+  options: O,
+  property: P,
+  allowedValues: ReadonlyArray<O[P]>,
+  fallback: undefined
+): O[P];
+function GetOption<
+  P extends StringlyTypedKeys<O>,
+  O extends Partial<Record<P, unknown>>,
+  Fallback extends Required<O>[P] | undefined
+>(
+  options: O,
+  property: P,
+  allowedValues: ReadonlyArray<O[P]>,
+  fallback: Fallback
+): Fallback extends undefined ? O[P] | undefined : Required<O>[P];
+function GetOption<
+  P extends StringlyTypedKeys<O>,
+  O extends Partial<Record<P, unknown>>,
+  Fallback extends Required<O>[P] | undefined
+>(
+  options: O,
+  property: P,
+  allowedValues: ReadonlyArray<O[P]>,
+  fallback: O[P]
+): Fallback extends undefined ? O[P] | undefined : Required<O>[P] {
+  let value = options[property];
+  if (value !== undefined) {
+    value = ToString(value) as O[P];
+    if (!allowedValues.includes(value)) {
+      throw new RangeError(`${property} must be one of ${allowedValues.join(', ')}, not ${value}`);
+    }
+    return value;
+  }
+  return fallback;
+}
+
+function GetNumberOption<P extends StringlyTypedKeys<T>, T extends Partial<Record<P, unknown>>>(
+  options: T,
+  property: P,
+  minimum: number,
+  maximum: number,
+  fallback: number
+): number {
+  let valueRaw = options[property];
+  if (valueRaw === undefined) return fallback;
+  const value = ToNumber(valueRaw);
+  if (NumberIsNaN(value) || value < minimum || value > maximum) {
+    throw new RangeError(`${String(property)} must be between ${minimum} and ${maximum}, not ${value}`);
+  }
+  return MathFloor(value);
+}
+
+export function IsBuiltinCalendar(id: string): id is BuiltinCalendarId {
+  return ArrayIncludes.call(BUILTIN_CALENDAR_IDS, id);
+}
+
+const OFFSET = new RegExp(`^${PARSE.offset.source}$`);
+
+function bisect(
+  getState: (epochNs: JSBI) => number,
+  leftParam: JSBI,
+  rightParam: JSBI,
+  lstateParam: number = getState(leftParam),
+  rstateParam: number = getState(rightParam)
+) {
+  // This doesn't make much sense - why do these get converted unnecessarily?
+  let left = JSBI.BigInt(leftParam);
+  let right = JSBI.BigInt(rightParam);
+  let lstate = lstateParam;
+  let rstate = rstateParam;
+  while (JSBI.greaterThan(JSBI.subtract(right, left), ONE)) {
+    const middle = JSBI.divide(JSBI.add(left, right), JSBI.BigInt(2));
+    const mstate = getState(middle);
+    if (mstate === lstate) {
+      left = middle;
+      lstate = mstate;
+    } else if (mstate === rstate) {
+      right = middle;
+      rstate = mstate;
+    } else {
+      throw new Error(`invalid state in bisection ${lstate} - ${mstate} - ${rstate}`);
+    }
+  }
+  return right;
+}
+
+const nsPerTimeUnit = {
+  hour: 3600e9,
+  minute: 60e9,
+  second: 1e9,
+  millisecond: 1e6,
+  microsecond: 1e3,
+  nanosecond: 1
+};

--- a/src/vendor/temporal/index.ts
+++ b/src/vendor/temporal/index.ts
@@ -1,0 +1,36 @@
+// This entry point treats Temporal as a library, and does not polyfill it onto
+// the global object.
+// This is in order to avoid breaking the web in the future, if the polyfill
+// gains wide adoption before the API is finalized. We do not want checks such
+// as `if (typeof Temporal === 'undefined')` in the wild, until browsers start
+// shipping the finalized API.
+
+import * as Temporal from './temporal';
+import * as Intl from './intl';
+import { toTemporalInstant } from './legacydate';
+
+// Work around https://github.com/babel/babel/issues/2025.
+const types = [
+  Temporal.Instant,
+  Temporal.Calendar,
+  Temporal.PlainDate,
+  Temporal.PlainDateTime,
+  Temporal.Duration,
+  Temporal.PlainMonthDay,
+  // Temporal.Now, // plain object (not a constructor), so no `prototype`
+  Temporal.PlainTime,
+  Temporal.TimeZone,
+  Temporal.PlainYearMonth,
+  Temporal.ZonedDateTime
+];
+for (const type of types) {
+  const descriptor = Object.getOwnPropertyDescriptor(type, 'prototype') as PropertyDescriptor;
+  if (descriptor.configurable || descriptor.enumerable || descriptor.writable) {
+    descriptor.configurable = false;
+    descriptor.enumerable = false;
+    descriptor.writable = false;
+    Object.defineProperty(type, 'prototype', descriptor);
+  }
+}
+
+export { Temporal, Intl, toTemporalInstant };

--- a/src/vendor/temporal/init.ts
+++ b/src/vendor/temporal/init.ts
@@ -1,0 +1,43 @@
+// This is an alternate entry point that polyfills Temporal onto the global
+// object. This is used only for the browser playground and the test262 tests.
+// See the note in index.mjs.
+
+import * as Temporal from './temporal';
+import * as Intl from './intl';
+import { toTemporalInstant } from './legacydate';
+
+Object.defineProperty(globalThis, 'Temporal', {
+  value: {},
+  writable: true,
+  enumerable: false,
+  configurable: true
+});
+const globalTemporal = (globalThis as unknown as { Temporal: typeof Temporal }).Temporal;
+copy(globalTemporal, Temporal);
+Object.defineProperty(globalTemporal, Symbol.toStringTag, {
+  value: 'Temporal',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+copy(globalTemporal.Now, Temporal.Now);
+copy(globalThis.Intl, Intl);
+Object.defineProperty(globalThis.Date.prototype, 'toTemporalInstant', {
+  value: toTemporalInstant,
+  writable: true,
+  enumerable: false,
+  configurable: true
+});
+
+function copy(target: Record<string | number | symbol, unknown>, source: Record<string | number | symbol, unknown>) {
+  for (const prop of Object.getOwnPropertyNames(source)) {
+    Object.defineProperty(target, prop, {
+      value: source[prop],
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+  }
+}
+
+export { Temporal, Intl, toTemporalInstant };

--- a/src/vendor/temporal/instant.ts
+++ b/src/vendor/temporal/instant.ts
@@ -1,0 +1,205 @@
+import { DEBUG } from './debug';
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { InstantParams as Params, InstantReturn as Return } from './internaltypes';
+
+import JSBI from 'jsbi';
+import { BILLION, MILLION, THOUSAND } from './ecmascript';
+
+export class Instant implements Temporal.Instant {
+  constructor(epochNanoseconds: bigint | JSBI) {
+    // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
+    //       to improve the error message.
+    if (arguments.length < 1) {
+      throw new TypeError('missing argument: epochNanoseconds is required');
+    }
+
+    const ns = ES.ToBigInt(epochNanoseconds);
+    ES.ValidateEpochNanoseconds(ns);
+    CreateSlots(this);
+    SetSlot(this, EPOCHNANOSECONDS, ns);
+
+    if (DEBUG) {
+      const repr = ES.TemporalInstantToString(this, undefined, 'auto');
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${repr}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+
+  get epochSeconds(): Return['epochSeconds'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return JSBI.toNumber(JSBI.divide(value, BILLION));
+  }
+  get epochMilliseconds(): Return['epochMilliseconds'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const value = JSBI.BigInt(GetSlot(this, EPOCHNANOSECONDS));
+    return JSBI.toNumber(JSBI.divide(value, MILLION));
+  }
+  get epochMicroseconds(): Return['epochMicroseconds'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const value = JSBI.BigInt(GetSlot(this, EPOCHNANOSECONDS));
+    return ES.ToBigIntExternal(JSBI.divide(value, THOUSAND));
+  }
+  get epochNanoseconds(): Return['epochNanoseconds'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.ToBigIntExternal(JSBI.BigInt(GetSlot(this, EPOCHNANOSECONDS)));
+  }
+
+  add(temporalDurationLike: Params['add'][0]): Return['add'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromInstant('add', this, temporalDurationLike);
+  }
+  subtract(temporalDurationLike: Params['subtract'][0]): Return['subtract'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromInstant('subtract', this, temporalDurationLike);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalInstant('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalInstant('since', this, other, options);
+  }
+  round(optionsParam: Params['round'][0]): Return['round'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (optionsParam === undefined) throw new TypeError('options parameter is required');
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const maximumIncrements = {
+      hour: 24,
+      minute: 1440,
+      second: 86400,
+      millisecond: 86400e3,
+      microsecond: 86400e6,
+      nanosecond: 86400e9
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], true);
+    const ns = GetSlot(this, EPOCHNANOSECONDS);
+    const roundedNs = ES.RoundInstant(ns, roundingIncrement, smallestUnit, roundingMode);
+    return new Instant(roundedNs);
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalInstant(otherParam);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    return JSBI.equal(JSBI.BigInt(one), JSBI.BigInt(two));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    let timeZone = options.timeZone;
+    if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
+    // Although TS doesn't acknowledge it, below here `timeZone` is a Temporal.TimeZoneProtocol
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    const ns = GetSlot(this, EPOCHNANOSECONDS);
+    const roundedNs = ES.RoundInstant(ns, increment, unit, roundingMode);
+    const roundedInstant = new Instant(roundedNs);
+    return ES.TemporalInstantToString(roundedInstant, timeZone as Temporal.TimeZoneProtocol, precision);
+  }
+  toJSON(): string {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalInstantToString(this, undefined, 'auto');
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.Instant');
+  }
+  toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(item)) {
+      throw new TypeError('invalid argument in toZonedDateTime');
+    }
+    const calendarLike = item.calendar;
+    if (calendarLike === undefined) {
+      throw new TypeError('missing calendar property in toZonedDateTime');
+    }
+    const calendar = ES.ToTemporalCalendar(calendarLike);
+    const temporalTimeZoneLike = item.timeZone;
+    if (temporalTimeZoneLike === undefined) {
+      throw new TypeError('missing timeZone property in toZonedDateTime');
+    }
+    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  toZonedDateTimeISO(itemParam: Params['toZonedDateTimeISO'][0]): Return['toZonedDateTimeISO'] {
+    let item = itemParam;
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (ES.IsObject(item)) {
+      const timeZoneProperty = item.timeZone;
+      if (timeZoneProperty !== undefined) {
+        item = timeZoneProperty;
+      }
+    }
+    const timeZone = ES.ToTemporalTimeZone(item as string | Temporal.TimeZoneProtocol);
+    const calendar = ES.GetISO8601Calendar();
+    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+
+  static fromEpochSeconds(epochSecondsParam: Params['fromEpochSeconds'][0]): Return['fromEpochSeconds'] {
+    const epochSeconds = ES.ToNumber(epochSecondsParam);
+    const epochNanoseconds = JSBI.multiply(JSBI.BigInt(epochSeconds), BILLION);
+    ES.ValidateEpochNanoseconds(epochNanoseconds);
+    return new Instant(epochNanoseconds);
+  }
+  static fromEpochMilliseconds(
+    epochMillisecondsParam: Params['fromEpochMilliseconds'][0]
+  ): Return['fromEpochMilliseconds'] {
+    const epochMilliseconds = ES.ToNumber(epochMillisecondsParam);
+    const epochNanoseconds = JSBI.multiply(JSBI.BigInt(epochMilliseconds), MILLION);
+    ES.ValidateEpochNanoseconds(epochNanoseconds);
+    return new Instant(epochNanoseconds);
+  }
+  static fromEpochMicroseconds(
+    epochMicrosecondsParam: Params['fromEpochMicroseconds'][0]
+  ): Return['fromEpochMicroseconds'] {
+    const epochMicroseconds = ES.ToBigInt(epochMicrosecondsParam);
+    const epochNanoseconds = JSBI.multiply(epochMicroseconds, THOUSAND);
+    ES.ValidateEpochNanoseconds(epochNanoseconds);
+    return new Instant(epochNanoseconds);
+  }
+  static fromEpochNanoseconds(
+    epochNanosecondsParam: Params['fromEpochNanoseconds'][0]
+  ): Return['fromEpochNanoseconds'] {
+    const epochNanoseconds = ES.ToBigInt(epochNanosecondsParam);
+    ES.ValidateEpochNanoseconds(epochNanoseconds);
+    return new Instant(epochNanoseconds);
+  }
+  static from(item: Params['from'][0]): Return['from'] {
+    if (ES.IsTemporalInstant(item)) {
+      return new Instant(GetSlot(item, EPOCHNANOSECONDS));
+    }
+    return ES.ToTemporalInstant(item);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalInstant(oneParam);
+    const two = ES.ToTemporalInstant(twoParam);
+    const oneNs = GetSlot(one, EPOCHNANOSECONDS);
+    const twoNs = GetSlot(two, EPOCHNANOSECONDS);
+    if (JSBI.lessThan(oneNs, twoNs)) return -1;
+    if (JSBI.greaterThan(oneNs, twoNs)) return 1;
+    return 0;
+  }
+}
+
+MakeIntrinsicClass(Instant, 'Temporal.Instant');

--- a/src/vendor/temporal/internaltypes.d.ts
+++ b/src/vendor/temporal/internaltypes.d.ts
@@ -1,0 +1,197 @@
+import type { Intl, Temporal } from '..';
+
+export type BuiltinCalendarId =
+  | 'iso8601'
+  | 'hebrew'
+  | 'islamic'
+  | 'islamic-umalqura'
+  | 'islamic-tbla'
+  | 'islamic-civil'
+  | 'islamic-rgsa'
+  | 'islamicc'
+  | 'persian'
+  | 'ethiopic'
+  | 'ethioaa'
+  | 'coptic'
+  | 'chinese'
+  | 'dangi'
+  | 'roc'
+  | 'indian'
+  | 'buddhist'
+  | 'japanese'
+  | 'gregory';
+
+export type AnyTemporalType =
+  | Temporal.Calendar
+  | Temporal.Duration
+  | Temporal.Instant
+  | Temporal.PlainDate
+  | Temporal.PlainDateTime
+  | Temporal.PlainMonthDay
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.TimeZone
+  | Temporal.ZonedDateTime;
+
+/*
+// unused, but uncomment if this is needed later
+export type AnyTemporalConstructor =
+  | typeof Temporal.Calendar
+  | typeof Temporal.Duration
+  | typeof Temporal.Instant
+  | typeof Temporal.PlainDate
+  | typeof Temporal.PlainDateTime
+  | typeof Temporal.PlainMonthDay
+  | typeof Temporal.PlainTime
+  | typeof Temporal.PlainYearMonth
+  | typeof Temporal.TimeZone
+  | typeof Temporal.ZonedDateTime;
+*/
+
+// Used in AnyTemporalLikeType
+// ts-prune-ignore-next
+type AllTemporalLikeTypes = [
+  Temporal.DurationLike,
+  Temporal.PlainDateLike,
+  Temporal.PlainDateTimeLike,
+  Temporal.PlainMonthDayLike,
+  Temporal.PlainTimeLike,
+  Temporal.PlainYearMonthLike,
+  Temporal.ZonedDateTimeLike
+];
+export type AnyTemporalLikeType = AllTemporalLikeTypes[number];
+
+// The properties below are all the names of Temporal properties that can be set with `with`.
+// `timeZone` and `calendar` are not on the list because they have special methods to set them.
+
+// Used in PrimitiveFieldsOf
+// ts-prune-ignore-next
+type PrimitivePropertyNames =
+  | 'year'
+  | 'month'
+  | 'monthCode'
+  | 'day'
+  | 'hour'
+  | 'minute'
+  | 'second'
+  | 'millisecond'
+  | 'microsecond'
+  | 'nanosecond'
+  | 'years'
+  | 'months'
+  | 'weeks'
+  | 'days'
+  | 'hours'
+  | 'minutes'
+  | 'seconds'
+  | 'milliseconds'
+  | 'microseconds'
+  | 'nanoseconds'
+  | 'era'
+  | 'eraYear'
+  | 'offset';
+
+export type PrimitiveFieldsOf<T extends AnyTemporalLikeType> = Pick<T, keyof T & PrimitivePropertyNames>;
+
+export type UnitSmallerThanOrEqualTo<T extends Temporal.DateTimeUnit> = T extends 'year'
+  ? Temporal.DateTimeUnit
+  : T extends 'month'
+  ? Exclude<Temporal.DateTimeUnit, 'year'>
+  : T extends 'week'
+  ? Exclude<Temporal.DateTimeUnit, 'year' | 'month'>
+  : T extends 'day'
+  ? Exclude<Temporal.DateTimeUnit, 'year' | 'month' | 'week'>
+  : T extends 'hour'
+  ? Temporal.TimeUnit
+  : T extends 'minute'
+  ? Exclude<Temporal.TimeUnit, 'hour'>
+  : T extends 'second'
+  ? Exclude<Temporal.TimeUnit, 'hour' | 'minute'>
+  : T extends 'millisecond'
+  ? Exclude<Temporal.TimeUnit, 'hour' | 'minute' | 'second'>
+  : T extends 'microsecond'
+  ? 'nanosecond'
+  : never;
+
+// ts-prune complains about the type definitions below, even though they're used
+// by exported types Not sure why and don't have time to investigate, so just
+// disabling the warnings for now.
+
+// ts-prune-ignore-next
+type Method = (...args: any) => any;
+// ts-prune-ignore-next
+type NonObjectKeys<T> = Exclude<keyof T, 'toString' | 'toLocaleString' | 'prototype'>;
+
+// ts-prune-ignore-next
+type MethodParams<Type extends new (...args: any) => any> = {
+  // constructor parameters
+  constructor: ConstructorParameters<Type>;
+} & {
+  // static method parameters
+  [Key in NonObjectKeys<Type>]: Type[Key] extends Method ? Parameters<Type[Key]> : never;
+} & {
+  // prototype method parameters
+  [Key in keyof InstanceType<Type>]: InstanceType<Type>[Key] extends Method
+    ? Parameters<InstanceType<Type>[Key]>
+    : never;
+};
+
+// ts-prune-ignore-next
+type MethodReturn<Type extends new (...args: any) => any> = {
+  constructor: InstanceType<Type>;
+} & {
+  [Key in NonObjectKeys<Type>]: Type[Key] extends Method ? ReturnType<Type[Key]> : Type[Key];
+} & {
+  [Key in keyof InstanceType<Type>]: InstanceType<Type>[Key] extends Method
+    ? ReturnType<InstanceType<Type>[Key]>
+    : InstanceType<Type>[Key];
+};
+
+/* Currently unused, but may use later
+type InterfaceReturn<Type> = {
+  [Key in keyof Type]: Type[Key] extends Method ? ReturnType<Type[Key]> : Type[Key];
+};
+*/
+
+// ts-prune-ignore-next
+type InterfaceParams<Type> = {
+  [Key in keyof Type]: Type[Key] extends Method ? Parameters<Type[Key]> : never;
+};
+
+// Parameters of each Temporal type. Examples:
+// * InstantParams['compare'][1] - static methods
+// * PlainDateParams['since'][0] - prototype methods
+// * DurationParams['constructor'][3] - constructors
+export interface ZonedDateTimeParams extends MethodParams<typeof Temporal.ZonedDateTime> {}
+export interface CalendarParams extends MethodParams<typeof Temporal.Calendar> {}
+export interface DurationParams extends MethodParams<typeof Temporal.Duration> {}
+export interface InstantParams extends MethodParams<typeof Temporal.Instant> {}
+export interface PlainDateParams extends MethodParams<typeof Temporal.PlainDate> {}
+export interface PlainDateTimeParams extends MethodParams<typeof Temporal.PlainDateTime> {}
+export interface PlainMonthDayParams extends MethodParams<typeof Temporal.PlainMonthDay> {}
+export interface PlainTimeParams extends MethodParams<typeof Temporal.PlainTime> {}
+export interface PlainYearMonthParams extends MethodParams<typeof Temporal.PlainYearMonth> {}
+export interface TimeZoneParams extends MethodParams<typeof Temporal.TimeZone> {}
+export interface ZonedDateTimeParams extends MethodParams<typeof Temporal.ZonedDateTime> {}
+
+// Return types of static or instance methods
+export interface ZonedDateTimeReturn extends MethodReturn<typeof Temporal.ZonedDateTime> {}
+export interface CalendarReturn extends MethodReturn<typeof Temporal.Calendar> {}
+export interface DurationReturn extends MethodReturn<typeof Temporal.Duration> {}
+export interface InstantReturn extends MethodReturn<typeof Temporal.Instant> {}
+export interface PlainDateReturn extends MethodReturn<typeof Temporal.PlainDate> {}
+export interface PlainDateTimeReturn extends MethodReturn<typeof Temporal.PlainDateTime> {}
+export interface PlainMonthDayReturn extends MethodReturn<typeof Temporal.PlainMonthDay> {}
+export interface PlainTimeReturn extends MethodReturn<typeof Temporal.PlainTime> {}
+export interface PlainYearMonthReturn extends MethodReturn<typeof Temporal.PlainYearMonth> {}
+export interface TimeZoneReturn extends MethodReturn<typeof Temporal.TimeZone> {}
+export interface ZonedDateTimeReturn extends MethodReturn<typeof Temporal.ZonedDateTime> {}
+
+export interface CalendarProtocolParams extends InterfaceParams<Temporal.CalendarProtocol> {}
+export interface TimeZoneProtocolParams extends InterfaceParams<Temporal.TimeZoneProtocol> {}
+// UNUSED, BUT MAY USE LATER
+// export interface TimeZoneProtocolReturn extends InterfaceReturn<Temporal.TimeZoneProtocol> {}
+// export interface CalendarProtocolReturn extends InterfaceReturn<Temporal.CalendarProtocol> {}
+
+export interface DateTimeFormatParams extends MethodParams<typeof Intl.DateTimeFormat> {}
+export interface DateTimeFormatReturn extends MethodReturn<typeof Intl.DateTimeFormat> {}

--- a/src/vendor/temporal/intl.ts
+++ b/src/vendor/temporal/intl.ts
@@ -1,0 +1,660 @@
+import * as ES from './ecmascript';
+import { GetIntrinsic } from './intrinsicclass';
+import {
+  GetSlot,
+  INSTANT,
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  CALENDAR,
+  TIME_ZONE
+} from './slots';
+import type { Temporal, Intl } from '..';
+import type { DateTimeFormatParams as Params, DateTimeFormatReturn as Return } from './internaltypes';
+
+const DATE = Symbol('date');
+const YM = Symbol('ym');
+const MD = Symbol('md');
+const TIME = Symbol('time');
+const DATETIME = Symbol('datetime');
+const ZONED = Symbol('zoneddatetime');
+const INST = Symbol('instant');
+const ORIGINAL = Symbol('original');
+const TZ_RESOLVED = Symbol('timezone');
+const TZ_GIVEN = Symbol('timezone-id-given');
+const CAL_ID = Symbol('calendar-id');
+const LOCALE = Symbol('locale');
+const OPTIONS = Symbol('options');
+
+const descriptor = <T extends (...args: any[]) => any>(value: T) => {
+  return {
+    value,
+    enumerable: true,
+    writable: false,
+    configurable: true
+  };
+};
+
+const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
+const ObjectAssign = Object.assign;
+const ObjectHasOwnProperty = Object.prototype.hasOwnProperty;
+const ReflectApply = Reflect.apply;
+
+interface CustomFormatters {
+  [DATE]: typeof dateAmend | globalThis.Intl.DateTimeFormat;
+  [YM]: typeof yearMonthAmend | typeof globalThis.Intl.DateTimeFormat;
+  [MD]: typeof monthDayAmend | typeof globalThis.Intl.DateTimeFormat;
+  [TIME]: typeof timeAmend | typeof globalThis.Intl.DateTimeFormat;
+  [DATETIME]: typeof datetimeAmend | typeof globalThis.Intl.DateTimeFormat;
+  [ZONED]: typeof zonedDateTimeAmend | typeof globalThis.Intl.DateTimeFormat;
+  [INST]: typeof instantAmend | typeof globalThis.Intl.DateTimeFormat;
+}
+
+interface PrivateProps extends CustomFormatters {
+  [ORIGINAL]: globalThis.Intl.DateTimeFormat;
+  [TZ_RESOLVED]: Temporal.TimeZoneProtocol | string;
+  [TZ_GIVEN]: Temporal.TimeZoneProtocol | string | null;
+  [CAL_ID]: globalThis.Intl.ResolvedDateTimeFormatOptions['calendar'];
+  [LOCALE]: globalThis.Intl.ResolvedDateTimeFormatOptions['locale'];
+  [OPTIONS]: Intl.DateTimeFormatOptions;
+}
+
+type OptionsAmenderFunction = (options: Intl.DateTimeFormatOptions) => globalThis.Intl.DateTimeFormatOptions;
+type FormatterOrAmender = globalThis.Intl.DateTimeFormat | OptionsAmenderFunction;
+
+// Construction of built-in Intl.DateTimeFormat objects is sloooooow,
+// so we'll only create those instances when we need them.
+// See https://bugs.chromium.org/p/v8/issues/detail?id=6528
+function getPropLazy<T extends PrivateProps, P extends keyof CustomFormatters>(
+  obj: T,
+  prop: P
+): globalThis.Intl.DateTimeFormat {
+  let val = obj[prop] as FormatterOrAmender;
+  if (typeof val === 'function') {
+    // If we get here, `val` is an "amender function". It will take the user's
+    // options and transform them into suitable options to be passed into the
+    // built-in (non-polyfill) Intl.DateTimeFormat constructor. These options
+    // will vary depending on the Temporal type, so that's why we store separate
+    // formatters in separate props on the polyfill's DateTimeFormat instances.
+    // The efficiency happens because we don't create an (expensive) formatter
+    // until the user calls toLocaleString for that Temporal type.
+    val = new IntlDateTimeFormat(obj[LOCALE], val(obj[OPTIONS]));
+    // TODO: can this be typed more cleanly?
+    (obj[prop] as globalThis.Intl.DateTimeFormat) = val;
+  }
+  return val;
+}
+
+// Similarly, lazy-init TimeZone instances.
+function getResolvedTimeZoneLazy(obj: PrivateProps) {
+  let val = obj[TZ_RESOLVED];
+  if (typeof val === 'string') {
+    val = ES.ToTemporalTimeZone(val);
+    obj[TZ_RESOLVED] = val;
+  }
+  return val;
+}
+
+type DateTimeFormatImpl = Intl.DateTimeFormat & PrivateProps;
+
+function DateTimeFormatImpl(
+  this: Intl.DateTimeFormat & PrivateProps,
+  locale: Params['constructor'][0] = undefined,
+  optionsParam: Params['constructor'][1] = {}
+) {
+  if (!(this instanceof DateTimeFormatImpl)) {
+    type Construct = new (
+      locale: Params['constructor'][0],
+      optionsParam: Params['constructor'][1]
+    ) => Intl.DateTimeFormat;
+    return new (DateTimeFormatImpl as unknown as Construct)(locale, optionsParam);
+  }
+  const hasOptions = typeof optionsParam !== 'undefined';
+  const options = hasOptions ? ObjectAssign({}, optionsParam) : {};
+  // TODO: remove type assertion after Temporal types land in TS lib types
+  const original = new IntlDateTimeFormat(locale, options as globalThis.Intl.DateTimeFormatOptions);
+  const ro = original.resolvedOptions();
+
+  // DateTimeFormat instances are very expensive to create. Therefore, they will
+  // be lazily created only when needed, using the locale and options provided.
+  // But it's possible for callers to mutate those inputs before lazy creation
+  // happens. For this reason, we clone the inputs instead of caching the
+  // original objects. To avoid the complexity of deep cloning any inputs that
+  // are themselves objects (e.g. the locales array, or options property values
+  // that will be coerced to strings), we rely on `resolvedOptions()` to do the
+  // coercion and cloning for us. Unfortunately, we can't just use the resolved
+  // options as-is because our options-amending logic adds additional fields if
+  // the user doesn't supply any unit fields like year, month, day, hour, etc.
+  // Therefore, we limit the properties in the clone to properties that were
+  // present in the original input.
+  if (hasOptions) {
+    const clonedResolved = ObjectAssign({}, ro);
+    for (const prop in clonedResolved) {
+      if (!ReflectApply(ObjectHasOwnProperty, options, [prop])) {
+        delete clonedResolved[prop as keyof typeof clonedResolved];
+      }
+    }
+    this[OPTIONS] = clonedResolved as Intl.DateTimeFormatOptions;
+  } else {
+    this[OPTIONS] = options;
+  }
+
+  this[TZ_GIVEN] = options.timeZone ? options.timeZone : null;
+  this[LOCALE] = ro.locale;
+  this[ORIGINAL] = original;
+  this[TZ_RESOLVED] = ro.timeZone;
+  this[CAL_ID] = ro.calendar;
+  this[DATE] = dateAmend;
+  this[YM] = yearMonthAmend;
+  this[MD] = monthDayAmend;
+  this[TIME] = timeAmend;
+  this[DATETIME] = datetimeAmend;
+  this[ZONED] = zonedDateTimeAmend;
+  this[INST] = instantAmend;
+  return undefined; // TODO: I couldn't satisfy TS without adding this. Is there another way?
+}
+
+Object.defineProperty(DateTimeFormatImpl, 'name', {
+  writable: true,
+  value: 'DateTimeFormat'
+});
+
+DateTimeFormatImpl.supportedLocalesOf = function (
+  locales: Params['supportedLocalesOf'][0],
+  options: Params['supportedLocalesOf'][1]
+) {
+  return IntlDateTimeFormat.supportedLocalesOf(locales, options as globalThis.Intl.DateTimeFormatOptions);
+};
+
+const propertyDescriptors: Partial<Record<keyof Intl.DateTimeFormat, PropertyDescriptor>> = {
+  resolvedOptions: descriptor(resolvedOptions),
+  format: descriptor(format),
+  formatRange: descriptor(formatRange)
+};
+
+if ('formatToParts' in IntlDateTimeFormat.prototype) {
+  propertyDescriptors.formatToParts = descriptor(formatToParts);
+}
+
+if ('formatRangeToParts' in IntlDateTimeFormat.prototype) {
+  propertyDescriptors.formatRangeToParts = descriptor(formatRangeToParts);
+}
+
+DateTimeFormatImpl.prototype = Object.create(IntlDateTimeFormat.prototype, propertyDescriptors);
+
+// Ensure that the prototype isn't writeable.
+Object.defineProperty(DateTimeFormatImpl, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+export const DateTimeFormat = DateTimeFormatImpl as unknown as typeof Intl.DateTimeFormat;
+
+function resolvedOptions(this: DateTimeFormatImpl): Return['resolvedOptions'] {
+  return this[ORIGINAL].resolvedOptions();
+}
+
+function adjustFormatterTimeZone(
+  formatter: globalThis.Intl.DateTimeFormat,
+  timeZone?: string
+): globalThis.Intl.DateTimeFormat {
+  if (!timeZone) return formatter;
+  const options = formatter.resolvedOptions();
+  if (options.timeZone === timeZone) return formatter;
+  // Existing Intl isn't typed to accept Temporal-specific options and the lib
+  // types for resolved options are less restrictive than the types for options.
+  // For example, `weekday` is
+  // `'long' | 'short' | 'narrow'` in options but `string` in resolved options.
+  // TODO: investigate why, and file an issue against TS if it's a bug.
+  if ((options as any)['dateStyle'] || (options as any)['timeStyle']) {
+    // Unfortunately, Safari's resolvedOptions include parameters that will
+    // cause errors at runtime if passed along with
+    // dateStyle or timeStyle options as per
+    // https://tc39.es/proposal-intl-datetime-style/#table-datetimeformat-components.
+    // This has been fixed in newer versions of Safari:
+    // https://bugs.webkit.org/show_bug.cgi?id=231041
+    delete options['weekday'];
+    delete options['era'];
+    delete options['year'];
+    delete options['month'];
+    delete options['day'];
+    delete options['hour'];
+    delete options['minute'];
+    delete options['second'];
+    delete options['timeZoneName'];
+    delete (options as any)['hourCycle'];
+    delete options['hour12'];
+    delete (options as any)['dayPeriod'];
+  }
+  return new IntlDateTimeFormat(options.locale, { ...(options as globalThis.Intl.DateTimeFormatOptions), timeZone });
+}
+
+// TODO: investigate why there's a rest parameter here. Does this function really need to accept extra params?
+// And if so, why doesn't formatRange also accept extra params?
+function format<P extends readonly unknown[]>(
+  this: DateTimeFormatImpl,
+  datetime: Params['format'][0],
+  ...rest: P
+): Return['format'] {
+  let { instant, formatter, timeZone } = extractOverrides(datetime, this);
+  if (instant && formatter) {
+    formatter = adjustFormatterTimeZone(formatter, timeZone);
+    return formatter.format(instant.epochMilliseconds);
+  }
+  // Support spreading additional args for future expansion of this Intl method
+  type AllowExtraParams = (datetime: Parameters<Intl.DateTimeFormat['format']>[0], ...rest: P) => Return['format'];
+  return (this[ORIGINAL].format as unknown as AllowExtraParams)(datetime, ...rest);
+}
+
+function formatToParts<P extends readonly unknown[]>(
+  this: DateTimeFormatImpl,
+  datetime: Params['formatToParts'][0],
+  ...rest: P
+): Return['formatToParts'] {
+  let { instant, formatter, timeZone } = extractOverrides(datetime, this);
+  if (instant && formatter) {
+    formatter = adjustFormatterTimeZone(formatter, timeZone);
+    return formatter.formatToParts(instant.epochMilliseconds);
+  }
+  // Support spreading additional args for future expansion of this Intl method
+  type AllowExtraParams = (
+    datetime: Parameters<Intl.DateTimeFormat['formatToParts']>[0],
+    ...rest: P
+  ) => Return['formatToParts'];
+  return (this[ORIGINAL].formatToParts as unknown as AllowExtraParams)(datetime, ...rest);
+}
+
+function formatRange(this: DateTimeFormatImpl, a: Params['formatRange'][0], b: Params['formatRange'][1]) {
+  if (isTemporalObject(a) || isTemporalObject(b)) {
+    if (!sameTemporalType(a, b)) {
+      throw new TypeError('Intl.DateTimeFormat.formatRange accepts two values of the same type');
+    }
+    const {
+      instant: aa,
+      formatter: aformatter,
+      timeZone: atz
+    } = extractOverrides(a as unknown as TypesWithToLocaleString, this);
+    const {
+      instant: bb,
+      formatter: bformatter,
+      timeZone: btz
+    } = extractOverrides(b as unknown as TypesWithToLocaleString, this);
+    if (atz && btz && atz !== btz) {
+      throw new RangeError('cannot format range between different time zones');
+    }
+    if (aa && bb && aformatter && bformatter && aformatter === bformatter) {
+      const formatter = adjustFormatterTimeZone(aformatter, atz);
+      // TODO: Remove type assertion after this method lands in TS lib types
+      return (formatter as Intl.DateTimeFormat).formatRange(aa.epochMilliseconds, bb.epochMilliseconds);
+    }
+  }
+  // TODO: Remove type assertion after this method lands in TS lib types
+  return (this[ORIGINAL] as Intl.DateTimeFormat).formatRange(a, b);
+}
+
+function formatRangeToParts(
+  this: DateTimeFormatImpl,
+  a: Params['formatRangeToParts'][0],
+  b: Params['formatRangeToParts'][1]
+) {
+  if (isTemporalObject(a) || isTemporalObject(b)) {
+    if (!sameTemporalType(a, b)) {
+      throw new TypeError('Intl.DateTimeFormat.formatRangeToParts accepts two values of the same type');
+    }
+    const { instant: aa, formatter: aformatter, timeZone: atz } = extractOverrides(a, this);
+    const { instant: bb, formatter: bformatter, timeZone: btz } = extractOverrides(b, this);
+    if (atz && btz && atz !== btz) {
+      throw new RangeError('cannot format range between different time zones');
+    }
+    if (aa && bb && aformatter && bformatter && aformatter === bformatter) {
+      const formatter = adjustFormatterTimeZone(aformatter, atz);
+      // TODO: Remove type assertion after this method lands in TS lib types
+      return (formatter as Intl.DateTimeFormat).formatRangeToParts(aa.epochMilliseconds, bb.epochMilliseconds);
+    }
+  }
+  // TODO: Remove type assertion after this method lands in TS lib types
+  return (this[ORIGINAL] as Intl.DateTimeFormat).formatRangeToParts(a, b);
+}
+
+// "false" is a signal to delete this option
+type MaybeFalseOptions = {
+  [K in keyof Intl.DateTimeFormatOptions]?: Intl.DateTimeFormatOptions[K] | false;
+};
+
+function amend(optionsParam: Intl.DateTimeFormatOptions = {}, amended: MaybeFalseOptions = {}) {
+  const options = ObjectAssign({}, optionsParam);
+  for (const opt of [
+    'year',
+    'month',
+    'day',
+    'hour',
+    'minute',
+    'second',
+    'weekday',
+    'dayPeriod',
+    'timeZoneName',
+    'dateStyle',
+    'timeStyle'
+  ] as const) {
+    // TODO: can this be typed more cleanly?
+    type OptionMaybeFalse = typeof options[typeof opt] | false;
+    (options[opt] as OptionMaybeFalse) = opt in amended ? amended[opt] : options[opt];
+    if ((options[opt] as OptionMaybeFalse) === false || options[opt] === undefined) delete options[opt];
+  }
+  return options as globalThis.Intl.DateTimeFormatOptions;
+}
+
+type OptionsType<T extends TypesWithToLocaleString> = NonNullable<Parameters<T['toLocaleString']>[1]>;
+
+function timeAmend(optionsParam: OptionsType<Temporal.PlainTime>) {
+  let options = amend(optionsParam, {
+    year: false,
+    month: false,
+    day: false,
+    weekday: false,
+    timeZoneName: false,
+    dateStyle: false
+  });
+  if (!hasTimeOptions(options)) {
+    options = ObjectAssign({}, options, {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+  }
+  return options;
+}
+
+function yearMonthAmend(optionsParam: OptionsType<Temporal.PlainYearMonth>) {
+  let options = amend(optionsParam, {
+    day: false,
+    hour: false,
+    minute: false,
+    second: false,
+    weekday: false,
+    dayPeriod: false,
+    timeZoneName: false,
+    dateStyle: false,
+    timeStyle: false
+  });
+  if (!('year' in options || 'month' in options)) {
+    options = ObjectAssign(options, { year: 'numeric', month: 'numeric' });
+  }
+  return options;
+}
+
+function monthDayAmend(optionsParam: OptionsType<Temporal.PlainMonthDay>) {
+  let options = amend(optionsParam, {
+    year: false,
+    hour: false,
+    minute: false,
+    second: false,
+    weekday: false,
+    dayPeriod: false,
+    timeZoneName: false,
+    dateStyle: false,
+    timeStyle: false
+  });
+  if (!('month' in options || 'day' in options)) {
+    options = ObjectAssign({}, options, { month: 'numeric', day: 'numeric' });
+  }
+  return options;
+}
+
+function dateAmend(optionsParam: OptionsType<Temporal.PlainDate>) {
+  let options = amend(optionsParam, {
+    hour: false,
+    minute: false,
+    second: false,
+    dayPeriod: false,
+    timeZoneName: false,
+    timeStyle: false
+  });
+  if (!hasDateOptions(options)) {
+    options = ObjectAssign({}, options, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric'
+    });
+  }
+  return options;
+}
+
+function datetimeAmend(optionsParam: OptionsType<Temporal.PlainDateTime>) {
+  let options = amend(optionsParam, { timeZoneName: false });
+  if (!hasTimeOptions(options) && !hasDateOptions(options)) {
+    options = ObjectAssign({}, options, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+  }
+  return options;
+}
+
+function zonedDateTimeAmend(optionsParam: OptionsType<Temporal.PlainTime>) {
+  let options = optionsParam;
+  if (!hasTimeOptions(options) && !hasDateOptions(options)) {
+    options = ObjectAssign({}, options, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+    if (options.timeZoneName === undefined) options.timeZoneName = 'short';
+  }
+  return options;
+}
+
+function instantAmend(optionsParam: OptionsType<Temporal.Instant>) {
+  let options = optionsParam;
+  if (!hasTimeOptions(options) && !hasDateOptions(options)) {
+    options = ObjectAssign({}, options, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+  }
+  return options;
+}
+
+function hasDateOptions(options: OptionsType<TypesWithToLocaleString>) {
+  return 'year' in options || 'month' in options || 'day' in options || 'weekday' in options || 'dateStyle' in options;
+}
+
+function hasTimeOptions(options: OptionsType<TypesWithToLocaleString>) {
+  return (
+    'hour' in options || 'minute' in options || 'second' in options || 'timeStyle' in options || 'dayPeriod' in options
+  );
+}
+
+function isTemporalObject(
+  obj: unknown
+): obj is
+  | Temporal.PlainDate
+  | Temporal.PlainTime
+  | Temporal.PlainDateTime
+  | Temporal.ZonedDateTime
+  | Temporal.PlainYearMonth
+  | Temporal.PlainMonthDay
+  | Temporal.Instant {
+  return (
+    ES.IsTemporalDate(obj) ||
+    ES.IsTemporalTime(obj) ||
+    ES.IsTemporalDateTime(obj) ||
+    ES.IsTemporalZonedDateTime(obj) ||
+    ES.IsTemporalYearMonth(obj) ||
+    ES.IsTemporalMonthDay(obj) ||
+    ES.IsTemporalInstant(obj)
+  );
+}
+
+function sameTemporalType(x: unknown, y: unknown) {
+  if (!isTemporalObject(x) || !isTemporalObject(y)) return false;
+  if (ES.IsTemporalTime(x) && !ES.IsTemporalTime(y)) return false;
+  if (ES.IsTemporalDate(x) && !ES.IsTemporalDate(y)) return false;
+  if (ES.IsTemporalDateTime(x) && !ES.IsTemporalDateTime(y)) return false;
+  if (ES.IsTemporalZonedDateTime(x) && !ES.IsTemporalZonedDateTime(y)) return false;
+  if (ES.IsTemporalYearMonth(x) && !ES.IsTemporalYearMonth(y)) return false;
+  if (ES.IsTemporalMonthDay(x) && !ES.IsTemporalMonthDay(y)) return false;
+  if (ES.IsTemporalInstant(x) && !ES.IsTemporalInstant(y)) return false;
+  return true;
+}
+
+type TypesWithToLocaleString =
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.PlainMonthDay
+  | Temporal.ZonedDateTime
+  | Temporal.Instant;
+
+function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormatImpl) {
+  const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+
+  if (ES.IsTemporalTime(temporalObj)) {
+    const hour = GetSlot(temporalObj, ISO_HOUR);
+    const minute = GetSlot(temporalObj, ISO_MINUTE);
+    const second = GetSlot(temporalObj, ISO_SECOND);
+    const millisecond = GetSlot(temporalObj, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalObj, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalObj, ISO_NANOSECOND);
+    const datetime = new DateTime(1970, 1, 1, hour, minute, second, millisecond, microsecond, nanosecond, main[CAL_ID]);
+    return {
+      instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
+      formatter: getPropLazy(main, TIME)
+    };
+  }
+
+  if (ES.IsTemporalYearMonth(temporalObj)) {
+    const isoYear = GetSlot(temporalObj, ISO_YEAR);
+    const isoMonth = GetSlot(temporalObj, ISO_MONTH);
+    const referenceISODay = GetSlot(temporalObj, ISO_DAY);
+    const calendar = ES.ToString(GetSlot(temporalObj, CALENDAR));
+    if (calendar !== main[CAL_ID]) {
+      throw new RangeError(
+        `cannot format PlainYearMonth with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
+      );
+    }
+    const datetime = new DateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
+    return {
+      instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
+      formatter: getPropLazy(main, YM)
+    };
+  }
+
+  if (ES.IsTemporalMonthDay(temporalObj)) {
+    const referenceISOYear = GetSlot(temporalObj, ISO_YEAR);
+    const isoMonth = GetSlot(temporalObj, ISO_MONTH);
+    const isoDay = GetSlot(temporalObj, ISO_DAY);
+    const calendar = ES.ToString(GetSlot(temporalObj, CALENDAR));
+    if (calendar !== main[CAL_ID]) {
+      throw new RangeError(
+        `cannot format PlainMonthDay with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
+      );
+    }
+    const datetime = new DateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
+    return {
+      instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
+      formatter: getPropLazy(main, MD)
+    };
+  }
+
+  if (ES.IsTemporalDate(temporalObj)) {
+    const isoYear = GetSlot(temporalObj, ISO_YEAR);
+    const isoMonth = GetSlot(temporalObj, ISO_MONTH);
+    const isoDay = GetSlot(temporalObj, ISO_DAY);
+    const calendar = ES.ToString(GetSlot(temporalObj, CALENDAR));
+    if (calendar !== 'iso8601' && calendar !== main[CAL_ID]) {
+      throw new RangeError(`cannot format PlainDate with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`);
+    }
+    const datetime = new DateTime(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, main[CAL_ID]);
+    return {
+      instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
+      formatter: getPropLazy(main, DATE)
+    };
+  }
+
+  if (ES.IsTemporalDateTime(temporalObj)) {
+    const isoYear = GetSlot(temporalObj, ISO_YEAR);
+    const isoMonth = GetSlot(temporalObj, ISO_MONTH);
+    const isoDay = GetSlot(temporalObj, ISO_DAY);
+    const hour = GetSlot(temporalObj, ISO_HOUR);
+    const minute = GetSlot(temporalObj, ISO_MINUTE);
+    const second = GetSlot(temporalObj, ISO_SECOND);
+    const millisecond = GetSlot(temporalObj, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalObj, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalObj, ISO_NANOSECOND);
+    const calendar = ES.ToString(GetSlot(temporalObj, CALENDAR));
+    if (calendar !== 'iso8601' && calendar !== main[CAL_ID]) {
+      throw new RangeError(
+        `cannot format PlainDateTime with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
+      );
+    }
+    let datetime = temporalObj;
+    if (calendar === 'iso8601') {
+      datetime = new DateTime(
+        isoYear,
+        isoMonth,
+        isoDay,
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond,
+        main[CAL_ID]
+      );
+    }
+    return {
+      instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
+      formatter: getPropLazy(main, DATETIME)
+    };
+  }
+
+  if (ES.IsTemporalZonedDateTime(temporalObj)) {
+    const calendar = ES.ToString(GetSlot(temporalObj, CALENDAR));
+    if (calendar !== 'iso8601' && calendar !== main[CAL_ID]) {
+      throw new RangeError(
+        `cannot format ZonedDateTime with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
+      );
+    }
+
+    const timeZone = GetSlot(temporalObj, TIME_ZONE);
+    const objTimeZone = ES.ToString(timeZone);
+    if (main[TZ_GIVEN] && main[TZ_GIVEN] !== objTimeZone) {
+      throw new RangeError(`timeZone option ${main[TZ_GIVEN]} doesn't match actual time zone ${objTimeZone}`);
+    }
+
+    return {
+      instant: GetSlot(temporalObj, INSTANT),
+      formatter: getPropLazy(main, ZONED),
+      timeZone: objTimeZone
+    };
+  }
+
+  if (ES.IsTemporalInstant(temporalObj)) {
+    return {
+      instant: temporalObj,
+      formatter: getPropLazy(main, INST)
+    };
+  }
+
+  return {};
+}

--- a/src/vendor/temporal/intrinsicclass.ts
+++ b/src/vendor/temporal/intrinsicclass.ts
@@ -1,0 +1,143 @@
+import type JSBI from 'jsbi';
+import type { Temporal } from '..';
+
+import { DEBUG } from './debug';
+
+type OmitConstructor<T> = { [P in keyof T as T[P] extends new (...args: any[]) => any ? P : never]: T[P] };
+
+type TemporalIntrinsics = Omit<typeof Temporal, 'Now' | 'Instant' | 'ZonedDateTime'> & {
+  Instant: OmitConstructor<Temporal.Instant> &
+    (new (epochNanoseconds: JSBI) => Temporal.Instant) & { prototype: typeof Temporal.Instant.prototype };
+  ZonedDateTime: OmitConstructor<Temporal.ZonedDateTime> &
+    (new (
+      epochNanoseconds: JSBI,
+      timeZone: Temporal.TimeZoneProtocol | string,
+      calendar?: Temporal.CalendarProtocol | string
+    ) => Temporal.ZonedDateTime) & {
+      prototype: typeof Temporal.ZonedDateTime.prototype;
+      from: typeof Temporal.ZonedDateTime.from;
+      compare: typeof Temporal.ZonedDateTime.compare;
+    };
+};
+type TemporalIntrinsicRegistrations = {
+  [key in keyof TemporalIntrinsics as `Temporal.${key}`]: TemporalIntrinsics[key];
+};
+type TemporalIntrinsicPrototypeRegistrations = {
+  [key in keyof TemporalIntrinsics as `Temporal.${key}.prototype`]: TemporalIntrinsics[key]['prototype'];
+};
+type TemporalIntrinsicRegisteredKeys = {
+  [key in keyof TemporalIntrinsicRegistrations as `%${key}%`]: TemporalIntrinsicRegistrations[key];
+};
+type TemporalIntrinsicPrototypeRegisteredKeys = {
+  [key in keyof TemporalIntrinsicPrototypeRegistrations as `%${key}%`]: TemporalIntrinsicPrototypeRegistrations[key];
+};
+
+interface StandaloneIntrinsics {
+  'Temporal.Calendar.from': typeof Temporal.Calendar.from;
+}
+type RegisteredStandaloneIntrinsics = { [key in keyof StandaloneIntrinsics as `%${key}%`]: StandaloneIntrinsics[key] };
+const INTRINSICS = {} as TemporalIntrinsicRegisteredKeys &
+  TemporalIntrinsicPrototypeRegisteredKeys &
+  RegisteredStandaloneIntrinsics;
+
+type customFormatFunction<T> = (
+  this: T,
+  depth: number,
+  options: { stylize: (value: unknown, type: 'number' | 'special') => string }
+) => string;
+const customUtilInspectFormatters: Partial<{
+  [key in keyof TemporalIntrinsicRegistrations]: customFormatFunction<
+    InstanceType<TemporalIntrinsicRegistrations[key]>
+  >;
+}> = {
+  ['Temporal.Duration'](depth, options) {
+    const descr = options.stylize(`${this[Symbol.toStringTag]} <${this}>`, 'special');
+    if (depth < 1) return descr;
+    const entries = [];
+    for (const prop of [
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ] as const) {
+      if (this[prop] !== 0) entries.push(`  ${prop}: ${options.stylize(this[prop], 'number')}`);
+    }
+    return descr + ' {\n' + entries.join(',\n') + '\n}';
+  }
+};
+
+type InspectFormatterOptions = { stylize: (str: string, styleType: string) => string };
+function defaultUtilInspectFormatter(this: any, depth: number, options: InspectFormatterOptions) {
+  return options.stylize(`${this[Symbol.toStringTag]} <${this}>`, 'special');
+}
+
+export function MakeIntrinsicClass(
+  Class: TemporalIntrinsicRegistrations[typeof name],
+  name: keyof TemporalIntrinsicRegistrations
+) {
+  Object.defineProperty(Class.prototype, Symbol.toStringTag, {
+    value: name,
+    writable: false,
+    enumerable: false,
+    configurable: true
+  });
+  if (DEBUG) {
+    Object.defineProperty(Class.prototype, Symbol.for('nodejs.util.inspect.custom'), {
+      value: customUtilInspectFormatters[name] || defaultUtilInspectFormatter,
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+  }
+  for (const prop of Object.getOwnPropertyNames(Class)) {
+    // we know that `prop` is present, so the descriptor is never undefined
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const desc = Object.getOwnPropertyDescriptor(Class, prop)!;
+    if (!desc.configurable || !desc.enumerable) continue;
+    desc.enumerable = false;
+    Object.defineProperty(Class, prop, desc);
+  }
+  for (const prop of Object.getOwnPropertyNames(Class.prototype)) {
+    // we know that `prop` is present, so the descriptor is never undefined
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const desc = Object.getOwnPropertyDescriptor(Class.prototype, prop)!;
+    if (!desc.configurable || !desc.enumerable) continue;
+    desc.enumerable = false;
+    Object.defineProperty(Class.prototype, prop, desc);
+  }
+
+  DefineIntrinsic(name, Class);
+  DefineIntrinsic(`${name}.prototype`, Class.prototype);
+}
+
+type IntrinsicDefinitionKeys =
+  | keyof TemporalIntrinsicRegistrations
+  | keyof TemporalIntrinsicPrototypeRegistrations
+  | keyof StandaloneIntrinsics;
+export function DefineIntrinsic<KeyT extends keyof TemporalIntrinsicRegistrations>(
+  name: KeyT,
+  value: TemporalIntrinsicRegistrations[KeyT]
+): void;
+export function DefineIntrinsic<KeyT extends keyof TemporalIntrinsicPrototypeRegistrations>(
+  name: KeyT,
+  value: TemporalIntrinsicPrototypeRegistrations[KeyT]
+): void;
+export function DefineIntrinsic<KeyT extends keyof StandaloneIntrinsics>(
+  name: KeyT,
+  value: StandaloneIntrinsics[KeyT]
+): void;
+export function DefineIntrinsic<KeyT>(name: KeyT, value: never): void;
+export function DefineIntrinsic<KeyT extends IntrinsicDefinitionKeys>(name: KeyT, value: unknown): void {
+  const key: `%${IntrinsicDefinitionKeys}%` = `%${name}%`;
+  if (INTRINSICS[key] !== undefined) throw new Error(`intrinsic ${name} already exists`);
+  INTRINSICS[key] = value;
+}
+export function GetIntrinsic<KeyT extends keyof typeof INTRINSICS>(intrinsic: KeyT): typeof INTRINSICS[KeyT] {
+  return INTRINSICS[intrinsic];
+}

--- a/src/vendor/temporal/legacydate.ts
+++ b/src/vendor/temporal/legacydate.ts
@@ -1,0 +1,11 @@
+import { Instant } from './instant';
+
+import JSBI from 'jsbi';
+import * as ES from './ecmascript';
+import { MILLION } from './ecmascript';
+
+export function toTemporalInstant(this: Date) {
+  // Observable access to valueOf is not correct here, but unavoidable
+  const epochNanoseconds = JSBI.multiply(JSBI.BigInt(+this), MILLION);
+  return new Instant(ES.ToBigInt(epochNanoseconds));
+}

--- a/src/vendor/temporal/now.ts
+++ b/src/vendor/temporal/now.ts
@@ -1,0 +1,59 @@
+import * as ES from './ecmascript';
+import { GetIntrinsic } from './intrinsicclass';
+import type { Temporal } from '..';
+
+const instant: typeof Temporal.Now['instant'] = () => {
+  const Instant = GetIntrinsic('%Temporal.Instant%');
+  return new Instant(ES.SystemUTCEpochNanoSeconds());
+};
+const plainDateTime: typeof Temporal.Now['plainDateTime'] = (calendarLike, temporalTimeZoneLike = timeZone()) => {
+  const tZ = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const calendar = ES.ToTemporalCalendar(calendarLike);
+  const inst = instant();
+  return ES.BuiltinTimeZoneGetPlainDateTimeFor(tZ, inst, calendar);
+};
+const plainDateTimeISO: typeof Temporal.Now['plainDateTimeISO'] = (temporalTimeZoneLike = timeZone()) => {
+  const tZ = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const calendar = ES.GetISO8601Calendar();
+  const inst = instant();
+  return ES.BuiltinTimeZoneGetPlainDateTimeFor(tZ, inst, calendar);
+};
+const zonedDateTime: typeof Temporal.Now['zonedDateTime'] = (calendarLike, temporalTimeZoneLike = timeZone()) => {
+  const tZ = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const calendar = ES.ToTemporalCalendar(calendarLike);
+  return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), tZ, calendar);
+};
+const zonedDateTimeISO: typeof Temporal.Now['zonedDateTimeISO'] = (temporalTimeZoneLike = timeZone()) => {
+  return zonedDateTime(ES.GetISO8601Calendar(), temporalTimeZoneLike);
+};
+const plainDate: typeof Temporal.Now['plainDate'] = (calendarLike, temporalTimeZoneLike = timeZone()) => {
+  return ES.TemporalDateTimeToDate(plainDateTime(calendarLike, temporalTimeZoneLike));
+};
+const plainDateISO: typeof Temporal.Now['plainDateISO'] = (temporalTimeZoneLike = timeZone()) => {
+  return ES.TemporalDateTimeToDate(plainDateTimeISO(temporalTimeZoneLike));
+};
+const plainTimeISO: typeof Temporal.Now['plainTimeISO'] = (temporalTimeZoneLike = timeZone()) => {
+  return ES.TemporalDateTimeToTime(plainDateTimeISO(temporalTimeZoneLike));
+};
+const timeZone: typeof Temporal.Now['timeZone'] = () => {
+  return ES.SystemTimeZone();
+};
+
+export const Now: typeof Temporal.Now = {
+  instant,
+  plainDateTime,
+  plainDateTimeISO,
+  plainDate,
+  plainDateISO,
+  plainTimeISO,
+  timeZone,
+  zonedDateTime,
+  zonedDateTimeISO,
+  [Symbol.toStringTag]: 'Temporal.Now'
+};
+Object.defineProperty(Now, Symbol.toStringTag, {
+  value: 'Temporal.Now',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/src/vendor/temporal/plaindate.ts
+++ b/src/vendor/temporal/plaindate.ts
@@ -1,0 +1,324 @@
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+import {
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  CALENDAR,
+  EPOCHNANOSECONDS,
+  GetSlot
+} from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { PlainDateParams as Params, PlainDateReturn as Return } from './internaltypes';
+
+export class PlainDate implements Temporal.PlainDate {
+  constructor(
+    isoYearParam: Params['constructor'][0],
+    isoMonthParam: Params['constructor'][1],
+    isoDayParam: Params['constructor'][2],
+    calendarParam: Params['constructor'][3] = ES.GetISO8601Calendar()
+  ) {
+    const isoYear = ES.ToIntegerThrowOnInfinity(isoYearParam);
+    const isoMonth = ES.ToIntegerThrowOnInfinity(isoMonthParam);
+    const isoDay = ES.ToIntegerThrowOnInfinity(isoDayParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       be rejected by RejectISODate in CreateTemporalDateSlots. This check
+    //       exists only to improve the error message.
+    if (arguments.length < 3) {
+      throw new RangeError('missing argument: isoYear, isoMonth and isoDay are required');
+    }
+
+    ES.CreateTemporalDateSlots(this, isoYear, isoMonth, isoDay, calendar);
+  }
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+  get era(): Return['era'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEra(GetSlot(this, CALENDAR), this);
+  }
+  get eraYear(): Return['eraYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEraYear(GetSlot(this, CALENDAR), this);
+  }
+  get year(): Return['year'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYear(GetSlot(this, CALENDAR), this);
+  }
+  get month(): Return['month'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonth(GetSlot(this, CALENDAR), this);
+  }
+  get monthCode(): Return['monthCode'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthCode(GetSlot(this, CALENDAR), this);
+  }
+  get day(): Return['day'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+  }
+  get dayOfWeek(): Return['dayOfWeek'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), this);
+  }
+  get dayOfYear(): Return['dayOfYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), this);
+  }
+  get weekOfYear(): Return['weekOfYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), this);
+  }
+  get daysInWeek(): Return['daysInWeek'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), this);
+  }
+  get daysInMonth(): Return['daysInMonth'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), this);
+  }
+  get daysInYear(): Return['daysInYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), this);
+  }
+  get monthsInYear(): Return['monthsInYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), this);
+  }
+  get inLeapYear(): Return['inLeapYear'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), this);
+  }
+  with(temporalDateLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalDateLike)) {
+      throw new TypeError('invalid argument');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalDateLike);
+
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year'] as const);
+    const props = ES.PrepareTemporalFields(temporalDateLike, fieldNames, 'partial');
+    if (!props) {
+      throw new TypeError('invalid date-like');
+    }
+    let fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    fields = ES.CalendarMergeFields(calendar, fields, props);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+
+    const options = ES.GetOptionsObject(optionsParam);
+
+    return ES.CalendarDateFromFields(calendar, fields, options);
+  }
+  withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    return new PlainDate(GetSlot(this, ISO_YEAR), GetSlot(this, ISO_MONTH), GetSlot(this, ISO_DAY), calendar);
+  }
+  add(temporalDurationLike: Params['add'][0], optionsParam: Params['add'][1] = undefined): Return['add'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+
+    const duration = ES.ToTemporalDuration(temporalDurationLike);
+    const options = ES.GetOptionsObject(optionsParam);
+
+    return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
+  }
+  subtract(
+    temporalDurationLike: Params['subtract'][0],
+    optionsParam: Params['subtract'][1] = undefined
+  ): Return['subtract'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+
+    const duration = ES.CreateNegatedTemporalDuration(ES.ToTemporalDuration(temporalDurationLike));
+    const options = ES.GetOptionsObject(optionsParam);
+
+    return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainDate('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainDate('since', this, other, options);
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalDate(otherParam);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return false;
+    }
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const showCalendar = ES.ToShowCalendarOption(options);
+    return ES.TemporalDateToString(this, showCalendar);
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateToString(this);
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.PlainDate');
+  }
+  toPlainDateTime(temporalTimeParam: Params['toPlainDateTime'][0] = undefined): Return['toPlainDateTime'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    const calendar = GetSlot(this, CALENDAR);
+
+    if (temporalTimeParam === undefined) return ES.CreateTemporalDateTime(year, month, day, 0, 0, 0, 0, 0, 0, calendar);
+
+    const temporalTime = ES.ToTemporalTime(temporalTimeParam);
+    const hour = GetSlot(temporalTime, ISO_HOUR);
+    const minute = GetSlot(temporalTime, ISO_MINUTE);
+    const second = GetSlot(temporalTime, ISO_SECOND);
+    const millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+
+    let timeZone, temporalTime;
+    if (ES.IsObject(item)) {
+      const timeZoneLike = item.timeZone;
+      if (timeZoneLike === undefined) {
+        // The cast below is needed because it's possible here for
+        // `timeZoneLike` here to be `{ plainTime: Temporal.PlainTimeLike }`,
+        // not a TimeZoneProtocol.
+        // TODO: should we check for that shape to improve on the (bad) error
+        // message that the caller will get from ToTemporalTimeZone?
+        timeZone = ES.ToTemporalTimeZone(item as Temporal.TimeZoneProtocol);
+      } else {
+        timeZone = ES.ToTemporalTimeZone(timeZoneLike);
+        type TimeZoneAndPlainTimeProps = Exclude<typeof item, Temporal.TimeZoneProtocol>;
+        temporalTime = (item as TimeZoneAndPlainTimeProps).plainTime;
+      }
+    } else {
+      timeZone = ES.ToTemporalTimeZone(item);
+    }
+
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    const calendar = GetSlot(this, CALENDAR);
+
+    let hour = 0,
+      minute = 0,
+      second = 0,
+      millisecond = 0,
+      microsecond = 0,
+      nanosecond = 0;
+    if (temporalTime !== undefined) {
+      temporalTime = ES.ToTemporalTime(temporalTime);
+      hour = GetSlot(temporalTime, ISO_HOUR);
+      minute = GetSlot(temporalTime, ISO_MINUTE);
+      second = GetSlot(temporalTime, ISO_SECOND);
+      millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+      microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+      nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+    }
+
+    const dt = ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  toPlainYearMonth(): Return['toPlainYearMonth'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
+  }
+  toPlainMonthDay(): Return['toPlainMonthDay'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      isoDay: GetSlot(this, ISO_DAY),
+      isoMonth: GetSlot(this, ISO_MONTH),
+      isoYear: GetSlot(this, ISO_YEAR)
+    };
+  }
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    if (ES.IsTemporalDate(item)) {
+      ES.ToTemporalOverflow(options); // validate and ignore
+      return ES.CreateTemporalDate(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    return ES.ToTemporalDate(item, options);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalDate(oneParam);
+    const two = ES.ToTemporalDate(twoParam);
+    return ES.CompareISODate(
+      GetSlot(one, ISO_YEAR),
+      GetSlot(one, ISO_MONTH),
+      GetSlot(one, ISO_DAY),
+      GetSlot(two, ISO_YEAR),
+      GetSlot(two, ISO_MONTH),
+      GetSlot(two, ISO_DAY)
+    );
+  }
+}
+
+MakeIntrinsicClass(PlainDate, 'Temporal.PlainDate');

--- a/src/vendor/temporal/plaindatetime.ts
+++ b/src/vendor/temporal/plaindatetime.ts
@@ -1,0 +1,481 @@
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+
+import {
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  CALENDAR,
+  EPOCHNANOSECONDS,
+  GetSlot
+} from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
+
+export class PlainDateTime implements Temporal.PlainDateTime {
+  constructor(
+    isoYearParam: Params['constructor'][0],
+    isoMonthParam: Params['constructor'][1],
+    isoDayParam: Params['constructor'][2],
+    hourParam: Params['constructor'][3] = 0,
+    minuteParam: Params['constructor'][4] = 0,
+    secondParam: Params['constructor'][5] = 0,
+    millisecondParam: Params['constructor'][6] = 0,
+    microsecondParam: Params['constructor'][7] = 0,
+    nanosecondParam: Params['constructor'][8] = 0,
+    calendarParam: Params['constructor'][9] = ES.GetISO8601Calendar()
+  ) {
+    const isoYear = ES.ToIntegerThrowOnInfinity(isoYearParam);
+    const isoMonth = ES.ToIntegerThrowOnInfinity(isoMonthParam);
+    const isoDay = ES.ToIntegerThrowOnInfinity(isoDayParam);
+    const hour = ES.ToIntegerThrowOnInfinity(hourParam);
+    const minute = ES.ToIntegerThrowOnInfinity(minuteParam);
+    const second = ES.ToIntegerThrowOnInfinity(secondParam);
+    const millisecond = ES.ToIntegerThrowOnInfinity(millisecondParam);
+    const microsecond = ES.ToIntegerThrowOnInfinity(microsecondParam);
+    const nanosecond = ES.ToIntegerThrowOnInfinity(nanosecondParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       be rejected by RejectDateTime in CreateTemporalDateTimeSlots. This
+    //       check exists only to improve the error message.
+    if (arguments.length < 3) {
+      throw new RangeError('missing argument: isoYear, isoMonth and isoDay are required');
+    }
+
+    ES.CreateTemporalDateTimeSlots(
+      this,
+      isoYear,
+      isoMonth,
+      isoDay,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+  get year(): Return['year'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYear(GetSlot(this, CALENDAR), this);
+  }
+  get month(): Return['month'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonth(GetSlot(this, CALENDAR), this);
+  }
+  get monthCode(): Return['monthCode'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthCode(GetSlot(this, CALENDAR), this);
+  }
+  get day(): Return['day'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+  }
+  get hour(): Return['hour'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_HOUR);
+  }
+  get minute(): Return['minute'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MINUTE);
+  }
+  get second(): Return['second'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_SECOND);
+  }
+  get millisecond(): Return['millisecond'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MILLISECOND);
+  }
+  get microsecond(): Return['microsecond'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MICROSECOND);
+  }
+  get nanosecond(): Return['nanosecond'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_NANOSECOND);
+  }
+  get era(): Return['era'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEra(GetSlot(this, CALENDAR), this);
+  }
+  get eraYear(): Return['eraYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEraYear(GetSlot(this, CALENDAR), this);
+  }
+  get dayOfWeek(): Return['dayOfWeek'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), this);
+  }
+  get dayOfYear(): Return['dayOfYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), this);
+  }
+  get weekOfYear(): Return['weekOfYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), this);
+  }
+  get daysInWeek(): Return['daysInWeek'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), this);
+  }
+  get daysInYear(): Return['daysInYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), this);
+  }
+  get daysInMonth(): Return['daysInMonth'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), this);
+  }
+  get monthsInYear(): Return['monthsInYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), this);
+  }
+  get inLeapYear(): Return['inLeapYear'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), this);
+  }
+  with(temporalDateTimeLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalDateTimeLike)) {
+      throw new TypeError('invalid argument');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalDateTimeLike);
+
+    const options = ES.GetOptionsObject(optionsParam);
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, [
+      'day',
+      'hour',
+      'microsecond',
+      'millisecond',
+      'minute',
+      'month',
+      'monthCode',
+      'nanosecond',
+      'second',
+      'year'
+    ] as const);
+    const props = ES.PrepareTemporalFields(temporalDateTimeLike, fieldNames, 'partial');
+    if (!props) {
+      throw new TypeError('invalid date-time-like');
+    }
+    let fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    fields = ES.CalendarMergeFields(calendar, fields, props);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+    const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
+      ES.InterpretTemporalDateTimeFields(calendar, fields, options);
+
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    const calendar = GetSlot(this, CALENDAR);
+
+    if (temporalTimeParam === undefined) return ES.CreateTemporalDateTime(year, month, day, 0, 0, 0, 0, 0, 0, calendar);
+
+    const temporalTime = ES.ToTemporalTime(temporalTimeParam);
+    const hour = GetSlot(temporalTime, ISO_HOUR);
+    const minute = GetSlot(temporalTime, ISO_MINUTE);
+    const second = GetSlot(temporalTime, ISO_SECOND);
+    const millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  withPlainDate(temporalDateParam: Params['withPlainDate'][0]): Return['withPlainDate'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+
+    const temporalDate = ES.ToTemporalDate(temporalDateParam);
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    let calendar = GetSlot(temporalDate, CALENDAR);
+
+    const hour = GetSlot(this, ISO_HOUR);
+    const minute = GetSlot(this, ISO_MINUTE);
+    const second = GetSlot(this, ISO_SECOND);
+    const millisecond = GetSlot(this, ISO_MILLISECOND);
+    const microsecond = GetSlot(this, ISO_MICROSECOND);
+    const nanosecond = GetSlot(this, ISO_NANOSECOND);
+
+    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    return new PlainDateTime(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(this, ISO_HOUR),
+      GetSlot(this, ISO_MINUTE),
+      GetSlot(this, ISO_SECOND),
+      GetSlot(this, ISO_MILLISECOND),
+      GetSlot(this, ISO_MICROSECOND),
+      GetSlot(this, ISO_NANOSECOND),
+      calendar
+    );
+  }
+  add(temporalDurationLike: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainDateTime('add', this, temporalDurationLike, options);
+  }
+  subtract(
+    temporalDurationLike: Params['subtract'][0],
+    options: Params['subtract'][1] = undefined
+  ): Return['subtract'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainDateTime('subtract', this, temporalDurationLike, options);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainDateTime('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainDateTime('since', this, other, options);
+  }
+  round(optionsParam: Params['round'][0]): Return['round'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (optionsParam === undefined) throw new TypeError('options parameter is required');
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const maximumIncrements = {
+      day: 1,
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+
+    let year = GetSlot(this, ISO_YEAR);
+    let month = GetSlot(this, ISO_MONTH);
+    let day = GetSlot(this, ISO_DAY);
+    let hour = GetSlot(this, ISO_HOUR);
+    let minute = GetSlot(this, ISO_MINUTE);
+    let second = GetSlot(this, ISO_SECOND);
+    let millisecond = GetSlot(this, ISO_MILLISECOND);
+    let microsecond = GetSlot(this, ISO_MICROSECOND);
+    let nanosecond = GetSlot(this, ISO_NANOSECOND);
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode
+    ));
+
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      GetSlot(this, CALENDAR)
+    );
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalDateTime(otherParam);
+    for (const slot of [
+      ISO_YEAR,
+      ISO_MONTH,
+      ISO_DAY,
+      ISO_HOUR,
+      ISO_MINUTE,
+      ISO_SECOND,
+      ISO_MILLISECOND,
+      ISO_MICROSECOND,
+      ISO_NANOSECOND
+    ]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return false;
+    }
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const showCalendar = ES.ToShowCalendarOption(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToString(this, 'auto');
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.PlainDateTime');
+  }
+
+  toZonedDateTime(
+    temporalTimeZoneLike: Params['toZonedDateTime'][0],
+    optionsParam: Params['toZonedDateTime'][1] = undefined
+  ): Return['toZonedDateTime'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const options = ES.GetOptionsObject(optionsParam);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, this, disambiguation);
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
+  }
+  toPlainDate(): Return['toPlainDate'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToDate(this);
+  }
+  toPlainYearMonth(): Return['toPlainYearMonth'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
+  }
+  toPlainMonthDay(): Return['toPlainMonthDay'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
+  }
+  toPlainTime(): Return['toPlainTime'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToTime(this);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      isoDay: GetSlot(this, ISO_DAY),
+      isoHour: GetSlot(this, ISO_HOUR),
+      isoMicrosecond: GetSlot(this, ISO_MICROSECOND),
+      isoMillisecond: GetSlot(this, ISO_MILLISECOND),
+      isoMinute: GetSlot(this, ISO_MINUTE),
+      isoMonth: GetSlot(this, ISO_MONTH),
+      isoNanosecond: GetSlot(this, ISO_NANOSECOND),
+      isoSecond: GetSlot(this, ISO_SECOND),
+      isoYear: GetSlot(this, ISO_YEAR)
+    };
+  }
+
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    if (ES.IsTemporalDateTime(item)) {
+      ES.ToTemporalOverflow(options); // validate and ignore
+      return ES.CreateTemporalDateTime(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, ISO_HOUR),
+        GetSlot(item, ISO_MINUTE),
+        GetSlot(item, ISO_SECOND),
+        GetSlot(item, ISO_MILLISECOND),
+        GetSlot(item, ISO_MICROSECOND),
+        GetSlot(item, ISO_NANOSECOND),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    return ES.ToTemporalDateTime(item, options);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalDateTime(oneParam);
+    const two = ES.ToTemporalDateTime(twoParam);
+    for (const slot of [
+      ISO_YEAR,
+      ISO_MONTH,
+      ISO_DAY,
+      ISO_HOUR,
+      ISO_MINUTE,
+      ISO_SECOND,
+      ISO_MILLISECOND,
+      ISO_MICROSECOND,
+      ISO_NANOSECOND
+    ] as const) {
+      const val1 = GetSlot(one, slot);
+      const val2 = GetSlot(two, slot);
+      if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
+    }
+    return 0;
+  }
+}
+
+MakeIntrinsicClass(PlainDateTime, 'Temporal.PlainDateTime');

--- a/src/vendor/temporal/plainmonthday.ts
+++ b/src/vendor/temporal/plainmonthday.ts
@@ -1,0 +1,139 @@
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { PlainMonthDayParams as Params, PlainMonthDayReturn as Return } from './internaltypes';
+
+const ObjectCreate = Object.create;
+
+export class PlainMonthDay implements Temporal.PlainMonthDay {
+  constructor(
+    isoMonthParam: Params['constructor'][0],
+    isoDayParam: Params['constructor'][0],
+    calendarParam: Temporal.CalendarProtocol | string = ES.GetISO8601Calendar(),
+    referenceISOYearParam = 1972
+  ) {
+    const isoMonth = ES.ToIntegerThrowOnInfinity(isoMonthParam);
+    const isoDay = ES.ToIntegerThrowOnInfinity(isoDayParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    const referenceISOYear = ES.ToIntegerThrowOnInfinity(referenceISOYearParam);
+
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       be rejected by RejectISODate in CreateTemporalMonthDaySlots. This
+    //       check exists only to improve the error message.
+    if (arguments.length < 2) {
+      throw new RangeError('missing argument: isoMonth and isoDay are required');
+    }
+
+    ES.CreateTemporalMonthDaySlots(this, isoMonth, isoDay, calendar, referenceISOYear);
+  }
+
+  get monthCode(): Return['monthCode'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthCode(GetSlot(this, CALENDAR), this);
+  }
+  get day(): Return['day'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+  }
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+
+  with(temporalMonthDayLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalMonthDayLike)) {
+      throw new TypeError('invalid argument');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalMonthDayLike);
+
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year'] as const);
+    const props = ES.PrepareTemporalFields(temporalMonthDayLike, fieldNames, 'partial');
+    if (!props) {
+      throw new TypeError('invalid month-day-like');
+    }
+    let fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    fields = ES.CalendarMergeFields(calendar, fields, props);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+
+    const options = ES.GetOptionsObject(optionsParam);
+    return ES.CalendarMonthDayFromFields(calendar, fields, options);
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalMonthDay(otherParam);
+    for (const slot of [ISO_MONTH, ISO_DAY, ISO_YEAR]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return false;
+    }
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const showCalendar = ES.ToShowCalendarOption(options);
+    return ES.TemporalMonthDayToString(this, showCalendar);
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalMonthDayToString(this);
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use equals() to compare Temporal.PlainMonthDay');
+  }
+  toPlainDate(item: Params['toPlainDate'][0]): Return['toPlainDate'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
+    const calendar = GetSlot(this, CALENDAR);
+
+    const receiverFieldNames = ES.CalendarFields(calendar, ['day', 'monthCode'] as const);
+    const fields = ES.PrepareTemporalFields(this, receiverFieldNames, []);
+
+    const inputFieldNames = ES.CalendarFields(calendar, ['year'] as const);
+    const inputFields = ES.PrepareTemporalFields(item, inputFieldNames, []);
+    let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
+
+    // TODO: Use MergeLists abstract operation.
+    const mergedFieldNames = [...new Set([...receiverFieldNames, ...inputFieldNames])];
+    mergedFields = ES.PrepareTemporalFields(mergedFields, mergedFieldNames, []);
+    const options = ObjectCreate(null);
+    options.overflow = 'reject';
+    return ES.CalendarDateFromFields(calendar, mergedFields, options);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      isoDay: GetSlot(this, ISO_DAY),
+      isoMonth: GetSlot(this, ISO_MONTH),
+      isoYear: GetSlot(this, ISO_YEAR)
+    };
+  }
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    if (ES.IsTemporalMonthDay(item)) {
+      ES.ToTemporalOverflow(options); // validate and ignore
+      return ES.CreateTemporalMonthDay(
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, CALENDAR),
+        GetSlot(item, ISO_YEAR)
+      );
+    }
+    return ES.ToTemporalMonthDay(item, options);
+  }
+}
+
+MakeIntrinsicClass(PlainMonthDay, 'Temporal.PlainMonthDay');

--- a/src/vendor/temporal/plaintime.ts
+++ b/src/vendor/temporal/plaintime.ts
@@ -1,0 +1,359 @@
+import { DEBUG } from './debug';
+import * as ES from './ecmascript';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+
+import {
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  CALENDAR,
+  EPOCHNANOSECONDS,
+  CreateSlots,
+  GetSlot,
+  SetSlot
+} from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { PlainTimeParams as Params, PlainTimeReturn as Return } from './internaltypes';
+
+const ObjectAssign = Object.assign;
+
+type TemporalTimeToStringOptions = {
+  unit: ReturnType<typeof ES.ToSecondsStringPrecision>['unit'];
+  increment: ReturnType<typeof ES.ToSecondsStringPrecision>['increment'];
+  roundingMode: Temporal.RoundingMode;
+};
+
+function TemporalTimeToString(
+  time: Temporal.PlainTime,
+  precision: ReturnType<typeof ES.ToSecondsStringPrecision>['precision'],
+  options: TemporalTimeToStringOptions | undefined = undefined
+) {
+  let hour = GetSlot(time, ISO_HOUR);
+  let minute = GetSlot(time, ISO_MINUTE);
+  let second = GetSlot(time, ISO_SECOND);
+  let millisecond = GetSlot(time, ISO_MILLISECOND);
+  let microsecond = GetSlot(time, ISO_MICROSECOND);
+  let nanosecond = GetSlot(time, ISO_NANOSECOND);
+
+  if (options) {
+    const { unit, increment, roundingMode } = options;
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      increment,
+      unit,
+      roundingMode
+    ));
+  }
+
+  const hourString = ES.ISODateTimePartString(hour);
+  const minuteString = ES.ISODateTimePartString(minute);
+  const seconds = ES.FormatSecondsStringPart(second, millisecond, microsecond, nanosecond, precision);
+  return `${hourString}:${minuteString}${seconds}`;
+}
+
+export class PlainTime implements Temporal.PlainTime {
+  constructor(
+    isoHourParam = 0,
+    isoMinuteParam = 0,
+    isoSecondParam = 0,
+    isoMillisecondParam = 0,
+    isoMicrosecondParam = 0,
+    isoNanosecondParam = 0
+  ) {
+    const isoHour = ES.ToIntegerThrowOnInfinity(isoHourParam);
+    const isoMinute = ES.ToIntegerThrowOnInfinity(isoMinuteParam);
+    const isoSecond = ES.ToIntegerThrowOnInfinity(isoSecondParam);
+    const isoMillisecond = ES.ToIntegerThrowOnInfinity(isoMillisecondParam);
+    const isoMicrosecond = ES.ToIntegerThrowOnInfinity(isoMicrosecondParam);
+    const isoNanosecond = ES.ToIntegerThrowOnInfinity(isoNanosecondParam);
+
+    ES.RejectTime(isoHour, isoMinute, isoSecond, isoMillisecond, isoMicrosecond, isoNanosecond);
+    CreateSlots(this);
+    SetSlot(this, ISO_HOUR, isoHour);
+    SetSlot(this, ISO_MINUTE, isoMinute);
+    SetSlot(this, ISO_SECOND, isoSecond);
+    SetSlot(this, ISO_MILLISECOND, isoMillisecond);
+    SetSlot(this, ISO_MICROSECOND, isoMicrosecond);
+    SetSlot(this, ISO_NANOSECOND, isoNanosecond);
+    SetSlot(this, CALENDAR, ES.GetISO8601Calendar());
+
+    if (DEBUG) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${TemporalTimeToString(this, 'auto')}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    // PlainTime's calendar isn't settable, so can't be a userland calendar
+    return GetSlot(this, CALENDAR) as Temporal.Calendar;
+  }
+  get hour(): Return['hour'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_HOUR);
+  }
+  get minute(): Return['minute'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MINUTE);
+  }
+  get second(): Return['second'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_SECOND);
+  }
+  get millisecond(): Return['millisecond'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MILLISECOND);
+  }
+  get microsecond(): Return['microsecond'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_MICROSECOND);
+  }
+  get nanosecond(): Return['nanosecond'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, ISO_NANOSECOND);
+  }
+
+  with(temporalTimeLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalTimeLike)) {
+      throw new TypeError('invalid argument');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalTimeLike);
+
+    const partialTime = ES.ToTemporalTimeRecord(temporalTimeLike, 'partial');
+    const options = ES.GetOptionsObject(optionsParam);
+    const overflow = ES.ToTemporalOverflow(options);
+
+    const fields = ES.ToTemporalTimeRecord(this);
+    let { hour, minute, second, millisecond, microsecond, nanosecond } = ObjectAssign(fields, partialTime);
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      overflow
+    ));
+    return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+  }
+  add(temporalDurationLike: Params['add'][0]): Return['add'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainTime('add', this, temporalDurationLike);
+  }
+  subtract(temporalDurationLike: Params['subtract'][0]): Return['subtract'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainTime('subtract', this, temporalDurationLike);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainTime('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainTime('since', this, other, options);
+  }
+  round(optionsParam: Params['round'][0]): Return['round'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (optionsParam === undefined) throw new TypeError('options parameter is required');
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const MAX_INCREMENTS = {
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
+
+    let hour = GetSlot(this, ISO_HOUR);
+    let minute = GetSlot(this, ISO_MINUTE);
+    let second = GetSlot(this, ISO_SECOND);
+    let millisecond = GetSlot(this, ISO_MILLISECOND);
+    let microsecond = GetSlot(this, ISO_MICROSECOND);
+    let nanosecond = GetSlot(this, ISO_NANOSECOND);
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode
+    ));
+
+    return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalTime(otherParam);
+    for (const slot of [ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return false;
+    }
+    return true;
+  }
+
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return TemporalTimeToString(this, 'auto');
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.PlainTime');
+  }
+
+  toPlainDateTime(temporalDateParam: Params['toPlainDateTime'][0]): Return['toPlainDateTime'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+
+    const temporalDate = ES.ToTemporalDate(temporalDateParam);
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    const calendar = GetSlot(temporalDate, CALENDAR);
+
+    const hour = GetSlot(this, ISO_HOUR);
+    const minute = GetSlot(this, ISO_MINUTE);
+    const second = GetSlot(this, ISO_SECOND);
+    const millisecond = GetSlot(this, ISO_MILLISECOND);
+    const microsecond = GetSlot(this, ISO_MICROSECOND);
+    const nanosecond = GetSlot(this, ISO_NANOSECOND);
+
+    return ES.CreateTemporalDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+  }
+  toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+
+    if (!ES.IsObject(item)) {
+      throw new TypeError('invalid argument');
+    }
+
+    const dateLike = item.plainDate;
+    if (dateLike === undefined) {
+      throw new TypeError('missing date property');
+    }
+    const temporalDate = ES.ToTemporalDate(dateLike);
+
+    const timeZoneLike = item.timeZone;
+    if (timeZoneLike === undefined) {
+      throw new TypeError('missing timeZone property');
+    }
+    const timeZone = ES.ToTemporalTimeZone(timeZoneLike);
+
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    const calendar = GetSlot(temporalDate, CALENDAR);
+    const hour = GetSlot(this, ISO_HOUR);
+    const minute = GetSlot(this, ISO_MINUTE);
+    const second = GetSlot(this, ISO_SECOND);
+    const millisecond = GetSlot(this, ISO_MILLISECOND);
+    const microsecond = GetSlot(this, ISO_MICROSECOND);
+    const nanosecond = GetSlot(this, ISO_NANOSECOND);
+
+    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    return {
+      calendar: GetSlot(this, CALENDAR) as Temporal.Calendar,
+      isoHour: GetSlot(this, ISO_HOUR),
+      isoMicrosecond: GetSlot(this, ISO_MICROSECOND),
+      isoMillisecond: GetSlot(this, ISO_MILLISECOND),
+      isoMinute: GetSlot(this, ISO_MINUTE),
+      isoNanosecond: GetSlot(this, ISO_NANOSECOND),
+      isoSecond: GetSlot(this, ISO_SECOND)
+    };
+  }
+
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    const overflow = ES.ToTemporalOverflow(options);
+    if (ES.IsTemporalTime(item)) {
+      return new PlainTime(
+        GetSlot(item, ISO_HOUR),
+        GetSlot(item, ISO_MINUTE),
+        GetSlot(item, ISO_SECOND),
+        GetSlot(item, ISO_MILLISECOND),
+        GetSlot(item, ISO_MICROSECOND),
+        GetSlot(item, ISO_NANOSECOND)
+      );
+    }
+    return ES.ToTemporalTime(item, overflow);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalTime(oneParam);
+    const two = ES.ToTemporalTime(twoParam);
+    for (const slot of [ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND] as const) {
+      const val1 = GetSlot(one, slot);
+      const val2 = GetSlot(two, slot);
+      if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
+    }
+    return 0;
+  }
+}
+
+MakeIntrinsicClass(PlainTime, 'Temporal.PlainTime');

--- a/src/vendor/temporal/plainyearmonth.ts
+++ b/src/vendor/temporal/plainyearmonth.ts
@@ -1,0 +1,197 @@
+import * as ES from './ecmascript';
+import { MakeIntrinsicClass } from './intrinsicclass';
+import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { PlainYearMonthParams as Params, PlainYearMonthReturn as Return } from './internaltypes';
+
+const ObjectCreate = Object.create;
+
+export class PlainYearMonth implements Temporal.PlainYearMonth {
+  constructor(
+    isoYearParam: Params['constructor'][0],
+    isoMonthParam: Params['constructor'][1],
+    calendarParam: Params['constructor'][2] = ES.GetISO8601Calendar(),
+    referenceISODayParam: Params['constructor'][3] = 1
+  ) {
+    const isoYear = ES.ToIntegerThrowOnInfinity(isoYearParam);
+    const isoMonth = ES.ToIntegerThrowOnInfinity(isoMonthParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    const referenceISODay = ES.ToIntegerThrowOnInfinity(referenceISODayParam);
+
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       be rejected by RejectISODate in CreateTemporalYearMonthSlots. This
+    //       check exists only to improve the error message.
+    if (arguments.length < 2) {
+      throw new RangeError('missing argument: isoYear and isoMonth are required');
+    }
+
+    ES.CreateTemporalYearMonthSlots(this, isoYear, isoMonth, calendar, referenceISODay);
+  }
+  get year(): Return['year'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYear(GetSlot(this, CALENDAR), this);
+  }
+  get month(): Return['month'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonth(GetSlot(this, CALENDAR), this);
+  }
+  get monthCode(): Return['monthCode'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthCode(GetSlot(this, CALENDAR), this);
+  }
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+  get era(): Return['era'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEra(GetSlot(this, CALENDAR), this);
+  }
+  get eraYear(): Return['eraYear'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEraYear(GetSlot(this, CALENDAR), this);
+  }
+  get daysInMonth(): Return['daysInMonth'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), this);
+  }
+  get daysInYear(): Return['daysInYear'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), this);
+  }
+  get monthsInYear(): Return['monthsInYear'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), this);
+  }
+  get inLeapYear(): Return['inLeapYear'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), this);
+  }
+  with(temporalYearMonthLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalYearMonthLike)) {
+      throw new TypeError('invalid argument');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalYearMonthLike);
+
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['month', 'monthCode', 'year'] as const);
+    const props = ES.PrepareTemporalFields(temporalYearMonthLike, fieldNames, 'partial');
+    if (!props) {
+      throw new TypeError('invalid year-month-like');
+    }
+    let fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    fields = ES.CalendarMergeFields(calendar, fields, props);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+
+    const options = ES.GetOptionsObject(optionsParam);
+
+    return ES.CalendarYearMonthFromFields(calendar, fields, options);
+  }
+  add(temporalDurationLike: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainYearMonth('add', this, temporalDurationLike, options);
+  }
+  subtract(
+    temporalDurationLike: Params['subtract'][0],
+    options: Params['subtract'][1] = undefined
+  ): Return['subtract'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromPlainYearMonth('subtract', this, temporalDurationLike, options);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainYearMonth('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalPlainYearMonth('since', this, other, options);
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalYearMonth(otherParam);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return false;
+    }
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const showCalendar = ES.ToShowCalendarOption(options);
+    return ES.TemporalYearMonthToString(this, showCalendar);
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalYearMonthToString(this);
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.PlainYearMonth');
+  }
+  toPlainDate(item: Params['toPlainDate'][0]): Return['toPlainDate'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
+    const calendar = GetSlot(this, CALENDAR);
+
+    const receiverFieldNames = ES.CalendarFields(calendar, ['monthCode', 'year'] as const);
+    const fields = ES.PrepareTemporalFields(this, receiverFieldNames, []);
+
+    const inputFieldNames = ES.CalendarFields(calendar, ['day'] as const);
+    const inputFields = ES.PrepareTemporalFields(item, inputFieldNames, []);
+    let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
+
+    // TODO: Use MergeLists abstract operation.
+    const mergedFieldNames = [...new Set([...receiverFieldNames, ...inputFieldNames])];
+    mergedFields = ES.PrepareTemporalFields(mergedFields, mergedFieldNames, []);
+    const options = ObjectCreate(null);
+    options.overflow = 'reject';
+    return ES.CalendarDateFromFields(calendar, mergedFields, options);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      isoDay: GetSlot(this, ISO_DAY),
+      isoMonth: GetSlot(this, ISO_MONTH),
+      isoYear: GetSlot(this, ISO_YEAR)
+    };
+  }
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    if (ES.IsTemporalYearMonth(item)) {
+      ES.ToTemporalOverflow(options); // validate and ignore
+      return ES.CreateTemporalYearMonth(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, CALENDAR),
+        GetSlot(item, ISO_DAY)
+      );
+    }
+    return ES.ToTemporalYearMonth(item, options);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalYearMonth(oneParam);
+    const two = ES.ToTemporalYearMonth(twoParam);
+    return ES.CompareISODate(
+      GetSlot(one, ISO_YEAR),
+      GetSlot(one, ISO_MONTH),
+      GetSlot(one, ISO_DAY),
+      GetSlot(two, ISO_YEAR),
+      GetSlot(two, ISO_MONTH),
+      GetSlot(two, ISO_DAY)
+    );
+  }
+}
+
+MakeIntrinsicClass(PlainYearMonth, 'Temporal.PlainYearMonth');

--- a/src/vendor/temporal/regex.ts
+++ b/src/vendor/temporal/regex.ts
@@ -1,0 +1,41 @@
+const tzComponent = /\.[-A-Za-z_]|\.\.[-A-Za-z._]{1,12}|\.[-A-Za-z_][-A-Za-z._]{0,12}|[A-Za-z_][-A-Za-z._]{0,13}/;
+const offsetNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9](?::?[0-5][0-9](?:[.,]\d{1,9})?)?)?)/;
+const timeZoneID = new RegExp(
+  `(?:(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*|Etc/GMT[-+]\\d{1,2}|${offsetNoCapture.source})`
+);
+
+const calComponent = /[A-Za-z0-9]{3,8}/;
+const calendarID = new RegExp(`(?:${calComponent.source}(?:-${calComponent.source})*)`);
+
+const yearpart = /(?:[+\u2212-]\d{6}|\d{4})/;
+const monthpart = /(?:0[1-9]|1[0-2])/;
+const daypart = /(?:0[1-9]|[12]\d|3[01])/;
+const datesplit = new RegExp(
+  `(${yearpart.source})(?:-(${monthpart.source})-(${daypart.source})|(${monthpart.source})(${daypart.source}))`
+);
+const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
+export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
+const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneID.source})\\])?`);
+const calendar = new RegExp(`\\[u-ca=(${calendarID.source})\\]`);
+
+export const zoneddatetime = new RegExp(
+  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,
+  'i'
+);
+
+export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
+
+// The short forms of YearMonth and MonthDay are only for the ISO calendar.
+// Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,
+// with the reference fields.
+// YYYYMM forbidden by ISO 8601 because ambiguous with YYMMDD, but allowed by
+// RFC 3339 and we don't allow 2-digit years, so we allow it.
+// Not ambiguous with HHMMSS because that requires a 'T' prefix
+export const yearmonth = new RegExp(`^(${yearpart.source})-?(${monthpart.source})$`);
+export const monthday = new RegExp(`^(?:--)?(${monthpart.source})-?(${daypart.source})$`);
+
+const fraction = /(\d+)(?:[.,](\d{1,9}))?/;
+
+const durationDate = /(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?/;
+const durationTime = new RegExp(`(?:${fraction.source}H)?(?:${fraction.source}M)?(?:${fraction.source}S)?`);
+export const duration = new RegExp(`^([+\u2212-])?P${durationDate.source}(?:T(?!$)${durationTime.source})?$`, 'i');

--- a/src/vendor/temporal/slots.ts
+++ b/src/vendor/temporal/slots.ts
@@ -1,0 +1,291 @@
+import type JSBI from 'jsbi';
+import type { Temporal } from '..';
+import type { BuiltinCalendarId, AnyTemporalType } from './internaltypes';
+
+// Instant
+export const EPOCHNANOSECONDS = 'slot-epochNanoSeconds';
+
+// TimeZone
+export const TIMEZONE_ID = 'slot-timezone-identifier';
+
+// DateTime, Date, Time, YearMonth, MonthDay
+export const ISO_YEAR = 'slot-year';
+export const ISO_MONTH = 'slot-month';
+export const ISO_DAY = 'slot-day';
+export const ISO_HOUR = 'slot-hour';
+export const ISO_MINUTE = 'slot-minute';
+export const ISO_SECOND = 'slot-second';
+export const ISO_MILLISECOND = 'slot-millisecond';
+export const ISO_MICROSECOND = 'slot-microsecond';
+export const ISO_NANOSECOND = 'slot-nanosecond';
+export const CALENDAR = 'slot-calendar';
+// Date, YearMonth, and MonthDay all have the same slots, disambiguation needed:
+export const DATE_BRAND = 'slot-date-brand';
+export const YEAR_MONTH_BRAND = 'slot-year-month-brand';
+export const MONTH_DAY_BRAND = 'slot-month-day-brand';
+
+// ZonedDateTime
+export const INSTANT = 'slot-cached-instant';
+export const TIME_ZONE = 'slot-time-zone';
+
+// Duration
+export const YEARS = 'slot-years';
+export const MONTHS = 'slot-months';
+export const WEEKS = 'slot-weeks';
+export const DAYS = 'slot-days';
+export const HOURS = 'slot-hours';
+export const MINUTES = 'slot-minutes';
+export const SECONDS = 'slot-seconds';
+export const MILLISECONDS = 'slot-milliseconds';
+export const MICROSECONDS = 'slot-microseconds';
+export const NANOSECONDS = 'slot-nanoseconds';
+
+// Calendar
+export const CALENDAR_ID = 'slot-calendar-identifier';
+
+interface SlotInfo<ValueType, UsedByType extends AnyTemporalType> {
+  value: ValueType;
+  usedBy: UsedByType;
+}
+
+interface SlotInfoRecord {
+  [k: string]: SlotInfo<unknown, AnyTemporalType>;
+}
+
+interface Slots extends SlotInfoRecord {
+  // Instant
+  [EPOCHNANOSECONDS]: SlotInfo<JSBI, Temporal.Instant | Temporal.ZonedDateTime>; // number? JSBI?
+
+  // TimeZone
+  [TIMEZONE_ID]: SlotInfo<string, Temporal.TimeZone>;
+
+  // DateTime, Date, Time, YearMonth, MonthDay
+  [ISO_YEAR]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_MONTH]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_DAY]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_HOUR]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_MINUTE]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_SECOND]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_MILLISECOND]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_MICROSECOND]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_NANOSECOND]: SlotInfo<number, TypesWithCalendarUnits>;
+  [CALENDAR]: SlotInfo<Temporal.CalendarProtocol, TypesWithCalendarUnits | Temporal.ZonedDateTime>;
+
+  // Date, YearMonth, MonthDay common slots
+  [DATE_BRAND]: SlotInfo<true, Temporal.PlainDate>;
+  [YEAR_MONTH_BRAND]: SlotInfo<true, Temporal.PlainYearMonth>;
+  [MONTH_DAY_BRAND]: SlotInfo<true, Temporal.PlainMonthDay>;
+
+  // ZonedDateTime
+  [INSTANT]: SlotInfo<Temporal.Instant, Temporal.ZonedDateTime>;
+  [TIME_ZONE]: SlotInfo<Temporal.TimeZoneProtocol, Temporal.ZonedDateTime>;
+
+  // Duration
+  [YEARS]: SlotInfo<number, Temporal.Duration>;
+  [MONTHS]: SlotInfo<number, Temporal.Duration>;
+  [WEEKS]: SlotInfo<number, Temporal.Duration>;
+  [DAYS]: SlotInfo<number, Temporal.Duration>;
+  [HOURS]: SlotInfo<number, Temporal.Duration>;
+  [MINUTES]: SlotInfo<number, Temporal.Duration>;
+  [SECONDS]: SlotInfo<number, Temporal.Duration>;
+  [MILLISECONDS]: SlotInfo<number, Temporal.Duration>;
+  [MICROSECONDS]: SlotInfo<number, Temporal.Duration>;
+  [NANOSECONDS]: SlotInfo<number, Temporal.Duration>;
+
+  // Calendar
+  [CALENDAR_ID]: SlotInfo<BuiltinCalendarId, Temporal.Calendar>;
+}
+
+type TypesWithCalendarUnits =
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.PlainMonthDay
+  | Temporal.ZonedDateTime;
+
+interface SlotsToTypes {
+  // Instant
+  [EPOCHNANOSECONDS]: Temporal.Instant;
+
+  // TimeZone
+  [TIMEZONE_ID]: Temporal.TimeZone;
+
+  // DateTime, Date, Time, YearMonth, MonthDay
+  [ISO_YEAR]: TypesWithCalendarUnits;
+  [ISO_MONTH]: TypesWithCalendarUnits;
+  [ISO_DAY]: TypesWithCalendarUnits;
+  [ISO_HOUR]: TypesWithCalendarUnits;
+  [ISO_MINUTE]: TypesWithCalendarUnits;
+  [ISO_SECOND]: TypesWithCalendarUnits;
+  [ISO_MILLISECOND]: TypesWithCalendarUnits;
+  [ISO_MICROSECOND]: TypesWithCalendarUnits;
+  [ISO_NANOSECOND]: TypesWithCalendarUnits;
+  [CALENDAR]: TypesWithCalendarUnits;
+
+  // Date, YearMonth, MonthDay common slots
+  [DATE_BRAND]: Temporal.PlainDate;
+  [YEAR_MONTH_BRAND]: Temporal.PlainYearMonth;
+  [MONTH_DAY_BRAND]: Temporal.PlainMonthDay;
+
+  // ZonedDateTime
+  [INSTANT]: Temporal.ZonedDateTime;
+  [TIME_ZONE]: Temporal.ZonedDateTime;
+
+  // Duration
+  [YEARS]: Temporal.Duration;
+  [MONTHS]: Temporal.Duration;
+  [WEEKS]: Temporal.Duration;
+  [DAYS]: Temporal.Duration;
+  [HOURS]: Temporal.Duration;
+  [MINUTES]: Temporal.Duration;
+  [SECONDS]: Temporal.Duration;
+  [MILLISECONDS]: Temporal.Duration;
+  [MICROSECONDS]: Temporal.Duration;
+  [NANOSECONDS]: Temporal.Duration;
+
+  // Calendar
+  [CALENDAR_ID]: Temporal.Calendar;
+}
+
+type SlotKey = keyof SlotsToTypes;
+
+const slots = new WeakMap();
+export function CreateSlots(container: AnyTemporalType): void {
+  slots.set(container, Object.create(null));
+}
+
+function GetSlots<T extends AnyTemporalType>(container: T) {
+  return slots.get(container);
+}
+// TODO: is there a better way than 9 overloads to make HasSlot into a type
+// guard that takes a variable number of parameters?
+export function HasSlot<ID1 extends SlotKey>(container: unknown, id1: ID1): container is Slots[ID1]['usedBy'];
+export function HasSlot<ID1 extends SlotKey, ID2 extends SlotKey>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2
+): container is Slots[ID1]['usedBy'] | Slots[ID2]['usedBy'];
+export function HasSlot<ID1 extends SlotKey, ID2 extends SlotKey, ID3 extends SlotKey>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3
+): container is Slots[ID1]['usedBy'] | Slots[ID2]['usedBy'] | Slots[ID3]['usedBy'];
+export function HasSlot<ID1 extends SlotKey, ID2 extends SlotKey, ID3 extends SlotKey, ID4 extends SlotKey>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4
+): container is Slots[ID1 | ID2 | ID3 | ID4]['usedBy'];
+export function HasSlot<
+  ID1 extends SlotKey,
+  ID2 extends SlotKey,
+  ID3 extends SlotKey,
+  ID4 extends SlotKey,
+  ID5 extends SlotKey
+>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4,
+  id5: ID5
+): container is Slots[ID1 | ID2 | ID3 | ID4 | ID5]['usedBy'];
+export function HasSlot<
+  ID1 extends SlotKey,
+  ID2 extends SlotKey,
+  ID3 extends SlotKey,
+  ID4 extends SlotKey,
+  ID5 extends SlotKey,
+  ID6 extends SlotKey
+>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4,
+  id5: ID5,
+  id6: ID6
+): container is Slots[ID1 | ID2 | ID3 | ID4 | ID5 | ID6]['usedBy'];
+export function HasSlot<
+  ID1 extends SlotKey,
+  ID2 extends SlotKey,
+  ID3 extends SlotKey,
+  ID4 extends SlotKey,
+  ID5 extends SlotKey,
+  ID6 extends SlotKey,
+  ID7 extends SlotKey
+>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4,
+  id5: ID5,
+  id6: ID6,
+  id7: ID7
+): container is Slots[ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7]['usedBy'];
+export function HasSlot<
+  ID1 extends SlotKey,
+  ID2 extends SlotKey,
+  ID3 extends SlotKey,
+  ID4 extends SlotKey,
+  ID5 extends SlotKey,
+  ID6 extends SlotKey,
+  ID7 extends SlotKey,
+  ID8 extends SlotKey
+>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4,
+  id5: ID5,
+  id6: ID6,
+  id7: ID7,
+  id8: ID8
+): container is Slots[ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7 | ID8]['usedBy'];
+export function HasSlot<
+  ID1 extends SlotKey,
+  ID2 extends SlotKey,
+  ID3 extends SlotKey,
+  ID4 extends SlotKey,
+  ID5 extends SlotKey,
+  ID6 extends SlotKey,
+  ID7 extends SlotKey,
+  ID8 extends SlotKey,
+  ID9 extends SlotKey
+>(
+  container: unknown,
+  id1: ID1,
+  id2: ID2,
+  id3: ID3,
+  id4: ID4,
+  id5: ID5,
+  id6: ID6,
+  id7: ID7,
+  id8: ID8,
+  id9: ID9
+): container is Slots[ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7 | ID8 | ID9]['usedBy'];
+export function HasSlot(container: unknown, ...ids: (keyof Slots)[]): boolean {
+  if (!container || 'object' !== typeof container) return false;
+  const myslots = GetSlots(container as AnyTemporalType);
+  return !!myslots && ids.reduce((all: boolean, id) => all && id in myslots, true);
+}
+export function GetSlot<KeyT extends keyof Slots>(
+  container: Slots[typeof id]['usedBy'],
+  id: KeyT
+): Slots[KeyT]['value'] {
+  const value = GetSlots(container)[id];
+  if (value === undefined) throw new TypeError(`Missing internal slot ${id}`);
+  return value;
+}
+export function SetSlot<KeyT extends SlotKey>(
+  container: Slots[KeyT]['usedBy'],
+  id: KeyT,
+  value: Slots[KeyT]['value']
+): void {
+  GetSlots(container)[id] = value;
+}

--- a/src/vendor/temporal/temporal.ts
+++ b/src/vendor/temporal/temporal.ts
@@ -1,0 +1,11 @@
+export { Instant } from './instant';
+export { Calendar } from './calendar';
+export { PlainDate } from './plaindate';
+export { PlainDateTime } from './plaindatetime';
+export { Duration } from './duration';
+export { PlainMonthDay } from './plainmonthday';
+export { Now } from './now';
+export { PlainTime } from './plaintime';
+export { TimeZone } from './timezone';
+export { PlainYearMonth } from './plainyearmonth';
+export { ZonedDateTime } from './zoneddatetime';

--- a/src/vendor/temporal/timezone.ts
+++ b/src/vendor/temporal/timezone.ts
@@ -1,0 +1,162 @@
+import { DEBUG } from './debug';
+import * as ES from './ecmascript';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import {
+  TIMEZONE_ID,
+  EPOCHNANOSECONDS,
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  ISO_HOUR,
+  ISO_MINUTE,
+  ISO_SECOND,
+  ISO_MILLISECOND,
+  ISO_MICROSECOND,
+  ISO_NANOSECOND,
+  CreateSlots,
+  GetSlot,
+  SetSlot
+} from './slots';
+import JSBI from 'jsbi';
+import type { Temporal } from '..';
+import type { TimeZoneParams as Params, TimeZoneReturn as Return } from './internaltypes';
+
+export class TimeZone implements Temporal.TimeZone {
+  constructor(timeZoneIdentifierParam: string) {
+    // Note: if the argument is not passed, GetCanonicalTimeZoneIdentifier(undefined) will throw.
+    //       This check exists only to improve the error message.
+    if (arguments.length < 1) {
+      throw new RangeError('missing argument: identifier is required');
+    }
+
+    const timeZoneIdentifier = ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifierParam);
+    CreateSlots(this);
+    SetSlot(this, TIMEZONE_ID, timeZoneIdentifier);
+
+    if (DEBUG) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${timeZoneIdentifier}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+  get id(): Return['id'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    return ES.ToString(this);
+  }
+  getOffsetNanosecondsFor(instantParam: Params['getOffsetNanosecondsFor'][0]): Return['getOffsetNanosecondsFor'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const instant = ES.ToTemporalInstant(instantParam);
+    const id = GetSlot(this, TIMEZONE_ID);
+
+    if (ES.TestTimeZoneOffsetString(id)) {
+      return ES.ParseTimeZoneOffsetString(id);
+    }
+    return ES.GetIANATimeZoneOffsetNanoseconds(GetSlot(instant, EPOCHNANOSECONDS), id);
+  }
+  getOffsetStringFor(instantParam: Params['getOffsetStringFor'][0]): Return['getOffsetStringFor'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const instant = ES.ToTemporalInstant(instantParam);
+    return ES.BuiltinTimeZoneGetOffsetStringFor(this, instant);
+  }
+  getPlainDateTimeFor(
+    instantParam: Params['getPlainDateTimeFor'][0],
+    calendarParam: Params['getPlainDateTimeFor'][1] = ES.GetISO8601Calendar()
+  ): Return['getPlainDateTimeFor'] {
+    const instant = ES.ToTemporalInstant(instantParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    return ES.BuiltinTimeZoneGetPlainDateTimeFor(this, instant, calendar);
+  }
+  getInstantFor(
+    dateTimeParam: Params['getInstantFor'][0],
+    optionsParam: Params['getInstantFor'][1] = undefined
+  ): Return['getInstantFor'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const dateTime = ES.ToTemporalDateTime(dateTimeParam);
+    const options = ES.GetOptionsObject(optionsParam);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    return ES.BuiltinTimeZoneGetInstantFor(this, dateTime, disambiguation);
+  }
+  getPossibleInstantsFor(dateTimeParam: Params['getPossibleInstantsFor'][0]): Return['getPossibleInstantsFor'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const dateTime = ES.ToTemporalDateTime(dateTimeParam);
+    const Instant = GetIntrinsic('%Temporal.Instant%');
+    const id = GetSlot(this, TIMEZONE_ID);
+
+    if (ES.TestTimeZoneOffsetString(id)) {
+      const epochNs = ES.GetEpochFromISOParts(
+        GetSlot(dateTime, ISO_YEAR),
+        GetSlot(dateTime, ISO_MONTH),
+        GetSlot(dateTime, ISO_DAY),
+        GetSlot(dateTime, ISO_HOUR),
+        GetSlot(dateTime, ISO_MINUTE),
+        GetSlot(dateTime, ISO_SECOND),
+        GetSlot(dateTime, ISO_MILLISECOND),
+        GetSlot(dateTime, ISO_MICROSECOND),
+        GetSlot(dateTime, ISO_NANOSECOND)
+      );
+      if (epochNs === null) throw new RangeError('DateTime outside of supported range');
+      const offsetNs = ES.ParseTimeZoneOffsetString(id);
+      return [new Instant(JSBI.subtract(epochNs, JSBI.BigInt(offsetNs)))];
+    }
+
+    const possibleEpochNs = ES.GetIANATimeZoneEpochValue(
+      id,
+      GetSlot(dateTime, ISO_YEAR),
+      GetSlot(dateTime, ISO_MONTH),
+      GetSlot(dateTime, ISO_DAY),
+      GetSlot(dateTime, ISO_HOUR),
+      GetSlot(dateTime, ISO_MINUTE),
+      GetSlot(dateTime, ISO_SECOND),
+      GetSlot(dateTime, ISO_MILLISECOND),
+      GetSlot(dateTime, ISO_MICROSECOND),
+      GetSlot(dateTime, ISO_NANOSECOND)
+    );
+    return possibleEpochNs.map((ns) => new Instant(ns));
+  }
+  getNextTransition(startingPointParam: Params['getNextTransition'][0]): Return['getNextTransition'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const startingPoint = ES.ToTemporalInstant(startingPointParam);
+    const id = GetSlot(this, TIMEZONE_ID);
+
+    // Offset time zones or UTC have no transitions
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
+      return null;
+    }
+
+    let epochNanoseconds: JSBI | null = GetSlot(startingPoint, EPOCHNANOSECONDS);
+    const Instant = GetIntrinsic('%Temporal.Instant%');
+    epochNanoseconds = ES.GetIANATimeZoneNextTransition(epochNanoseconds, id);
+    return epochNanoseconds === null ? null : new Instant(epochNanoseconds);
+  }
+  getPreviousTransition(startingPointParam: Params['getPreviousTransition'][0]): Return['getPreviousTransition'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    const startingPoint = ES.ToTemporalInstant(startingPointParam);
+    const id = GetSlot(this, TIMEZONE_ID);
+
+    // Offset time zones or UTC have no transitions
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
+      return null;
+    }
+
+    let epochNanoseconds: JSBI | null = GetSlot(startingPoint, EPOCHNANOSECONDS);
+    const Instant = GetIntrinsic('%Temporal.Instant%');
+    epochNanoseconds = ES.GetIANATimeZonePreviousTransition(epochNanoseconds, id);
+    return epochNanoseconds === null ? null : new Instant(epochNanoseconds);
+  }
+  toString(): string {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    return ES.ToString(GetSlot(this, TIMEZONE_ID));
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    return ES.ToString(this);
+  }
+  static from(item: Params['from'][0]): Return['from'] {
+    return ES.ToTemporalTimeZone(item);
+  }
+}
+
+MakeIntrinsicClass(TimeZone, 'Temporal.TimeZone');

--- a/src/vendor/temporal/zoneddatetime.ts
+++ b/src/vendor/temporal/zoneddatetime.ts
@@ -1,0 +1,552 @@
+import * as ES from './ecmascript';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import {
+  CALENDAR,
+  EPOCHNANOSECONDS,
+  ISO_HOUR,
+  INSTANT,
+  ISO_DAY,
+  ISO_MONTH,
+  ISO_YEAR,
+  ISO_MICROSECOND,
+  ISO_MILLISECOND,
+  ISO_MINUTE,
+  ISO_NANOSECOND,
+  ISO_SECOND,
+  TIME_ZONE,
+  GetSlot
+} from './slots';
+import type { Temporal } from '..';
+import { DateTimeFormat } from './intl';
+import type { ZonedDateTimeParams as Params, ZonedDateTimeReturn as Return } from './internaltypes';
+
+import JSBI from 'jsbi';
+import { BILLION, MILLION, THOUSAND, ZERO } from './ecmascript';
+
+export class ZonedDateTime implements Temporal.ZonedDateTime {
+  constructor(
+    epochNanosecondsParam: bigint | JSBI,
+    timeZoneParam: Temporal.TimeZoneProtocol | string,
+    calendarParam: Temporal.CalendarProtocol | string = ES.GetISO8601Calendar()
+  ) {
+    // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
+    //       to improve the error message.
+    //       ToTemporalTimeZone(undefined) will end up calling TimeZone.from("undefined"), which
+    //       could succeed.
+    if (arguments.length < 1) {
+      throw new TypeError('missing argument: epochNanoseconds is required');
+    }
+    const epochNanoseconds = ES.ToBigInt(epochNanosecondsParam);
+    const timeZone = ES.ToTemporalTimeZone(timeZoneParam);
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+
+    ES.CreateTemporalZonedDateTimeSlots(this, epochNanoseconds, timeZone, calendar);
+  }
+  get calendar(): Return['calendar'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+  get timeZone(): Return['timeZone'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, TIME_ZONE);
+  }
+  get year(): Return['year'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get month(): Return['month'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonth(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get monthCode(): Return['monthCode'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthCode(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get day(): Return['day'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDay(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get hour(): Return['hour'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_HOUR);
+  }
+  get minute(): Return['minute'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_MINUTE);
+  }
+  get second(): Return['second'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_SECOND);
+  }
+  get millisecond(): Return['millisecond'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_MILLISECOND);
+  }
+  get microsecond(): Return['microsecond'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_MICROSECOND);
+  }
+  get nanosecond(): Return['nanosecond'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), ISO_NANOSECOND);
+  }
+  get era(): Return['era'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEra(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get eraYear(): Return['eraYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarEraYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get epochSeconds(): Return['epochSeconds'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return JSBI.toNumber(JSBI.divide(value, BILLION));
+  }
+  get epochMilliseconds(): Return['epochMilliseconds'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return JSBI.toNumber(JSBI.divide(value, MILLION));
+  }
+  get epochMicroseconds(): Return['epochMicroseconds'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return ES.ToBigIntExternal(JSBI.divide(value, THOUSAND));
+  }
+  get epochNanoseconds(): Return['epochNanoseconds'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.ToBigIntExternal(GetSlot(this, EPOCHNANOSECONDS));
+  }
+  get dayOfWeek(): Return['dayOfWeek'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get dayOfYear(): Return['dayOfYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get weekOfYear(): Return['weekOfYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get hoursInDay(): Return['hoursInDay'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
+    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const year = GetSlot(dt, ISO_YEAR);
+    const month = GetSlot(dt, ISO_MONTH);
+    const day = GetSlot(dt, ISO_DAY);
+    const today = new DateTime(year, month, day, 0, 0, 0, 0, 0, 0);
+    const tomorrowFields = ES.AddISODate(year, month, day, 0, 0, 0, 1, 'reject');
+    const tomorrow = new DateTime(tomorrowFields.year, tomorrowFields.month, tomorrowFields.day, 0, 0, 0, 0, 0, 0);
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const todayNs = GetSlot(ES.BuiltinTimeZoneGetInstantFor(timeZone, today, 'compatible'), EPOCHNANOSECONDS);
+    const tomorrowNs = GetSlot(ES.BuiltinTimeZoneGetInstantFor(timeZone, tomorrow, 'compatible'), EPOCHNANOSECONDS);
+    return JSBI.toNumber(JSBI.subtract(tomorrowNs, todayNs)) / 3.6e12;
+  }
+  get daysInWeek(): Return['daysInWeek'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get daysInMonth(): Return['daysInMonth'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get daysInYear(): Return['daysInYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get monthsInYear(): Return['monthsInYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get inLeapYear(): Return['inLeapYear'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), dateTime(this));
+  }
+  get offset(): Return['offset'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.BuiltinTimeZoneGetOffsetStringFor(GetSlot(this, TIME_ZONE), GetSlot(this, INSTANT));
+  }
+  get offsetNanoseconds(): Return['offsetNanoseconds'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.GetOffsetNanosecondsFor(GetSlot(this, TIME_ZONE), GetSlot(this, INSTANT));
+  }
+  with(temporalZonedDateTimeLike: Params['with'][0], optionsParam: Params['with'][1] = undefined): Return['with'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsObject(temporalZonedDateTimeLike)) {
+      throw new TypeError('invalid zoned-date-time-like');
+    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalZonedDateTimeLike);
+
+    // TODO: Reorder according to spec.
+    const options = ES.GetOptionsObject(optionsParam);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const offset = ES.ToTemporalOffset(options, 'prefer');
+
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, [
+      'day',
+      'hour',
+      'microsecond',
+      'millisecond',
+      'minute',
+      'month',
+      'monthCode',
+      'nanosecond',
+      'second',
+      'year'
+    ] as const);
+    const fieldsWithOffset = ES.ArrayPush(fieldNames, 'offset');
+    const props = ES.PrepareTemporalFields(temporalZonedDateTimeLike, fieldsWithOffset, 'partial');
+    const fieldsWithTimeZoneAndOffset = ES.ArrayPush(fieldsWithOffset, 'timeZone');
+    let fields = ES.PrepareTemporalFields(this, fieldsWithTimeZoneAndOffset, ['timeZone', 'offset']);
+    fields = ES.CalendarMergeFields(calendar, fields, props);
+    fields = ES.PrepareTemporalFields(fields, fieldsWithTimeZoneAndOffset, ['timeZone', 'offset']);
+    let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
+      ES.InterpretTemporalDateTimeFields(calendar, fields, options);
+    const offsetNs = ES.ParseTimeZoneOffsetString(fields.offset);
+    const epochNanoseconds = ES.InterpretISODateTimeOffset(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      'option',
+      offsetNs,
+      timeZone,
+      disambiguation,
+      offset,
+      /* matchMinute = */ false
+    );
+
+    return ES.CreateTemporalZonedDateTime(epochNanoseconds, GetSlot(this, TIME_ZONE), calendar);
+  }
+  withPlainDate(temporalDateParam: Params['withPlainDate'][0]): Return['withPlainDate'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+
+    const temporalDate = ES.ToTemporalDate(temporalDateParam);
+
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    let calendar = GetSlot(temporalDate, CALENDAR);
+    const thisDt = dateTime(this);
+    const hour = GetSlot(thisDt, ISO_HOUR);
+    const minute = GetSlot(thisDt, ISO_MINUTE);
+    const second = GetSlot(thisDt, ISO_SECOND);
+    const millisecond = GetSlot(thisDt, ISO_MILLISECOND);
+    const microsecond = GetSlot(thisDt, ISO_MICROSECOND);
+    const nanosecond = GetSlot(thisDt, ISO_NANOSECOND);
+
+    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+
+    const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
+    const temporalTime = temporalTimeParam === undefined ? new PlainTime() : ES.ToTemporalTime(temporalTimeParam);
+
+    const thisDt = dateTime(this);
+    const year = GetSlot(thisDt, ISO_YEAR);
+    const month = GetSlot(thisDt, ISO_MONTH);
+    const day = GetSlot(thisDt, ISO_DAY);
+    const calendar = GetSlot(this, CALENDAR);
+    const hour = GetSlot(temporalTime, ISO_HOUR);
+    const minute = GetSlot(temporalTime, ISO_MINUTE);
+    const second = GetSlot(temporalTime, ISO_SECOND);
+    const millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  withTimeZone(timeZoneParam: Params['withTimeZone'][0]): Return['withTimeZone'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(timeZoneParam);
+    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
+  }
+  withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = ES.ToTemporalCalendar(calendarParam);
+    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), GetSlot(this, TIME_ZONE), calendar);
+  }
+  add(temporalDurationLike: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromZonedDateTime('add', this, temporalDurationLike, options);
+  }
+  subtract(
+    temporalDurationLike: Params['subtract'][0],
+    options: Params['subtract'][1] = undefined
+  ): Return['subtract'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.AddDurationToOrSubtractDurationFromZonedDateTime('subtract', this, temporalDurationLike, options);
+  }
+  until(other: Params['until'][0], options: Params['until'][1] = undefined): Return['until'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalZonedDateTime('until', this, other, options);
+  }
+  since(other: Params['since'][0], options: Params['since'][1] = undefined): Return['since'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.DifferenceTemporalZonedDateTime('since', this, other, options);
+  }
+  round(optionsParam: Params['round'][0]): Return['round'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (optionsParam === undefined) throw new TypeError('options parameter is required');
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const maximumIncrements = {
+      day: 1,
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+
+    // first, round the underlying DateTime fields
+    const dt = dateTime(this);
+    let year = GetSlot(dt, ISO_YEAR);
+    let month = GetSlot(dt, ISO_MONTH);
+    let day = GetSlot(dt, ISO_DAY);
+    let hour = GetSlot(dt, ISO_HOUR);
+    let minute = GetSlot(dt, ISO_MINUTE);
+    let second = GetSlot(dt, ISO_SECOND);
+    let millisecond = GetSlot(dt, ISO_MILLISECOND);
+    let microsecond = GetSlot(dt, ISO_MICROSECOND);
+    let nanosecond = GetSlot(dt, ISO_NANOSECOND);
+
+    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const calendar = GetSlot(this, CALENDAR);
+    const dtStart = new DateTime(GetSlot(dt, ISO_YEAR), GetSlot(dt, ISO_MONTH), GetSlot(dt, ISO_DAY), 0, 0, 0, 0, 0, 0);
+    const instantStart = ES.BuiltinTimeZoneGetInstantFor(timeZone, dtStart, 'compatible');
+    const endNs = ES.AddZonedDateTime(instantStart, timeZone, calendar, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0);
+    const dayLengthNs = JSBI.subtract(endNs, JSBI.BigInt(GetSlot(instantStart, EPOCHNANOSECONDS)));
+    if (JSBI.equal(dayLengthNs, ZERO)) {
+      throw new RangeError('cannot round a ZonedDateTime in a calendar with zero-length days');
+    }
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode,
+      // Days are guaranteed to be shorter than Number.MAX_SAFE_INTEGER
+      // (which can hold up to 104 days in nanoseconds)
+      JSBI.toNumber(dayLengthNs)
+    ));
+
+    // Now reset all DateTime fields but leave the TimeZone. The offset will
+    // also be retained if the new date/time values are still OK with the old
+    // offset. Otherwise the offset will be changed to be compatible with the
+    // new date/time values. If DST disambiguation is required, the `compatible`
+    // disambiguation algorithm will be used.
+    const offsetNs = ES.GetOffsetNanosecondsFor(timeZone, GetSlot(this, INSTANT));
+    const epochNanoseconds = ES.InterpretISODateTimeOffset(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      'option',
+      offsetNs,
+      timeZone,
+      'compatible',
+      'prefer',
+      /* matchMinute = */ false
+    );
+
+    return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, GetSlot(this, CALENDAR));
+  }
+  equals(otherParam: Params['equals'][0]): Return['equals'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const other = ES.ToTemporalZonedDateTime(otherParam);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    if (!JSBI.equal(JSBI.BigInt(one), JSBI.BigInt(two))) return false;
+    if (!ES.TimeZoneEquals(GetSlot(this, TIME_ZONE), GetSlot(other, TIME_ZONE))) return false;
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(optionsParam: Params['toString'][0] = undefined): string {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const options = ES.GetOptionsObject(optionsParam);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    const showCalendar = ES.ToShowCalendarOption(options);
+    const showTimeZone = ES.ToShowTimeZoneNameOption(options);
+    const showOffset = ES.ToShowOffsetOption(options);
+    return ES.TemporalZonedDateTimeToString(this, precision, showCalendar, showTimeZone, showOffset, {
+      unit,
+      increment,
+      roundingMode
+    });
+  }
+  toLocaleString(
+    locales: Params['toLocaleString'][0] = undefined,
+    options: Params['toLocaleString'][1] = undefined
+  ): string {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalZonedDateTimeToString(this, 'auto');
+  }
+  valueOf(): never {
+    throw new TypeError('use compare() or equals() to compare Temporal.ZonedDateTime');
+  }
+  startOfDay(): Return['startOfDay'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
+    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const calendar = GetSlot(this, CALENDAR);
+    const dtStart = new DateTime(
+      GetSlot(dt, ISO_YEAR),
+      GetSlot(dt, ISO_MONTH),
+      GetSlot(dt, ISO_DAY),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      calendar
+    );
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dtStart, 'compatible');
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  toInstant(): Return['toInstant'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    return new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
+  }
+  toPlainDate(): Return['toPlainDate'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToDate(dateTime(this));
+  }
+  toPlainTime(): Return['toPlainTime'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToTime(dateTime(this));
+  }
+  toPlainDateTime(): Return['toPlainDateTime'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return dateTime(this);
+  }
+  toPlainYearMonth(): Return['toPlainYearMonth'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
+  }
+  toPlainMonthDay(): Return['toPlainMonthDay'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode'] as const);
+    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
+  }
+  getISOFields(): Return['getISOFields'] {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
+    const tz = GetSlot(this, TIME_ZONE);
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      isoDay: GetSlot(dt, ISO_DAY),
+      isoHour: GetSlot(dt, ISO_HOUR),
+      isoMicrosecond: GetSlot(dt, ISO_MICROSECOND),
+      isoMillisecond: GetSlot(dt, ISO_MILLISECOND),
+      isoMinute: GetSlot(dt, ISO_MINUTE),
+      isoMonth: GetSlot(dt, ISO_MONTH),
+      isoNanosecond: GetSlot(dt, ISO_NANOSECOND),
+      isoSecond: GetSlot(dt, ISO_SECOND),
+      isoYear: GetSlot(dt, ISO_YEAR),
+      offset: ES.BuiltinTimeZoneGetOffsetStringFor(tz, GetSlot(this, INSTANT)),
+      timeZone: tz
+    };
+  }
+  static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {
+    const options = ES.GetOptionsObject(optionsParam);
+    if (ES.IsTemporalZonedDateTime(item)) {
+      ES.ToTemporalOverflow(options); // validate and ignore
+      ES.ToTemporalDisambiguation(options);
+      ES.ToTemporalOffset(options, 'reject');
+      return ES.CreateTemporalZonedDateTime(
+        GetSlot(item, EPOCHNANOSECONDS),
+        GetSlot(item, TIME_ZONE),
+        GetSlot(item, CALENDAR)
+      );
+    }
+    return ES.ToTemporalZonedDateTime(item, options);
+  }
+  static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
+    const one = ES.ToTemporalZonedDateTime(oneParam);
+    const two = ES.ToTemporalZonedDateTime(twoParam);
+    const ns1 = GetSlot(one, EPOCHNANOSECONDS);
+    const ns2 = GetSlot(two, EPOCHNANOSECONDS);
+    if (JSBI.lessThan(JSBI.BigInt(ns1), JSBI.BigInt(ns2))) return -1;
+    if (JSBI.greaterThan(JSBI.BigInt(ns1), JSBI.BigInt(ns2))) return 1;
+    return 0;
+  }
+}
+
+MakeIntrinsicClass(ZonedDateTime, 'Temporal.ZonedDateTime');
+
+function dateTime(zdt: Temporal.ZonedDateTime) {
+  return ES.BuiltinTimeZoneGetPlainDateTimeFor(GetSlot(zdt, TIME_ZONE), GetSlot(zdt, INSTANT), GetSlot(zdt, CALENDAR));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "declaration": true,
         "module": "esnext",
         // Search under node_modules for non-relative imports.
-        "moduleResolution": "node",
+        "moduleResolution": "node10",
+        "ignoreDeprecations": "6.0",
         // Process & infer types from .js files.
         // "allowJs": true,
         // "checkJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "compilerOptions": {
+        "paths": {
+            "@js-temporal/polyfill-patched": ["./node_modules/@js-temporal/polyfill"]
+        },
         "skipLibCheck": true,
         "allowJs": true,
         // Target latest version of ECMAScript.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "baseUrl": ".",
         "paths": {
             "@js-temporal/polyfill-patched": [
                 "./node_modules/@js-temporal/polyfill"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
     "compilerOptions": {
         "paths": {
-            "@js-temporal/polyfill-patched": ["./node_modules/@js-temporal/polyfill"]
+            "@js-temporal/polyfill-patched": [
+                "./node_modules/@js-temporal/polyfill"
+            ]
         },
         "skipLibCheck": true,
         "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "module": "esnext",
         // Search under node_modules for non-relative imports.
         "moduleResolution": "node10",
+        "rootDir": "./src",
         "ignoreDeprecations": "6.0",
         // Process & infer types from .js files.
         // "allowJs": true,
@@ -25,7 +26,7 @@
     },
     "files": ["src/index.ts"],
     "include": ["src/**/*"],
-    "exclude": [],
+    "exclude": ["src/vendor"],
     // this ts-node config is needed for cucumberjs to work with TypeScript
     "ts-node": {
         "esm": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4648,6 +4648,17 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
+babel-plugin-module-resolver@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.3.tgz#13f03cf29048ad7e0239e6a1c4dcc669d199f394"
+  integrity sha512-h8h6H71ZvdLJZxZrYkaeR30BojTaV7O9GfqacY14SNj5CNB8ocL9tydNzTC0JrnNN7vY3eJhwCmkDj7tuEUaqQ==
+  dependencies:
+    find-babel-config "^2.1.1"
+    glob "^9.3.3"
+    pkg-up "^3.1.0"
+    reselect "^4.1.7"
+    resolve "^1.22.8"
+
 babel-plugin-named-asset-import@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz#6b7fa43c59229685368683c28bc9734f24524cc2"
@@ -6500,6 +6511,11 @@ es-array-method-boxes-properly@^1.0.0:
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 es-get-iterator@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
@@ -7276,6 +7292,13 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+find-babel-config@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-2.1.2.tgz#2841b1bfbbbcdb971e1e39df8cbc43dafa901716"
+  integrity sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==
+  dependencies:
+    json5 "^2.2.3"
+
 find-cache-dir@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
@@ -7478,6 +7501,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
@@ -7661,6 +7689,16 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^9.3.3:
+  version "9.3.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.5.tgz#ca2ed8ca452781a3009685607fdf025a899dfe21"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 glob@~7.1.1:
   version "7.1.7"
@@ -7913,6 +7951,13 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
 
 he@^1.2.0:
   version "1.2.0"
@@ -8377,6 +8422,13 @@ is-core-module@^2.11.0, is-core-module@^2.5.0, is-core-module@^2.9.0:
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
   dependencies:
     has "^1.0.3"
+
+is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -9836,7 +9888,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2, json5@^2.2.0, json5@^2.2.2:
+json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -10151,6 +10203,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -10390,6 +10447,13 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^8.0.2:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.7.tgz#954766e22da88a3e0a17ad93b58c15c9d8a579de"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@~3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
@@ -10418,6 +10482,16 @@ minipass@^2.6.0, minipass@^2.9.0:
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minizlib@^1.3.3:
   version "1.3.3"
@@ -11068,6 +11142,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.6.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -12409,6 +12491,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
+reselect@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
@@ -12479,6 +12566,16 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.8:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13949,15 +13949,15 @@ typeface-roboto@^0.0.75:
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
   integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
-typescript@4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
 typescript@^3.6.3:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,6 +2872,9 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@js-temporal/polyfill-patched@file:./src/vendor/temporal":
+  version "0.4.3-patched"
+
 "@js-temporal/polyfill@0.4.3", "@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"


### PR DESCRIPTION
[CLDR 48](https://cldr.unicode.org/downloads/cldr-48#identifiers) renamed Ethiopic Intl era codes from era0/era1 to aa/am, breaking all Ethiopic calendar operations in @js-temporal/polyfill. Until a fixed upstream release ships, we vendor the v0.4.3 source into src/vendor/temporal/ and apply the fix from temporal-polyfill#357 directly. Once that one is released, we can go ahead with the PR for upgrading to 0.5 which will be a breaking change - although with minimal real-life implications in our case - since it changes the Temporal object structure itself (but right now, even 0.5 has the Ethiopic issue).

The patched copy is aliased as @js-temporal/polyfill-patched (to make clear this is patched) and wired into tsconfig.json (types), Jest moduleNameMapper (tests), and babel.config.js (build) so no consumer action is needed.

Also bumps TypeScript to 6.0 and expands public-interface test coverage.